### PR TITLE
🧪 Add test for Patron_GetBarcodeFromId

### DIFF
--- a/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
@@ -128,5 +128,28 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual(expectedPath, handler.LastRequest!.RequestUri!.AbsolutePath);
             Assert.AreEqual(expectedQuery, handler.LastRequest.RequestUri.Query);
         }
+
+        [TestMethod]
+        public void Patron_GetBarcodeFromId_FormatsUrlCorrectly()
+        {
+            var handler = new CaptureHttpMessageHandler();
+            var client = CreateClient(handler);
+            var patronId = 12345;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "token-segment",
+                AccessSecret = "token-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(1)
+            };
+
+            client.Patron_GetBarcodeFromId(patronId);
+
+            var expectedPath = "/PAPIService/REST/protected/v1/1033/100/1/token-segment/patron/barcode";
+            var expectedQuery = $"?patronid={patronId}";
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(expectedPath, handler.LastRequest!.RequestUri!.AbsolutePath);
+            Assert.AreEqual(expectedQuery, handler.LastRequest.RequestUri.Query);
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the `Patron_GetBarcodeFromId` method.
📊 **Coverage:** Tests that `Patron_GetBarcodeFromId` correctly formats the protected REST path and includes the `patronid` inside the query string.
✨ **Result:** Improved test coverage and reliability for this endpoint by verifying accurate path interpolation and query formatting.

---
*PR created automatically by Jules for task [16121018814654646104](https://jules.google.com/task/16121018814654646104) started by @wesochuck*