### PR TITLE
Migrate safe Polaris query construction to QueryParameters

### DIFF
--- a/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
+++ b/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
@@ -15,9 +15,11 @@ namespace Clc.Polaris.Api
     {
         public IRestResponse<CreatePatronBlocksResult> CreatePatronBlocks(string barcode, BlockType blockType, string blockValue, int? userId = null, int? workstationId = null)
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/blocks?wsid={workstationId ?? WorkstationId}&userid={userId ?? UserId}";
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/blocks";
             var body = new CreatePatronBlocksRequest((int)blockType, blockValue);
             var request = new PapiRestRequest(HttpMethod.Post, url) { Body = body };
+            request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
+            request.QueryParameters.Add("userid", userId ?? UserId);
 
             return Execute<CreatePatronBlocksResult>(request);
         }

--- a/src/polaris-api-csharp/Methods/HoldRequestCancel.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestCancel.cs
@@ -9,8 +9,10 @@ namespace Clc.Polaris.Api
     {
         public IRestResponse<HoldRequestCancelResult> HoldRequestCancel(string barcode, int requestId, string password = "", int? userId = null, int? workstationId = null)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/cancelled?wsid={workstationId ?? WorkstationId}&userid={userId ?? UserId}";
+            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/cancelled";
             var request = new PapiRestRequest(HttpMethod.Put, url) { Password = password };
+            request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
+            request.QueryParameters.Add("userid", userId ?? UserId);
             return Execute<HoldRequestCancelResult>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
@@ -13,8 +13,11 @@ namespace Clc.Polaris.Api
     {
         public IRestResponse<HoldRequestGetListResult> HoldRequestGetList(int branchId, RequestListBranchType branchType = RequestListBranchType.PickupBranch, HoldStatus status = HoldStatus.Held)
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/circulation/requests/list?branch={branchId}&branchtype={(int)branchType}&requeststatus={(int)status}";
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/circulation/requests/list";
             var request = new PapiRestRequest(url);
+            request.QueryParameters.Add("branch", branchId);
+            request.QueryParameters.Add("branchtype", (int)branchType);
+            request.QueryParameters.Add("requeststatus", (int)status);
             return Execute<HoldRequestGetListResult>(request);
         }
     }    

--- a/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
+++ b/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
@@ -12,10 +12,11 @@ namespace Clc.Polaris.Api
     {
         public IRestResponse<PapiResponseCommon> ItemUpdateBarcode(string newBarcode, int? itemRecordId = null, int? transactionBranchId = null, string oldBarcode = "")
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/cataloging/items/{(itemRecordId.HasValue ? itemRecordId.Value.ToString() : oldBarcode)}/barcode?wsid={transactionBranchId ?? WorkstationId}";
-            if (!string.IsNullOrWhiteSpace(oldBarcode)) { url += "&isBarcode=1"; }
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/cataloging/items/{(itemRecordId.HasValue ? itemRecordId.Value.ToString() : oldBarcode)}/barcode";
             var body = new ItemUpdateBarcodeData { ItemBarcode = newBarcode, TransactionBranchId = transactionBranchId ?? OrganizationId };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            request.QueryParameters.Add("wsid", transactionBranchId ?? WorkstationId);
+            if (!string.IsNullOrWhiteSpace(oldBarcode)) { request.QueryParameters.Add("isBarcode", 1); }
             return Execute<PapiResponseCommon>(request);
         }
 

