### PR TITLE
Retarget Clc.Polaris.Api to net8.0 and add temporary sync Execute shim for rest-client v3 alpha

### DIFF
--- a/src/polaris-api-csharp/Clc.Polaris.Api.csproj
+++ b/src/polaris-api-csharp/Clc.Polaris.Api.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>Clc.Polaris</RootNamespace>
 		<PackageId>Clc.Polaris.Api</PackageId>
 		<Authors>Central Library Consortium, Michael Fields</Authors>
 		<Description>A helper library that assists in the consumption of the Polaris ILS API</Description>
 		<PackageTags>clc; polaris; papi; polarisapi</PackageTags>
 		<PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
-		<Version>3.1.5</Version>
+		<Version>4.0.0-alpha.1</Version>
 		<Title>Polaris Api Library Helper Library</Title>
 		<PackageProjectUrl>https://bitbucket.org/clcdpc/polaris-api-csharp</PackageProjectUrl>
 		<RepositoryUrl>https://bitbucket.org/clcdpc/polaris-api-csharp</RepositoryUrl>
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Clc.Rest.Client" Version="2.2.1-beta" />
+		<PackageReference Include="Clc.Rest.Client" Version="3.0.0-alpha.1" />
 	</ItemGroup>
 
 </Project>

--- a/src/polaris-api-csharp/Models/PapiRestRequest.cs
+++ b/src/polaris-api-csharp/Models/PapiRestRequest.cs
@@ -41,7 +41,7 @@ namespace Clc.Polaris.Api.Models
             Method = request.Method;
             Path = request.Path;
             Body = request.Body;
-            Parameters = request.Parameters;
+            QueryParameters = request.QueryParameters;
             Headers = request.Headers;
         }
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -91,6 +91,16 @@ namespace Clc.Polaris.Api
         public override string BaseUrl { get => Hostname; set => Hostname = value; }
         public override string PathPrefix { get; set; } = "PAPIService/REST";
 
+        private IRestResponse<T> Execute<T>(RestRequest request)
+        {
+            return ExecuteAsync<T>(request).GetAwaiter().GetResult();
+        }
+
+        private IRestResponse<T> Post<T>(string path, object body = null)
+        {
+            return Execute<T>(new PapiRestRequest(HttpMethod.Post, path, body: body));
+        }
+
         public override RestRequest PreformatRestRequest(RestRequest request)
         {
             var papiRequest = request is PapiRestRequest ? request as PapiRestRequest : new PapiRestRequest(request);

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -38,14 +38,14 @@ namespace Clc.Polaris.Api.Tests
                 Path = "/protected/foo",
                 Body = new { Value = "v" },
             };
-            existing.Parameters.Add("limit", "5");
+            existing.QueryParameters.Add("limit", "5");
             existing.Headers.Add("X-Test", "header");
 
             var copied = new PapiRestRequest(existing);
             Assert.AreEqual(existing.Method, copied.Method);
             Assert.AreEqual(existing.Path, copied.Path);
             Assert.AreSame(existing.Body, copied.Body);
-            Assert.AreSame(existing.Parameters, copied.Parameters);
+            Assert.AreSame(existing.QueryParameters, copied.QueryParameters);
             Assert.AreSame(existing.Headers, copied.Headers);
         }
 


### PR DESCRIPTION
### Motivation
- Prepare the Polaris API for the rest-client v3 alpha baseline which targets `net8.0` and removes the synchronous `Execute<T>` path. 
- Preserve the existing synchronous public API surface while upgrading the dependency so downstream callers do not need immediate changes. 

### Description
- Retargeted `Clc.Polaris.Api` from `netstandard2.0` to `net8.0` and updated the package reference `Clc.Rest.Client` to `3.0.0-alpha.1` while bumping the package `Version` to `4.0.0-alpha.1` in `Clc.Polaris.Api.csproj`. 
- Added a private compatibility method `Execute<T>(RestRequest request)` to `PapiClient` that delegates to `ExecuteAsync<T>(request).GetAwaiter().GetResult()` to keep synchronous call sites compiling. 
- Added a minimal private `Post<T>(string path, object body = null)` helper on `PapiClient` used to replace a couple of `Post<T>` call sites that no longer existed on the v3 client. 
- Adjusted `PapiRestRequest` copy constructor to use `QueryParameters` (v3 API) instead of the old `Parameters` and updated the characterization test to assert `QueryParameters` behavior, with no changes to the `IPapiClient` synchronous signatures. 

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` which completed successfully. 
- Ran `dotnet build src/polaris-api-csharp.sln --no-restore` which completed successfully and produced the `Clc.Polaris.Api` and test assemblies. 
- Ran `dotnet test src/polaris-api-csharp.sln --no-build --filter TestCategory=Unit` and the unit test subset passed (19 passed, 0 failed). 
- Ran `dotnet test src/polaris-api-csharp.sln --no-build` and the full test run failed (69 failed, 41 passed) due to a missing `appsettings.Test.json` in the test output directory rather than changes introduced by this migration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a19dc8cb6d483238bfe435d01d98b96)