### PR TITLE
🧪 [testing improvement NotificationQueueGet]

### DIFF
--- a/src/polaris-api-csharp/IPapiClient.cs
+++ b/src/polaris-api-csharp/IPapiClient.cs
@@ -58,6 +58,7 @@ namespace Clc.Polaris.Api
         IRestResponse<MARCTypeOfMaterialsGetResult> MARCTypeOfMaterialsGet(int? branchId = null);
         IRestResponse<MaterialTypesGetResult> MaterialTypesGet(int? branchId = null);
         IRestResponse<NotificationUpdateResult> NotificationUpdate(NotificationUpdateParams updateParams);
+        IRestResponse<PapiResponseCommon> NotificationQueueGet(int orgId = 1);
         IRestResponse<OrganizationsGetResult> OrganizationsGet(OrganizationType type = OrganizationType.All);
         IRestResponse<PapiResponseCommon> PatronAccountCreateCredit(string barcode, double txnAmount, PaymentMethod paymentMethod, int? workstationId = null, int? userId = null, string note = "");
         IRestResponse<PapiResponseCommon> PatronAccountCreateTitleList(string barcode, string listName, string password = "");

--- a/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
@@ -128,5 +128,24 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual(expectedPath, handler.LastRequest!.RequestUri!.AbsolutePath);
             Assert.AreEqual(expectedQuery, handler.LastRequest.RequestUri.Query);
         }
+
+        [TestMethod]
+        public void NotificationQueueGet_RequestsCorrectUrl()
+        {
+            var handler = new CaptureHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "token-segment",
+                AccessSecret = "token-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(1)
+            };
+
+            client.NotificationQueueGet(1);
+
+            var expectedPath = $"/PAPIService/REST/protected/v1/1033/24/1/token-segment/notification/";
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(expectedPath, handler.LastRequest!.RequestUri!.AbsolutePath);
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing unit test for the `NotificationQueueGet` method in `PapiClient`. It also adds the method signature to the `IPapiClient` interface.

📊 **Coverage:** What scenarios are now tested
The unit test `NotificationQueueGet_RequestsCorrectUrl` verifies that the method constructs the correct API URL path by interpolating the `orgId` and `Token.AccessToken` as expected, without making actual live HTTP requests.

✨ **Result:** The improvement in test coverage
Test coverage is improved by validating the internal URL routing and construction logic for notification queues, increasing reliability.

---
*PR created automatically by Jules for task [12698251187307909841](https://jules.google.com/task/12698251187307909841) started by @wesochuck*