--- a/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
@@ -15,9 +15,11 @@ namespace Clc.Polaris.Api
     {
         public IRestResponse<PapiResponseCommon> PatronAccountCreateCredit(string barcode, double txnAmount, PaymentMethod paymentMethod, int? workstationId = null, int? userId = null, string note = "")
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/createcredit?wsid={workstationId ?? WorkstationId}&userid={userId ?? UserId}";
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/createcredit";
             var body = new PatronAccountCreateCreditData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
+            request.QueryParameters.Add("userid", userId ?? UserId);
             return Execute<PapiResponseCommon>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronAccountDeleteTitleList.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDeleteTitleList.cs
@@ -15,8 +15,9 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PapiResponseCommon> PatronAccountDeleteTitleList(string barcode, int listId, string password = "")
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patronaccountdeletetitlelist?list={listId}";
+            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patronaccountdeletetitlelist";
             var request = new PapiRestRequest(HttpMethod.Delete, url) { Password = password };
+            request.QueryParameters.Add("list", listId);
             return Execute<PapiResponseCommon>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
@@ -17,9 +17,11 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PapiResponseCommon> PatronAccountDepositCredit(string barcode, double txnAmount, int? workstationId = null, int? userId = null, string note = "")
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumdepositcredit?wsid={workstationId ?? WorkstationId}&userid={userId ?? UserId}";
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumdepositcredit";
             var body = new PatronAccountDepositCreditData { TxnAmount = txnAmount, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
+            request.QueryParameters.Add("userid", userId ?? UserId);
             return Execute<PapiResponseCommon>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronAccountPay.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPay.cs
@@ -17,9 +17,11 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PapiResponseCommon> PatronAccountPay(string barcode, int txnId, double txnAmount, PaymentMethod paymentMethod, int? workstationId = null, int? userId = null, string note = "")
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/{txnId}/pay?wsid={workstationId ?? WorkstationId}&userid={userId ?? UserId}";
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/{txnId}/pay";
             var body = new PatronAccountPayData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
+            request.QueryParameters.Add("userid", userId ?? UserId);
             return Execute<PapiResponseCommon>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
@@ -17,9 +17,11 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PapiResponseCommon> PatronAccountPayAll(string barcode, double txnAmount, PaymentMethod paymentMethod, int? workstationId = 1, int? userId = 1, string note = "")
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumpayment?wsid={workstationId ?? WorkstationId}&userid={userId ?? UserId}";
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumpayment";
             var body = new PatronAccountPayData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
+            request.QueryParameters.Add("userid", userId ?? UserId);
             return Execute<PapiResponseCommon>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
@@ -17,9 +17,11 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PapiResponseCommon> PatronAccountRefundCredit(string barcode, double txnAmount, int? workstationId = null, int? userId = null, string note = "")
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumrefundcredit?wsid={workstationId ?? WorkstationId}&userid={userId ?? UserId}";
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumrefundcredit";
             var body = new PatronAccountRefundCreditData { TxnAmount = txnAmount, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
+            request.QueryParameters.Add("userid", userId ?? UserId);
             return Execute<PapiResponseCommon>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
@@ -17,8 +17,10 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PapiResponseCommon> PatronAccountVoid(string barcode, int paymentTxnId, int? workstationId = null, int? userId = null, string note = "")
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/{paymentTxnId}/void/payment?wsid={workstationId ?? WorkstationId}&userid={userId ?? UserId}";
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/{paymentTxnId}/void/payment";
             var request = new PapiRestRequest(HttpMethod.Delete, url);
+            request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
+            request.QueryParameters.Add("userid", userId ?? UserId);
             return Execute<PapiResponseCommon>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronBasicDataGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronBasicDataGet.cs
@@ -16,8 +16,10 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PatronBasicDataGetResult> PatronBasicDataGet(string barcode, string password = "", bool addresses = false, bool notes = false)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/basicdata?addresses={Convert.ToInt32(addresses)}&notes={Convert.ToInt32(notes)}";
+            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/basicdata";
             var request = new PapiRestRequest(url) { Password = password };
+            request.QueryParameters.Add("addresses", Convert.ToInt32(addresses));
+            request.QueryParameters.Add("notes", Convert.ToInt32(notes));
             return Execute<PatronBasicDataGetResult>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronMessagesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessagesGet.cs
@@ -15,8 +15,9 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PatronMessagesGetResult> PatronMessagesGet(string barcode, bool unreadOnly = false, string password = "")
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/messages?unreadonly={(unreadOnly ? 1 : 0)}";
+            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/messages";
             var request = new PapiRestRequest(url) { Password = password };
+            request.QueryParameters.Add("unreadonly", unreadOnly ? 1 : 0);
             return Execute<PatronMessagesGetResult>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
+++ b/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
@@ -18,8 +18,8 @@ namespace Clc.Polaris.Api
         public IRestResponse<PapiResponseCommon> PatronReadingHistoryClear(string barcode, string password, params int[] ids)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/readinghistory";
-            if (ids.Any()) { url += $"?ids={string.Join(",", ids)}"; }
             var request = new PapiRestRequest(HttpMethod.Delete, url) { Password = password };
+            if (ids.Any()) { request.QueryParameters.Add("ids", string.Join(",", ids)); }
             return Execute<PapiResponseCommon>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronReadingHistoryGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronReadingHistoryGet.cs
@@ -15,8 +15,10 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PatronReadingHistoryGetResult> PatronReadingHistoryGet(string barcode, int page = 1, int rowsPerPage = 50, string password = "")
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/readinghistory?page={page}&rowsperpage={rowsPerPage}";
+            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/readinghistory";
             var request = new PapiRestRequest(url) { Password = password };
+            request.QueryParameters.Add("page", page);
+            request.QueryParameters.Add("rowsperpage", rowsPerPage);
             return Execute<PatronReadingHistoryGetResult>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronSearch.cs
+++ b/src/polaris-api-csharp/Methods/PatronSearch.cs
@@ -11,8 +11,12 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PatronSearchResult> PatronSearch(string query, int page = 1, int pageSize = 10, PatronSortKeys sortBy = PatronSortKeys.PATN, int? orgId = null)
         {
-            var url = $"/protected/v1/1033/100/{orgId ?? OrganizationId}/{Token.AccessToken}/search/patrons/Boolean?q={WebUtility.UrlEncode(query)}&patronsperpage={pageSize}&page={page}&sort={sortBy}";
+            var url = $"/protected/v1/1033/100/{orgId ?? OrganizationId}/{Token.AccessToken}/search/patrons/Boolean";
             var request = new PapiRestRequest(url);
+            request.QueryParameters.Add("q", query);
+            request.QueryParameters.Add("patronsperpage", pageSize);
+            request.QueryParameters.Add("page", page);
+            request.QueryParameters.Add("sort", sortBy);
             return Execute<PatronSearchResult>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronTitleListDeleteAllTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListDeleteAllTitles.cs
@@ -17,8 +17,9 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PapiResponseCommon> PatronTitleListDeleteAllTitles(string barcode, int listId, string password = "")
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistdeletealltitles?list={listId}";
+            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistdeletealltitles";
             var request = new PapiRestRequest(HttpMethod.Delete, url) { Password = password };
+            request.QueryParameters.Add("list", listId);
             return Execute<PapiResponseCommon>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs
@@ -25,8 +25,10 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PapiResponseCommon> PatronTitleListDeleteTitle(string barcode, int listId, int position, string password = "")
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistdeletetitle?list={listId}&position={position}";
+            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistdeletetitle";
             var request = new PapiRestRequest(HttpMethod.Delete, url) { Password = password };
+            request.QueryParameters.Add("list", listId);
+            request.QueryParameters.Add("position", position);
             return Execute<PapiResponseCommon>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronTitleListGetTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListGetTitles.cs
@@ -15,8 +15,11 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PatronTitleListGetTitlesResult> PatronTitleListGetTitles(string barcode, int listId, int startPosition = 1, int endPosition = 100, string password = "")
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistgettitles?list={listId}&startPosition={startPosition}&endPosition={endPosition}";
+            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistgettitles";
             var request = new PapiRestRequest(url) { Password = password };
+            request.QueryParameters.Add("list", listId);
+            request.QueryParameters.Add("startPosition", startPosition);
+            request.QueryParameters.Add("endPosition", endPosition);
             return Execute<PatronTitleListGetTitlesResult>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronUpdate.cs
+++ b/src/polaris-api-csharp/Methods/PatronUpdate.cs
@@ -18,8 +18,9 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PatronUpdateResult> PatronUpdate(string barcode, PatronUpdateParams updateParams, string password = "", bool ignoresa = true)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}?ignoresa={ignoresa}";
+            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}";
             var request = new PapiRestRequest(HttpMethod.Put, url) { Password = password, Body = updateParams };
+            request.QueryParameters.Add("ignoresa", ignoresa);
             return Execute<PatronUpdateResult>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
+++ b/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
@@ -11,8 +11,9 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<GetBarcodeAndPatronIDResult> Patron_GetBarcodeFromId(int patronId)
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/barcode?patronid={patronId}";
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/barcode";
             var request = new PapiRestRequest(url);
+            request.QueryParameters.Add("patronid", patronId);
             return Execute<GetBarcodeAndPatronIDResult>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
@@ -15,9 +15,12 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PapiResponseCommon> RecordSetContentPut(int recordSetId, IEnumerable<int> records, RecordSetContentPutActions action, int? userId = null, int? workstationId = null)
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/recordsets/{recordSetId}?action={action}&userid={userId ?? UserId}&wsid={workstationId ?? WorkstationId}";
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/recordsets/{recordSetId}";
             var body = new { records = string.Join(",", records) };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            request.QueryParameters.Add("action", action);
+            request.QueryParameters.Add("userid", userId ?? UserId);
+            request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             return Execute<PapiResponseCommon>(request);
         }
         public IRestResponse<PapiResponseCommon> RecordSetContentAdd(int recordSetId, int recordId, int userId = 1, int workstationId = 1)

--- a/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
@@ -15,8 +15,12 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<RecordSetRecordsGetResult> RecordSetRecordsGet(int recordSetId, int userId = 1, int workstationId = 1, int startIndex = 0, int numRecords = 1000)
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/recordsets/{recordSetId}/records?startIndex={startIndex}&numRecords={numRecords}&userid={userId}&wsid={workstationId}";
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/recordsets/{recordSetId}/records";
             var request = new PapiRestRequest(url);
+            request.QueryParameters.Add("startIndex", startIndex);
+            request.QueryParameters.Add("numRecords", numRecords);
+            request.QueryParameters.Add("userid", userId);
+            request.QueryParameters.Add("wsid", workstationId);
             return Execute<RecordSetRecordsGetResult>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
+++ b/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
@@ -14,9 +14,14 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<RemoteStorageItemsGetResult> RemoteStorageItemsGet(int branchId, string startDate, string endDate, int maxItems, int listType, int? startItemRecordId = null)
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/cataloging/remotestorage/items?branch={branchId}&startdate={startDate}&enddate={endDate}&maxitems={maxItems}&listtype={(int)listType}";
-            if (startItemRecordId.HasValue) { url += $"&startitemrecordid={startItemRecordId.Value}"; }
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/cataloging/remotestorage/items";
             var request = new PapiRestRequest(url);
+            request.QueryParameters.Add("branch", branchId);
+            request.QueryParameters.Add("startdate", startDate);
+            request.QueryParameters.Add("enddate", endDate);
+            request.QueryParameters.Add("maxitems", maxItems);
+            request.QueryParameters.Add("listtype", (int)listType);
+            if (startItemRecordId.HasValue) { request.QueryParameters.Add("startitemrecordid", startItemRecordId.Value); }
             return Execute<RemoteStorageItemsGetResult>(request);
         }
     }

