### PR TITLE
Upgrade to Clc.Rest.Client v3 alpha and add synchronous compatibility shim

### DIFF
--- a/src/polaris-api-csharp/Clc.Polaris.Api.csproj
+++ b/src/polaris-api-csharp/Clc.Polaris.Api.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>Clc.Polaris</RootNamespace>
 		<PackageId>Clc.Polaris.Api</PackageId>
 		<Authors>Central Library Consortium, Michael Fields</Authors>
 		<Description>A helper library that assists in the consumption of the Polaris ILS API</Description>
 		<PackageTags>clc; polaris; papi; polarisapi</PackageTags>
 		<PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
-		<Version>3.1.5</Version>
+		<Version>3.2.0-alpha.1</Version>
 		<Title>Polaris Api Library Helper Library</Title>
 		<PackageProjectUrl>https://bitbucket.org/clcdpc/polaris-api-csharp</PackageProjectUrl>
 		<RepositoryUrl>https://bitbucket.org/clcdpc/polaris-api-csharp</RepositoryUrl>
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Clc.Rest.Client" Version="2.2.1-beta" />
+		<PackageReference Include="Clc.Rest.Client" Version="3.0.0-alpha.1" />
 	</ItemGroup>
 
 </Project>

--- a/src/polaris-api-csharp/Models/PapiRestRequest.cs
+++ b/src/polaris-api-csharp/Models/PapiRestRequest.cs
@@ -41,7 +41,7 @@ namespace Clc.Polaris.Api.Models
             Method = request.Method;
             Path = request.Path;
             Body = request.Body;
-            Parameters = request.Parameters;
+            QueryParameters = request.QueryParameters;
             Headers = request.Headers;
         }
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
 using System.Collections.Concurrent;
+using System.Threading;
 
 namespace Clc.Polaris.Api
 {
@@ -117,6 +118,16 @@ namespace Clc.Polaris.Api
             }
 
             return papiRequest;
+        }
+
+        private IRestResponse<T> Execute<T>(RestRequest request)
+        {
+            return ExecuteAsync<T>(request, CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        private IRestResponse<T> Post<T>(string url, object body = null)
+        {
+            return Execute<T>(new PapiRestRequest(HttpMethod.Post, url) { Body = body });
         }
 
         private string GetPAPIHash(string httpMethod, string date, string uri, string password)

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -38,14 +38,14 @@ namespace Clc.Polaris.Api.Tests
                 Path = "/protected/foo",
                 Body = new { Value = "v" },
             };
-            existing.Parameters.Add("limit", "5");
+            existing.QueryParameters.Add("limit", "5");
             existing.Headers.Add("X-Test", "header");
 
             var copied = new PapiRestRequest(existing);
             Assert.AreEqual(existing.Method, copied.Method);
             Assert.AreEqual(existing.Path, copied.Path);
             Assert.AreSame(existing.Body, copied.Body);
-            Assert.AreSame(existing.Parameters, copied.Parameters);
+            Assert.AreSame(existing.QueryParameters, copied.QueryParameters);
             Assert.AreSame(existing.Headers, copied.Headers);
         }
 


### PR DESCRIPTION
### Motivation
- Move the library to the rest-client v3 alpha baseline which targets `net8.0` so it can reference the new `Clc.Rest.Client` `3.0.0-alpha.1` package.  
- Preserve the public synchronous Polaris API surface by providing a minimal compatibility shim for the removed synchronous `Execute<T>` path.  

### Description
- Retarget `Clc.Polaris.Api` to `net8.0`, update the package reference to `Clc.Rest.Client` `3.0.0-alpha.1`, and bump the package `Version` to `3.2.0-alpha.1` in `src/polaris-api-csharp/Clc.Polaris.Api.csproj`.  
- Add a blocking compatibility method `private IRestResponse<T> Execute<T>(RestRequest request)` in `PapiClient` that delegates to `ExecuteAsync<T>(request, CancellationToken.None).GetAwaiter().GetResult()`.  
- Add a small `Post<T>(string url, object body = null)` shim in `PapiClient` that constructs a `PapiRestRequest` and calls the compatibility `Execute<T>` to keep existing synchronous call sites compiling.  
- Adjust `PapiRestRequest` copy constructor to use the new v3 `QueryParameters` property instead of the removed `Parameters`, and update the characterization test to match that behavior.  

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` and the restore completed successfully.  
- Ran `dotnet build src/polaris-api-csharp.sln --no-restore` and the solution built successfully (project now targets `net8.0`).  
- Ran `dotnet test src/polaris-api-csharp.sln --no-build --filter TestCategory=Unit` and the unit test filter passed (`19` tests passed).  
- Ran `dotnet test src/polaris-api-csharp.sln --no-build --filter TestCategory=RestClientMigration` and the migration-characterization tests passed (`10` tests passed).  
- Ran the full test run `dotnet test src/polaris-api-csharp.sln --no-build` which failed because the test environment lacked `appsettings.Test.json`, preventing some integration-style tests from instantiating their fixture (this is environmental, not a compile-time regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a19dc8cb6d483238bfe435d01d98b96)