### PR TITLE
Extract GetBibResultRowInt helper and add BibGetResult unit tests

### DIFF
--- a/src/polaris-api-csharp/Models/BibGetResult.cs
+++ b/src/polaris-api-csharp/Models/BibGetResult.cs
@@ -33,12 +33,12 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Number of items associated with this record system-wide.
         /// </summary>
-        public int? SystemItemsTotal => int.TryParse(GetBibResultRow(7).FirstOrDefault(), out int result) ? result : (int?)null;
+        public int? SystemItemsTotal => GetBibResultRowInt(7);
 
         /// <summary>
         /// Current number of holds on this record.
         /// </summary>
-        public int? CurrentHolds => int.TryParse(GetBibResultRow(8).FirstOrDefault(), out int result) ? result : (int?)null;
+        public int? CurrentHolds => GetBibResultRowInt(8);
 
         /// <summary>
         /// Summary(ies) of this record.
@@ -51,7 +51,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Control number of this record.
         /// </summary>
-        public int? ControlNumber => int.TryParse(GetBibResultRow(11).FirstOrDefault(), out int result) ? result : (int?)null;
+        public int? ControlNumber => GetBibResultRowInt(11);
 
         /// <summary>
         /// Call number(s) of this record.
@@ -60,12 +60,12 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Number of local items available that are associated with this record.
         /// </summary>
-        public int? LocalItemsAvailable => int.TryParse(GetBibResultRow(15).FirstOrDefault(), out int result) ? result : (int?)null;
+        public int? LocalItemsAvailable => GetBibResultRowInt(15);
 
         /// <summary>
         /// Number of available items associated with this record system-wide.
         /// </summary>
-        public int? SystemItemsAvailable => int.TryParse(GetBibResultRow(16).FirstOrDefault(), out int result) ? result : (int?)null;
+        public int? SystemItemsAvailable => GetBibResultRowInt(16);
 
         /// <summary>
         /// Format of the record.
@@ -192,6 +192,13 @@ namespace Clc.Polaris.Api.Models
         /// Medium of the record.
         /// </summary>
         public string Medium => GetBibResultRow(46).FirstOrDefault();
+
+        private int? GetBibResultRowInt(int id)
+        {
+            return int.TryParse(GetBibResultRow(id).FirstOrDefault(), out var result)
+                ? result
+                : (int?)null;
+        }
 
         private List<string> GetBibResultRow(int id)
         {

--- a/src/polaris-api-csharpTests/Models/BibGetResultTests.cs
+++ b/src/polaris-api-csharpTests/Models/BibGetResultTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using Clc.Polaris.Api.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Clc.Polaris.Api.Tests.Models
+{
+    [TestClass]
+    public class BibGetResultTests
+    {
+        [TestMethod]
+        public void NullableIntProperties_MapToExpectedElementIds()
+        {
+            var sut = new BibGetResult
+            {
+                BibGetRows = new List<BibGetRow>
+                {
+                    new BibGetRow { ElementID = 7, Value = "70" },
+                    new BibGetRow { ElementID = 8, Value = "80" },
+                    new BibGetRow { ElementID = 11, Value = "110" },
+                    new BibGetRow { ElementID = 15, Value = "150" },
+                    new BibGetRow { ElementID = 16, Value = "160" }
+                }
+            };
+
+            Assert.AreEqual(70, sut.SystemItemsTotal);
+            Assert.AreEqual(80, sut.CurrentHolds);
+            Assert.AreEqual(110, sut.ControlNumber);
+            Assert.AreEqual(150, sut.LocalItemsAvailable);
+            Assert.AreEqual(160, sut.SystemItemsAvailable);
+        }
+
+        [DataTestMethod]
+        [DataRow("123", 123)]
+        [DataRow("0", 0)]
+        [DataRow("-1", -1)]
+        [DataRow("2147483647", 2147483647)]
+        [DataRow("-2147483648", -2147483648)]
+        public void SystemItemsTotal_ParsesValidIntegers(string value, int expected)
+        {
+            var sut = CreateWithSystemItemsTotalRows(value);
+
+            Assert.AreEqual(expected, sut.SystemItemsTotal);
+        }
+
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("not-a-number")]
+        [DataRow("12.3")]
+        [DataRow("2147483648")]
+        public void SystemItemsTotal_ReturnsNullForInvalidValues(string value)
+        {
+            var sut = CreateWithSystemItemsTotalRows(value);
+
+            Assert.IsNull(sut.SystemItemsTotal);
+        }
+
+        [TestMethod]
+        public void SystemItemsTotal_ReturnsNullWhenRowMissing()
+        {
+            var sut = new BibGetResult
+            {
+                BibGetRows = new List<BibGetRow>
+                {
+                    new BibGetRow { ElementID = 8, Value = "42" }
+                }
+            };
+
+            Assert.IsNull(sut.SystemItemsTotal);
+        }
+
+        [TestMethod]
+        public void SystemItemsTotal_UsesFirstRowValue_WhenMultipleRowsExist()
+        {
+            var sut = CreateWithSystemItemsTotalRows("123", "456");
+
+            Assert.AreEqual(123, sut.SystemItemsTotal);
+        }
+
+        [TestMethod]
+        public void SystemItemsTotal_UsesFirstRowValue_WhenFirstRowInvalidAndSecondRowValid()
+        {
+            var sut = CreateWithSystemItemsTotalRows("not-a-number", "123");
+
+            Assert.IsNull(sut.SystemItemsTotal);
+        }
+
+        private static BibGetResult CreateWithSystemItemsTotalRows(params string[] values)
+        {
+            var rows = new List<BibGetRow>();
+            foreach (var value in values)
+            {
+                rows.Add(new BibGetRow { ElementID = 7, Value = value });
+            }
+
+            return new BibGetResult { BibGetRows = rows };
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Remove repeated nullable integer parsing logic in `BibGetResult` to centralize behavior and improve maintainability.
- Keep existing `GetBibResultRow` behavior unchanged while making integer parsing consistent across related properties.

### Description
- Added private helper `GetBibResultRowInt(int id)` to parse the first value returned by `GetBibResultRow(id)` into an `int?` using `int.TryParse`.
- Updated properties to use the helper: `SystemItemsTotal` (ElementID 7), `CurrentHolds` (ElementID 8), `ControlNumber` (ElementID 11), `LocalItemsAvailable` (ElementID 15), and `SystemItemsAvailable` (ElementID 16).
- Added unit tests in `src/polaris-api-csharpTests/Models/BibGetResultTests.cs` that verify the five properties map to the correct `ElementID`s and cover parsing behavior through `SystemItemsTotal`, including valid/invalid values, boundary/overflow, missing row, and first-row precedence scenarios.
- Did not change `GetBibResultRow` or add support/tests for `BibGetRows = null` as requested.

### Testing
- Added automated tests: `Clc.Polaris.Api.Tests.Models.BibGetResultTests` verifying mapping and parsing behavior for `SystemItemsTotal` and the other nullable-int properties.
- Attempted to run the tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter BibGetResultTests`, but the run failed because the environment lacks the .NET SDK (`dotnet` command not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ffd39c721883238c6be134e9126ac3)