### PR TITLE
🧹 Code Health Improvement: Remove double semicolon in PapiClientTests.cs

### DIFF
--- a/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
@@ -206,7 +206,7 @@ namespace Clc.Polaris.Api.Tests
         public void ItemStatusesGetAsyncTest()
         {
             var response = papi.ItemStatusesGet(7);
-            Assert.IsTrue(response.Data.ItemStatusesRows.Count() == response.Data.PAPIErrorCode); ;
+            Assert.IsTrue(response.Data.ItemStatusesRows.Count() == response.Data.PAPIErrorCode);
         }
 
         [TestMethod()]


### PR DESCRIPTION
🎯 **What:** Removed a double semicolon (`;;`) from `ItemStatusesGetAsyncTest` in `PapiClientTests.cs`.
💡 **Why:** Double semicolons are simple typos that produce empty statements. Removing them improves code readability and maintainability without altering functionality.
✅ **Verification:** The change removes an empty statement, so no functional logic is altered. Reviewed code and the fix received a #Correct# rating. Note: Full test suite execution failed independently of this fix due to missing `appsettings.Test.json`.
✨ **Result:** A cleaner codebase with reduced syntactic noise.

---
*PR created automatically by Jules for task [2595617326608638470](https://jules.google.com/task/2595617326608638470) started by @wesochuck*