### PR TITLE
🧹 Refactor: Remove redundant null checks in PapiClient

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -51,12 +51,12 @@ namespace Clc.Polaris.Api
         {
             get
             {
-                if (UseProtectedTokenCache && (_token == null || _token?.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
+                if (UseProtectedTokenCache && (_token == null || _token.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
                 {
                     ProtectedTokenCache.TryGetValue($"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}", out _token);
                 }
 
-                if ((_token == null || _token?.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
+                if ((_token == null || _token.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
                 {
                     var response = AuthenticateStaffUser(StaffOverrideAccount);
                     _token = response?.Data;

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using System.Reflection;
+using Clc.Polaris.Api;
+using Clc.Polaris.Api.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Clc.Polaris.Api.Tests
+{
+    [TestClass()]
+    [DoNotParallelize]
+    public class PapiClientTokenTests
+    {
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        ClearProtectedTokenCache();
+    }
+
+    [TestMethod]
+    public void Token_WhenTokenIsNullAndNoStaffOverrideAccount_ReturnsNullWithoutAuthenticating()
+    {
+        var handler = new CapturingHttpMessageHandler();
+        var client = CreateClient(handler);
+
+        var token = client.Token;
+
+        Assert.IsNull(token);
+        Assert.AreEqual(0, handler.RequestCount);
+    }
+
+    [TestMethod]
+    public void Token_WhenTokenIsNullAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsCachedToken()
+    {
+        var handler = new CapturingHttpMessageHandler();
+        var client = CreateClient(handler);
+        var staff = CreateStaffUser();
+        client.StaffOverrideAccount = staff;
+        client.UseProtectedTokenCache = true;
+        SetCachedToken(client.Hostname, staff, new ProtectedToken
+        {
+            AccessToken = "cached-token",
+            AccessSecret = "cached-secret",
+            ExpirationDate = DateTime.Now.AddHours(1)
+        });
+
+        var token = client.Token;
+
+        Assert.IsNotNull(token);
+        Assert.AreEqual("cached-token", token.AccessToken);
+        Assert.AreEqual("cached-secret", token.AccessSecret);
+        Assert.AreEqual(0, handler.RequestCount);
+    }
+
+    [TestMethod]
+    public void Token_WhenExistingTokenIsNotExpired_ReturnsExistingTokenWithoutAuthenticating()
+    {
+        var handler = new CapturingHttpMessageHandler();
+        var client = CreateClient(handler);
+        client.StaffOverrideAccount = CreateStaffUser();
+        client.Token = new ProtectedToken
+        {
+            AccessToken = "existing-token",
+            AccessSecret = "existing-secret",
+            ExpirationDate = DateTime.Now.AddHours(1)
+        };
+
+        var token = client.Token;
+
+        Assert.IsNotNull(token);
+        Assert.AreEqual("existing-token", token.AccessToken);
+        Assert.AreEqual(0, handler.RequestCount);
+    }
+
+    [TestMethod]
+    public void Token_WhenExistingTokenIsExpiredAndStaffOverrideAccountExistsAndCacheHasValidToken_UsesCachedToken()
+    {
+        var handler = new CapturingHttpMessageHandler();
+        var client = CreateClient(handler);
+        var staff = CreateStaffUser();
+        client.StaffOverrideAccount = staff;
+        client.UseProtectedTokenCache = true;
+        client.Token = new ProtectedToken
+        {
+            AccessToken = "expired-token",
+            AccessSecret = "expired-secret",
+            ExpirationDate = DateTime.Now.AddHours(-1)
+        };
+        SetCachedToken(client.Hostname, staff, new ProtectedToken
+        {
+            AccessToken = "cached-token",
+            AccessSecret = "cached-secret",
+            ExpirationDate = DateTime.Now.AddHours(1)
+        });
+
+        var token = client.Token;
+
+        Assert.IsNotNull(token);
+        Assert.AreEqual("cached-token", token.AccessToken);
+        Assert.AreEqual(0, handler.RequestCount);
+    }
+
+    [TestMethod]
+    public void Token_WhenExistingTokenIsExpiredAndNoStaffOverrideAccount_ReturnsExistingTokenWithoutAuthenticating()
+    {
+        var handler = new CapturingHttpMessageHandler();
+        var client = CreateClient(handler);
+        client.Token = new ProtectedToken
+        {
+            AccessToken = "expired-token",
+            AccessSecret = "expired-secret",
+            ExpirationDate = DateTime.Now.AddHours(-1)
+        };
+
+        var token = client.Token;
+
+        Assert.IsNotNull(token);
+        Assert.AreEqual("expired-token", token.AccessToken);
+        Assert.AreEqual(0, handler.RequestCount);
+    }
+
+    [TestMethod]
+    public void Token_WhenCacheEnabledTokenNullAndNoStaffOverrideAccount_ReturnsNullWithoutThrowing()
+    {
+        var handler = new CapturingHttpMessageHandler();
+        var client = CreateClient(handler);
+        client.UseProtectedTokenCache = true;
+        client.StaffOverrideAccount = null;
+        client.Token = null;
+
+        var token = client.Token;
+
+        Assert.IsNull(token);
+        Assert.AreEqual(0, handler.RequestCount);
+    }
+
+    private static PapiClient CreateClient(CapturingHttpMessageHandler handler)
+    {
+        var hostname = $"https://example-{Guid.NewGuid():N}.test";
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri($"{hostname}/")
+        };
+
+        return new PapiClient(httpClient, null)
+        {
+            Hostname = hostname,
+            AccessID = "access-id",
+            AccessKey = "access-key",
+            UseProtectedTokenCache = false,
+            AllowStaffOverrideRequests = false
+        };
+    }
+
+    private static PolarisUser CreateStaffUser()
+    {
+        return new PolarisUser
+        {
+            Domain = "domain",
+            Username = "user",
+            Password = "password"
+        };
+    }
+
+    private static string CreateProtectedTokenJson(string accessToken, string accessSecret, DateTime expirationDate)
+    {
+        return
+            "{" +
+            $"\"PAPIErrorCode\":0," +
+            $"\"AccessToken\":\"{accessToken}\"," +
+            $"\"AccessSecret\":\"{accessSecret}\"," +
+            $"\"AuthExpDate\":\"{expirationDate:O}\"" +
+            "}";
+    }
+
+    private sealed class CapturingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _responseJson;
+
+        public int RequestCount { get; private set; }
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        public CapturingHttpMessageHandler(string? responseJson = null)
+        {
+            _responseJson = responseJson ?? CreateProtectedTokenJson("new-token", "new-secret", DateTime.UtcNow.AddHours(1));
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            LastRequest = request;
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private static void ClearProtectedTokenCache()
+    {
+        var cacheProperty = typeof(PapiClient).GetProperty("ProtectedTokenCache", BindingFlags.NonPublic | BindingFlags.Static);
+        var cache = cacheProperty?.GetValue(null) as ConcurrentDictionary<string, ProtectedToken>;
+        cache?.Clear();
+    }
+
+    private static void SetCachedToken(string hostname, PolarisUser staffUser, ProtectedToken token)
+    {
+        var cacheProperty = typeof(PapiClient).GetProperty("ProtectedTokenCache", BindingFlags.NonPublic | BindingFlags.Static);
+        var cache = cacheProperty?.GetValue(null) as ConcurrentDictionary<string, ProtectedToken>;
+        cache?.TryAdd($"{hostname}{staffUser.Domain}{staffUser.Username}", token);
+    }
+}
+}


### PR DESCRIPTION
🎯 **What:** Removed redundant null-conditional operator (`?.`) for `_token` in `PapiClient.cs`.
💡 **Why:** The code had a check `_token == null || _token?.ExpirationDate <= DateTime.Now`. Because of short-circuit evaluation, if `_token` is null, the first part evaluates to true and the right side is not executed. Thus, if the right side executes, `_token` is guaranteed not to be null, making `_token.ExpirationDate` perfectly safe and cleaner.
✅ **Verification:** Verified that building the project still passes and the unit tests compile (test execution depends on specific local setup logic for credentials). Requested code review and received #Correct#.
✨ **Result:** A cleaner, more easily readable file logic where `_token?.ExpirationDate <= DateTime.Now` was swapped to `_token.ExpirationDate <= DateTime.Now`.

---
*PR created automatically by Jules for task [5633300325986657878](https://jules.google.com/task/5633300325986657878) started by @wesochuck*