--- a/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
+++ b/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
@@ -13,12 +13,13 @@ namespace Clc.Polaris.Api
     {
         public IRestResponse<Sync_BibsByIdGetResult> Synch_BibsByIdGet(int[] bibIds, bool includeItems = false)
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/synch/bibs/MARCxml?bibids={string.Join(",", bibIds)}";
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/synch/bibs/MARCxml";
+            var request = new PapiRestRequest(url);
+            request.QueryParameters.Add("bibids", string.Join(",", bibIds));
             if (includeItems)
             {
-                url += $"&includeItems=1";
+                request.QueryParameters.Add("includeItems", 1);
             }
-            var request = new PapiRestRequest(url);
             return Execute<Sync_BibsByIdGetResult>(request);
         }
 

--- a/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
     {
         public IRestResponse<PapiResponseCommon> UpdatePatronNotesData(string barcode, string nonBlockingNote = null, string blockingNote = null, UpdateNoteMode updateMode = UpdateNoteMode.Prepend, int? workstationId = null)
         {
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/notes?wsid={workstationId ?? WorkstationId}";
+            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/notes";
             var body = new UpdatePatronNotesData();
 
             if (!string.IsNullOrWhiteSpace(nonBlockingNote))
@@ -34,7 +34,9 @@ namespace Clc.Polaris.Api
                 body.BlockingNoteMode = (int)updateMode;
             }
 
-            return Post<PapiResponseCommon>(url, body: body);
+            var request = new PapiRestRequest(HttpMethod.Post, url) { Body = body };
+            request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
+            return Execute<PapiResponseCommon>(request);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/UpdatePickupBranchID.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePickupBranchID.cs
@@ -16,8 +16,11 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PapiResponseCommon> UpdatePickupBranchID(string barcode, int requestId, int pickupBranchId, string password = "", int? userId = null, int? workstationId = null)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/pickupbranch?userid={userId ?? UserId}&wsid={workstationId ?? WorkstationId}&pickupbranchid={pickupBranchId}";
+            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/pickupbranch";
             var request = new PapiRestRequest(HttpMethod.Put, url) { Password = password };
+            request.QueryParameters.Add("userid", userId ?? UserId);
+            request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
+            request.QueryParameters.Add("pickupbranchid", pickupBranchId);
             return Execute<PapiResponseCommon>(request);
         }
     }

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -9,6 +9,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Collections.Concurrent;
 using System.Threading;
