### PR TITLE
Upgrade to Clc.Rest.Client v3 alpha and add synchronous Execute shim

### DIFF
--- a/src/polaris-api-csharp/Clc.Polaris.Api.csproj
+++ b/src/polaris-api-csharp/Clc.Polaris.Api.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>Clc.Polaris</RootNamespace>
 		<PackageId>Clc.Polaris.Api</PackageId>
 		<Authors>Central Library Consortium, Michael Fields</Authors>
 		<Description>A helper library that assists in the consumption of the Polaris ILS API</Description>
 		<PackageTags>clc; polaris; papi; polarisapi</PackageTags>
 		<PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
-		<Version>3.1.5</Version>
+		<Version>3.2.0-alpha.1</Version>
 		<Title>Polaris Api Library Helper Library</Title>
 		<PackageProjectUrl>https://bitbucket.org/clcdpc/polaris-api-csharp</PackageProjectUrl>
 		<RepositoryUrl>https://bitbucket.org/clcdpc/polaris-api-csharp</RepositoryUrl>
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Clc.Rest.Client" Version="2.2.1-beta" />
+		<PackageReference Include="Clc.Rest.Client" Version="3.0.0-alpha.1" />
 	</ItemGroup>
 
 </Project>

--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -17,8 +17,7 @@ namespace Clc.Polaris.Api
         {
             var url = "/protected/v1/1033/100/1/authenticator/staff";
             var request = new PapiRestRequest(HttpMethod.Post, url) { Body = staffUser };
-            return Post<ProtectedToken>(url, body: staffUser);
-            //return Execute<ProtectedToken>(request);
+            return Execute<ProtectedToken>(request);
         }
 
         

--- a/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
@@ -34,7 +34,8 @@ namespace Clc.Polaris.Api
                 body.BlockingNoteMode = (int)updateMode;
             }
 
-            return Post<PapiResponseCommon>(url, body: body);
+            var request = new PapiRestRequest(HttpMethod.Post, url) { Body = body };
+            return Execute<PapiResponseCommon>(request);
         }
     }
 }

--- a/src/polaris-api-csharp/Models/PapiRestRequest.cs
+++ b/src/polaris-api-csharp/Models/PapiRestRequest.cs
@@ -41,7 +41,7 @@ namespace Clc.Polaris.Api.Models
             Method = request.Method;
             Path = request.Path;
             Body = request.Body;
-            Parameters = request.Parameters;
+            QueryParameters = request.QueryParameters;
             Headers = request.Headers;
         }
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -119,6 +119,11 @@ namespace Clc.Polaris.Api
             return papiRequest;
         }
 
+        private IRestResponse<T> Execute<T>(RestRequest request)
+        {
+            return ExecuteAsync<T>(request).GetAwaiter().GetResult();
+        }
+
         private string GetPAPIHash(string httpMethod, string date, string uri, string password)
         {
             var hashString = httpMethod + uri + date + password;

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -38,14 +38,14 @@ namespace Clc.Polaris.Api.Tests
                 Path = "/protected/foo",
                 Body = new { Value = "v" },
             };
-            existing.Parameters.Add("limit", "5");
+            existing.QueryParameters.Add("limit", "5");
             existing.Headers.Add("X-Test", "header");
 
             var copied = new PapiRestRequest(existing);
             Assert.AreEqual(existing.Method, copied.Method);
             Assert.AreEqual(existing.Path, copied.Path);
             Assert.AreSame(existing.Body, copied.Body);
-            Assert.AreSame(existing.Parameters, copied.Parameters);
+            Assert.AreSame(existing.QueryParameters, copied.QueryParameters);
             Assert.AreSame(existing.Headers, copied.Headers);
         }
 


### PR DESCRIPTION
### Motivation
- Move the Polaris client baseline to the rest-client v3 alpha so we can begin migration work while preserving the existing synchronous public API.
- Provide a minimal compatibility layer so existing synchronous call sites continue to compile without redesigning the public API.
- Make only the small changes required to compile against the v3 alpha surface and leave broader request/query/auth migration for later.

### Description
- Retarget `Clc.Polaris.Api` from `netstandard2.0` to `net8.0` and bump the package `Version` to `3.2.0-alpha.1` in `Clc.Polaris.Api.csproj`.
- Replace the `Clc.Rest.Client` package reference from `2.2.1-beta` to `3.0.0-alpha.1` in the project file.
- Add a private compatibility method `Execute<T>(RestRequest request)` inside `PapiClient` that calls `ExecuteAsync<T>(request).GetAwaiter().GetResult()` to preserve synchronous call sites.
- Update `PapiRestRequest` copy-constructor to use `QueryParameters` (v3 API) instead of the removed `Parameters` property.
- Route a small number of `Post<T>` call sites to create a `PapiRestRequest` and call the new `Execute<T>` shim (e.g., `AuthenticateStaffUser`, `UpdatePatronNotesData`) and update the related unit test expectations to use `QueryParameters`.

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` which completed successfully.
- Ran `dotnet build src/polaris-api-csharp.sln --no-restore` which completed successfully and produced the `Clc.Polaris.Api` and tests assemblies.
- Ran `dotnet test src/polaris-api-csharp.sln --no-build --no-restore`; test execution ran but many tests failed because the test configuration file `appsettings.Test.json` was not present in the test output directory (observed result: 41 passed, 69 failed, total 110), so the failing tests are due to missing test config rather than the migration changes themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a19dc8cb6d483238bfe435d01d98b96)