### PR TITLE
🧪 Add missing error path test for Require.Argument

### DIFF
--- a/src/polaris-api-csharpTests/Validation/RequireTests.cs
+++ b/src/polaris-api-csharpTests/Validation/RequireTests.cs
@@ -1,0 +1,38 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Clc.Polaris.Api.Validation;
+using System;
+
+namespace Clc.Polaris.Api.Validation.Tests
+{
+    [TestClass]
+    public class RequireTests
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Argument_NullValue_ThrowsArgumentNullException()
+        {
+            // Arrange
+            string argumentName = "testArgument";
+            object? nullValue = null;
+
+            // Act
+            Require.Argument(argumentName, nullValue);
+
+            // Assert is handled by ExpectedException
+        }
+
+        [TestMethod]
+        public void Argument_NotNullValue_DoesNotThrow()
+        {
+            // Arrange
+            string argumentName = "testArgument";
+            object notNullValue = new object();
+
+            // Act
+            Require.Argument(argumentName, notNullValue);
+
+            // Assert
+            // No exception should be thrown
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing error path test for `Require.Argument` in `Validation/Require.cs`.
📊 **Coverage:** The test now checks the expected `ArgumentNullException` when `value` is `null`, and also includes a happy path test that ensures no exception is thrown when a valid object is passed.
✨ **Result:** Increased test coverage and assurance that `Require.Argument` appropriately validates parameters and protects against null values.

---
*PR created automatically by Jules for task [14174773433870233017](https://jules.google.com/task/14174773433870233017) started by @wesochuck*