### PR TITLE
Upgrade Polaris API to rest-client v3 alpha and add sync Execute<T> shim

### DIFF
--- a/src/polaris-api-csharp/Clc.Polaris.Api.csproj
+++ b/src/polaris-api-csharp/Clc.Polaris.Api.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>Clc.Polaris</RootNamespace>
 		<PackageId>Clc.Polaris.Api</PackageId>
 		<Authors>Central Library Consortium, Michael Fields</Authors>
 		<Description>A helper library that assists in the consumption of the Polaris ILS API</Description>
 		<PackageTags>clc; polaris; papi; polarisapi</PackageTags>
 		<PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
-		<Version>3.1.5</Version>
+		<Version>3.2.0-alpha.1</Version>
 		<Title>Polaris Api Library Helper Library</Title>
 		<PackageProjectUrl>https://bitbucket.org/clcdpc/polaris-api-csharp</PackageProjectUrl>
 		<RepositoryUrl>https://bitbucket.org/clcdpc/polaris-api-csharp</RepositoryUrl>
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Clc.Rest.Client" Version="2.2.1-beta" />
+		<PackageReference Include="Clc.Rest.Client" Version="3.0.0-alpha.1" />
 	</ItemGroup>
 
 </Project>

--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -17,8 +17,7 @@ namespace Clc.Polaris.Api
         {
             var url = "/protected/v1/1033/100/1/authenticator/staff";
             var request = new PapiRestRequest(HttpMethod.Post, url) { Body = staffUser };
-            return Post<ProtectedToken>(url, body: staffUser);
-            //return Execute<ProtectedToken>(request);
+            return Execute<ProtectedToken>(request);
         }
 
         

--- a/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
@@ -34,7 +34,8 @@ namespace Clc.Polaris.Api
                 body.BlockingNoteMode = (int)updateMode;
             }
 
-            return Post<PapiResponseCommon>(url, body: body);
+            var request = new PapiRestRequest(HttpMethod.Post, url) { Body = body };
+            return Execute<PapiResponseCommon>(request);
         }
     }
 }

--- a/src/polaris-api-csharp/Models/PapiRestRequest.cs
+++ b/src/polaris-api-csharp/Models/PapiRestRequest.cs
@@ -41,7 +41,7 @@ namespace Clc.Polaris.Api.Models
             Method = request.Method;
             Path = request.Path;
             Body = request.Body;
-            Parameters = request.Parameters;
+            QueryParameters = request.QueryParameters;
             Headers = request.Headers;
         }
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -91,6 +91,11 @@ namespace Clc.Polaris.Api
         public override string BaseUrl { get => Hostname; set => Hostname = value; }
         public override string PathPrefix { get; set; } = "PAPIService/REST";
 
+        private IRestResponse<T> Execute<T>(RestRequest request)
+        {
+            return ExecuteAsync<T>(request).GetAwaiter().GetResult();
+        }
+
         public override RestRequest PreformatRestRequest(RestRequest request)
         {
             var papiRequest = request is PapiRestRequest ? request as PapiRestRequest : new PapiRestRequest(request);

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -38,14 +38,14 @@ namespace Clc.Polaris.Api.Tests
                 Path = "/protected/foo",
                 Body = new { Value = "v" },
             };
-            existing.Parameters.Add("limit", "5");
+            existing.QueryParameters.Add("limit", "5");
             existing.Headers.Add("X-Test", "header");
 
             var copied = new PapiRestRequest(existing);
             Assert.AreEqual(existing.Method, copied.Method);
             Assert.AreEqual(existing.Path, copied.Path);
             Assert.AreSame(existing.Body, copied.Body);
-            Assert.AreSame(existing.Parameters, copied.Parameters);
+            Assert.AreSame(existing.QueryParameters, copied.QueryParameters);
             Assert.AreSame(existing.Headers, copied.Headers);
         }
 


### PR DESCRIPTION
### Motivation
- Move the Polaris API baseline to rest-client v3 alpha which targets .NET 8.0 while preserving the existing synchronous public API surface.
- Provide a temporary compatibility layer so existing synchronous call sites continue to compile against the new async-only rest-client API.

### Description
- Retarget `Clc.Polaris.Api` to `net8.0` and bump package `Version` to `3.2.0-alpha.1` in `src/polaris-api-csharp/Clc.Polaris.Api.csproj` and update `Clc.Rest.Client` to `3.0.0-alpha.1`.
- Add a private compatibility shim `Execute<T>(RestRequest request)` inside `PapiClient` that calls `ExecuteAsync<T>(request).GetAwaiter().GetResult()` so existing synchronous methods compile unchanged.
- Replace remaining direct `Post<T>` convenience calls with `PapiRestRequest` + the new `Execute<T>` shim where needed to compile against the v3 client.
- Update `PapiRestRequest` constructor and the migration characterization test to use `QueryParameters` instead of the removed `Parameters` property to address compilation fallout from the rest-client upgrade.

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` which completed successfully.
- Ran `dotnet build src/polaris-api-csharp.sln --no-restore` which completed successfully (project builds; one existing nullable warning observed in tests project).
- Ran `dotnet test src/polaris-api-csharp.sln --no-build --filter TestCategory=Unit` and the unit subset passed (19 passed, 0 failed).
- Ran full `dotnet test src/polaris-api-csharp.sln --no-build` but it failed due to missing `appsettings.Test.json` in this environment, causing integration-style tests to error; this is an environment/configuration issue, not a compilation failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a19dc8cb6d483238bfe435d01d98b96)