### PR TITLE
Simplify ToString calls in patron model classes

### DIFF
--- a/src/polaris-api-csharp/Models/PatronReadingHistoryGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronReadingHistoryGetResult.cs
@@ -9,7 +9,7 @@ namespace Clc.Polaris.Api.Models
     {
         public PatronReadingHistoryGetRow[] PatronReadingHistoryGetRows { get; set; }
 
-        public override string ToString() => string.Join("\r\n", (IEnumerable<PatronReadingHistoryGetRow>)PatronReadingHistoryGetRows);
+        public override string ToString() => string.Join("\r\n", PatronReadingHistoryGetRows);
     }
 
     public class PatronReadingHistoryGetRow

--- a/src/polaris-api-csharp/Models/PatronTitleListGetTitlesResult.cs
+++ b/src/polaris-api-csharp/Models/PatronTitleListGetTitlesResult.cs
@@ -11,7 +11,7 @@ namespace Clc.Polaris.Api.Models
         public object ErrorMessage { get; set; }
         public PatronTitleListTitleRow[] PatronTitleListTitleRows { get; set; }
 
-        public override string ToString() => string.Join("\r\n", (IEnumerable<PatronTitleListTitleRow>)PatronTitleListTitleRows);
+        public override string ToString() => string.Join("\r\n", PatronTitleListTitleRows);
     }
 
     public class PatronTitleListTitleRow


### PR DESCRIPTION
### Motivation
- Remove redundant casts in `ToString` implementations to simplify code and avoid unnecessary use of `IEnumerable<T>` when calling `string.Join`.

### Description
- Updated `PatronReadingHistoryGetResult.ToString` and `PatronTitleListGetTitlesResult.ToString` to call `string.Join` directly with the array property instead of casting to `IEnumerable<T>`.

### Testing
- Ran the existing automated unit test suite with `dotnet test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0741e33700832381be0ea6a5c504d0)