+using System.Linq;
 
 namespace Clc.Polaris.Api
 {
@@ -112,7 +113,7 @@ namespace Clc.Polaris.Api
                 }
 
                 var date = DateTime.Now.ToUniversalTime().ToString("R");
-                var hash = GetPAPIHash(papiRequest.Method.ToString(), date, BuildUrl(papiRequest), password);
+                var hash = GetPAPIHash(papiRequest.Method.ToString(), date, BuildUrlWithQueryParameters(papiRequest), password);
                 papiRequest.Headers.Add("PolarisDate", date);
                 papiRequest.Headers.Add("Authorization", string.Format("PWS {0}:{1}", AccessID, hash));
             }
@@ -128,6 +129,26 @@ namespace Clc.Polaris.Api
         private IRestResponse<T> Post<T>(string url, object body = null)
         {
             return Execute<T>(new PapiRestRequest(HttpMethod.Post, url) { Body = body });
+        }
+
+        private string BuildUrlWithQueryParameters(RestRequest request)
+        {
+            var url = BuildUrl(request);
+            if (request.QueryParameters == null || !request.QueryParameters.Any())
+            {
+                return url;
+            }
+
+            var queryString = string.Join("&", request.QueryParameters
+                .Select(parameter => new { parameter.Key, Value = parameter.Value?.ToString() })
+                .Where(parameter => !string.IsNullOrEmpty(parameter.Value))
+                .Select(parameter => $"{Uri.EscapeDataString(parameter.Key)}={Uri.EscapeDataString(parameter.Value)}"));
+            if (string.IsNullOrEmpty(queryString))
+            {
+                return url;
+            }
+
+            return $"{url}{(url.Contains("?") ? "&" : "?")}{queryString}";
         }
 
         private string GetPAPIHash(string httpMethod, string date, string uri, string password)

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -133,6 +134,23 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsTrue(formatted.Headers.ContainsKey("Authorization"));
         }
 
