### PR TITLE
🧪 Add unit test for UpdatePickupBranchID

### DIFF
--- a/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
@@ -128,5 +128,25 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual(expectedPath, handler.LastRequest!.RequestUri!.AbsolutePath);
             Assert.AreEqual(expectedQuery, handler.LastRequest.RequestUri.Query);
         }
+
+        [TestMethod]
+        public void UpdatePickupBranchID_EncodesBarcodeAndConstructsQuery()
+        {
+            var handler = new CaptureHttpMessageHandler();
+            var client = CreateClient(handler);
+            var barcode = "AB C/+#?=";
+            var requestId = 1234;
+            var pickupBranchId = 5678;
+
+            client.UpdatePickupBranchID(barcode, requestId, pickupBranchId, "pin", userId: 888, workstationId: 999);
+
+            var expectedPath = $"/PAPIService/REST/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/pickupbranch";
+            var expectedQuery = $"?userid=888&wsid=999&pickupbranchid={pickupBranchId}";
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(HttpMethod.Put, handler.LastRequest!.Method);
+            Assert.AreEqual(expectedPath, handler.LastRequest.RequestUri!.AbsolutePath);
+            Assert.AreEqual(expectedQuery, handler.LastRequest.RequestUri.Query);
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `UpdatePickupBranchID` method constructs an HTTP request, but it lacked a unit test verifying that the URL and parameters are correctly formatted, specifically ensuring the `barcode` segment is URL-encoded.

📊 **Coverage:** What scenarios are now tested
A new test method `UpdatePickupBranchID_EncodesBarcodeAndConstructsQuery` was added to `PapiClientUrlEncodingTests.cs`. It tests the happy path, edge cases where the barcode contains special characters (triggering URL encoding), and verifies correct query parameter mapping for `userid`, `wsid`, and `pickupbranchid`.

✨ **Result:** The improvement in test coverage
The code now has robust test coverage that prevents regressions in URL generation for this endpoint.

---
*PR created automatically by Jules for task [5188578689151144875](https://jules.google.com/task/5188578689151144875) started by @wesochuck*