### PR TITLE
Add focused unit tests for PapiClient.Token behavior (PR #7)

### DIFF
--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Clc.Polaris.Api;
+using Clc.Polaris.Api.Models;
+
+namespace Clc.Polaris.Api.Tests
+{
+    [TestClass]
+    public class PapiClientTokenTests
+    {
+        private sealed class CapturingHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly string _responseJson;
+
+            public int RequestCount { get; private set; }
+            public HttpRequestMessage LastRequest { get; private set; }
+
+            public CapturingHttpMessageHandler(string responseJson = null)
+            {
+                _responseJson = responseJson ?? CreateProtectedTokenJson(
+                    "new-token",
+                    "new-secret",
+                    DateTime.UtcNow.AddHours(1));
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                RequestCount++;
+                LastRequest = request;
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                });
+            }
+        }
+
+        private static string CreateProtectedTokenJson(
+            string accessToken,
+            string accessSecret,
+            DateTime expirationDate)
+        {
+            return $@"{{
+  \"PAPIErrorCode\": 0,
+  \"AccessToken\": \"{accessToken}\",
+  \"AccessSecret\": \"{accessSecret}\",
+  \"AuthExpDate\": \"{expirationDate:O}\"
+}}";
+        }
+
+        private static PapiClient CreateClient(CapturingHttpMessageHandler handler)
+        {
+            return new PapiClient(new HttpClient(handler), null)
+            {
+                Hostname = "https://example.test",
+                AccessID = "access-id",
+                AccessKey = "access-key",
+                UseProtectedTokenCache = false,
+                AllowStaffOverrideRequests = false
+            };
+        }
+
+        private static PolarisUser CreateStaffUser()
+        {
+            return new PolarisUser
+            {
+                Domain = "domain",
+                Username = "user",
+                Password = "password"
+            };
+        }
+
+        [TestMethod]
+        public void Token_WhenTokenIsNullAndNoStaffOverrideAccount_ReturnsNullWithoutAuthenticating()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+
+            var token = client.Token;
+
+            Assert.IsNull(token);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenTokenIsNullAndStaffOverrideAccountExists_AuthenticatesAndReturnsToken()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.StaffOverrideAccount = CreateStaffUser();
+
+            var token = client.Token;
+
+            Assert.IsNotNull(token);
+            Assert.AreEqual("new-token", token.AccessToken);
+            Assert.AreEqual("new-secret", token.AccessSecret);
+            Assert.AreEqual(1, handler.RequestCount);
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.IsTrue(handler.LastRequest.RequestUri.ToString().Contains("/protected/"));
+            Assert.IsTrue(handler.LastRequest.RequestUri.ToString().Contains("/authenticator/staff"));
+        }
+
+        [TestMethod]
+        public void Token_WhenExistingTokenIsNotExpired_ReturnsExistingTokenWithoutAuthenticating()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.StaffOverrideAccount = CreateStaffUser();
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "existing-token",
+                AccessSecret = "existing-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            };
+
+            var token = client.Token;
+
+            Assert.IsNotNull(token);
+            Assert.AreEqual("existing-token", token.AccessToken);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenExistingTokenIsExpiredAndStaffOverrideAccountExists_AuthenticatesAndReplacesToken()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.StaffOverrideAccount = CreateStaffUser();
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "expired-token",
+                AccessSecret = "expired-secret",
+                ExpirationDate = DateTime.Now.AddHours(-1)
+            };
+
+            var token = client.Token;
+
+            Assert.IsNotNull(token);
+            Assert.AreEqual("new-token", token.AccessToken);
+            Assert.AreEqual(1, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenExistingTokenIsExpiredAndNoStaffOverrideAccount_ReturnsExistingTokenWithoutAuthenticating()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "expired-token",
+                AccessSecret = "expired-secret",
+                ExpirationDate = DateTime.Now.AddHours(-1)
+            };
+
+            var token = client.Token;
+
+            Assert.IsNotNull(token);
+            Assert.AreEqual("expired-token", token.AccessToken);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenCacheEnabledTokenNullAndNoStaffOverrideAccount_ReturnsNullWithoutThrowing()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.UseProtectedTokenCache = true;
+            client.StaffOverrideAccount = null;
+            client.Token = null;
+
+            var token = client.Token;
+
+            Assert.IsNull(token);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Verify that the change in `PapiClient.Token` (replacing `_token?.ExpirationDate` with `_token.ExpirationDate`) is behavior-preserving across the cache and staff-authentication branches and does not introduce null dereferences. 

### Description
- Added a new MSTest class `PapiClientTokenTests` at `src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs` with focused unit tests separate from the integration-oriented `PapiClientTests`. 
- Implemented an in-memory `CapturingHttpMessageHandler` that returns deterministic `ProtectedToken` JSON and records `RequestCount` and `LastRequest` to avoid live network calls. 
- Added helpers to generate protected-token JSON (`AuthExpDate`), construct a test `PapiClient` with controlled defaults, and create a staff `PolarisUser`. 
- Added six unit tests covering null/expired/non-expired `_token` cases with and without `StaffOverrideAccount`, plus a cache-enabled null-token path to exercise the cache lookup condition. 

### Testing
- Attempted to run the new tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter FullyQualifiedName~PapiClientTokenTests` but the environment could not execute them because `dotnet` is not installed (`/bin/bash: dotnet: command not found`). 
- No automated tests were executed in this environment; the tests are unit-only and use a fake `HttpMessageHandler`, so they perform no real network I/O when run in a proper .NET environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ffe5cef1a08323ad41a713ab332bf9)