+
+        [TestMethod]
+        public void PreformatRestRequest_HashesQueryParameters_WhenPresent()
+        {
+            var client = CreateClient();
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search");
+            request.QueryParameters.Add("q", "a b&c");
+            request.QueryParameters.Add("page", 2);
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            var date = formatted.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/search?q=a%20b%26c&page=2";
+            var expectedHash = Convert.ToBase64String(HMACSHA1.HashData(Encoding.UTF8.GetBytes("access-key"), Encoding.UTF8.GetBytes($"GET{expectedUri}{date}")));
+            Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
+        }
+
         [TestMethod]
         public void ApiKeyValidate_RequestShape_IsStable()
         {
@@ -219,12 +237,39 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual(HttpMethod.Put, handler.LastRequest!.Method);
             var encodedBarcode = WebUtility.UrlEncode("AB C/+#?=");
             StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, $"/public/v1/1033/100/1/patron/{encodedBarcode}");
-            StringAssert.Contains(handler.LastRequest.RequestUri.Query, "ignoresa=True");
+            AssertQueryParameter(handler.LastRequest.RequestUri, "ignoresa", "True");
             Assert.IsNotNull(handler.LastRequest.Content);
             Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
             Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
             Assert.IsNotNull(handler.LastRequestContent);
             StringAssert.Contains(handler.LastRequestContent, "patron@example.test");
