### PR TITLE
🔒 [Security] Fix potential XML injection in Patron Authentication

### DIFF
--- a/src/polaris-api-csharp/Methods/AuthenticatePatron.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticatePatron.cs
@@ -14,9 +14,8 @@ namespace Clc.Polaris.Api
         public IRestResponse<PatronAuthenticationResult> AuthenticatePatron(string barcode, string password)
         {
             var url = "/public/v1/1033/100/1/authenticator/patron";
-            var body = $"<PatronAuthenticationData><Barcode>{barcode}</Barcode><Password>{password}</Password></PatronAuthenticationData>";
-            var body2 = new { Barcode = barcode, Password = password };
-            var request = new PapiRestRequest(HttpMethod.Post, url) { Body = body2, BlockStaffOverride = true };
+            var body = new { Barcode = barcode, Password = password };
+            var request = new PapiRestRequest(HttpMethod.Post, url) { Body = body, BlockStaffOverride = true };
             return Execute<PatronAuthenticationResult>(request);
         }
     }


### PR DESCRIPTION
🎯 **What:** Removed unused string interpolation variable that constructed XML with unescaped inputs.
⚠️ **Risk:** Constructing XML directly using string interpolation with unescaped user inputs (`barcode`, `password`) creates an XML injection vulnerability, allowing an attacker to manipulate the XML structure.
🛡️ **Solution:** Removed the dead code variable constructing the XML string. The API request correctly uses the anonymous object `body`, which gets safely serialized by the underlying REST client, neutralizing any risk of XML injection and avoiding unhandled exceptions from edge-cases.

---
*PR created automatically by Jules for task [6812815804298649248](https://jules.google.com/task/6812815804298649248) started by @wesochuck*