+        }
+
+
+        [TestMethod]
+        public void PatronSearch_RequestShape_UsesQueryParameters()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "token-segment",
+                AccessSecret = "secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(1)
+            };
+
+            var response = client.PatronSearch("name: O'Neil & family", page: 3, pageSize: 25, sortBy: PatronSortKeys.PATNL, orgId: 77);
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
+            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/protected/v1/1033/100/77/token-segment/search/patrons/Boolean");
+            AssertQueryParameter(handler.LastRequest.RequestUri, "q", "name: O'Neil & family");
+            AssertQueryParameter(handler.LastRequest.RequestUri, "patronsperpage", "25");
+            AssertQueryParameter(handler.LastRequest.RequestUri, "page", "3");
+            AssertQueryParameter(handler.LastRequest.RequestUri, "sort", "PATNL");
+            Assert.IsNull(handler.LastRequest.Content);
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
         }
 
         private static PapiClient CreateClient(HttpMessageHandler? handler = null)
@@ -236,6 +281,24 @@ namespace Clc.Polaris.Api.Tests
                 AllowStaffOverrideRequests = false,
                 UseProtectedTokenCache = false
             };
+        }
+
+
+        private static void AssertQueryParameter(Uri uri, string name, string expectedValue)
+        {
+            var parameters = ParseQuery(uri.Query);
+            Assert.IsTrue(parameters.TryGetValue(name, out var actualValue), $"Missing query parameter '{name}' in '{uri.Query}'.");
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        private static Dictionary<string, string> ParseQuery(string query)
+        {
+            return query.TrimStart('?')
+                .Split('&', StringSplitOptions.RemoveEmptyEntries)
+                .Select(part => part.Split('=', 2))
+                .ToDictionary(
+                    pair => Uri.UnescapeDataString(pair[0]).Replace("+", " "),
+                    pair => pair.Length > 1 ? Uri.UnescapeDataString(pair[1]).Replace("+", " ") : string.Empty);
         }
 
         private sealed class TestPapiSettings : IPapiSettings


### PR DESCRIPTION
### Motivation
- Move Polaris request construction toward rest-client v3 by using `PapiRestRequest.QueryParameters` for straightforward query values while preserving public API signatures and existing path encoding. 
- Ensure PAPI auth hashing continues to match the final outgoing URI that rest-client v3 will send so auth headers remain valid for converted endpoints. 

### Description
- Replaced many manually appended query strings with `request.QueryParameters.Add(...)` and left the endpoint `Path` unchanged for methods including `PatronSearch`, `PatronUpdate`, `PatronReadingHistoryGet/Clear`, `RemoteStorageItemsGet`, `HoldRequestGetList`, `CreatePatronBlocks`, `RecordSetContentPut`, `RecordSetRecordsGet`, `Synch_BibsByIdGet`, and several `PatronAccount*` methods. 
- Added `BuildUrlWithQueryParameters(RestRequest)` and used it when generating the PAPI hash in `PreformatRestRequest` so the hashed URI includes non-empty query parameters produced via `QueryParameters`. 
- Preserved existing value formatting (booleans/enums/integers) and avoided adding null/empty optional parameters; path-segment encoding was left as-is. 
- Extended `RestClientMigrationCharacterizationTests` with: a hashing test that asserts query parameters are included in the hash, a query-parameter-based `PatronSearch` test, a boolean-query test for `ignoresa`, and helpers to assert query semantics rather than raw ordering. 

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` and `dotnet build src/polaris-api-csharp.sln --no-restore` successfully. 
- Ran the migration characterization tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter TestCategory=RestClientMigration` and they passed. 
- Ran the non-migration unit tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=Unit&TestCategory!=RestClientMigration"` and they passed. 
- Full `dotnet test src/polaris-api-csharp.sln --no-build` fails in this environment because `appsettings.Test.json` is not present for integration-style `PapiClientTests`; this is unrelated to the query-parameter migration and was documented in the test run output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1a35081aa08323b5cfb145d074fdfe)