### PR TITLE
Harden PAPI request auth formatting

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -104,7 +104,7 @@ namespace Clc.Polaris.Api
                 if (papiRequest.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(password) && !papiRequest.BlockStaffOverride && Token != null)
                 {
                     password = Token.AccessSecret;
-                    papiRequest.Headers.Add("X-PAPI-AccessToken", Token.AccessToken);
+                    papiRequest.Headers["X-PAPI-AccessToken"] = Token.AccessToken;
                 }
 
                 if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password) && _token != null)
@@ -114,8 +114,8 @@ namespace Clc.Polaris.Api
 
                 var date = DateTime.Now.ToUniversalTime().ToString("R");
                 var hash = GetPAPIHash(papiRequest.Method.ToString(), date, BuildUrlForPapiHash(papiRequest), password);
-                papiRequest.Headers.Add("PolarisDate", date);
-                papiRequest.Headers.Add("Authorization", string.Format("PWS {0}:{1}", AccessID, hash));
+                papiRequest.Headers["PolarisDate"] = date;
+                papiRequest.Headers["Authorization"] = string.Format("PWS {0}:{1}", AccessID, hash);
             }
 
             return papiRequest;

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -134,6 +134,219 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsTrue(formatted.Headers.ContainsKey("Authorization"));
         }
 
+
+        [TestMethod]
+        public void PreformatRestRequest_HashesPublicAuthenticatedGetWithoutQueryParameters_AsLegacyUri()
+        {
+            var client = CreateClient();
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/apikeyvalidate");
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            AssertPapiAuthorization(
+                formatted,
+                "GET",
+                "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate",
+                string.Empty);
+            Assert.AreEqual(0, formatted.QueryParameters.Count);
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_HashesPublicAuthenticatedGetWithQueryParameters_UsingRestClientEscaping()
+        {
+            var client = CreateClient();
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.QueryParameters.Add("q", "harry potter & stone");
+            request.QueryParameters.Add("sort", "MP");
+            request.QueryParameters.Add("empty", null!);
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            AssertPapiAuthorization(
+                formatted,
+                "GET",
+                "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&empty=",
+                string.Empty);
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_HashesBodyRequestsWithQueryParameters_WithoutChangingBodies()
+        {
+            var client = CreateClient();
+            var putBody = new PatronUpdateParams { EmailAddress = "patron@example.test" };
+            var put = new PapiRestRequest(HttpMethod.Put, "/public/v1/1033/100/1/patron/ABC", "pin", putBody);
+            put.QueryParameters.Add("ignoresa", true);
+            var postBody = new PolarisUser { Domain = "main", Username = "staff", Password = "secret" };
+            var post = new PapiRestRequest(HttpMethod.Post, "/protected/v1/1033/100/1/authenticator/staff", body: postBody);
+            post.QueryParameters.Add("wsid", 3);
+
+            var formattedPut = (PapiRestRequest)client.PreformatRestRequest(put);
+            var formattedPost = (PapiRestRequest)client.PreformatRestRequest(post);
+
+            Assert.AreSame(putBody, formattedPut.Body);
+            AssertPapiAuthorization(
+                formattedPut,
+                "PUT",
+                "https://example.test/PAPIService/REST/public/v1/1033/100/1/patron/ABC?ignoresa=True",
+                "pin");
+            Assert.AreSame(postBody, formattedPost.Body);
+            AssertPapiAuthorization(
+                formattedPost,
+                "POST",
+                "https://example.test/PAPIService/REST/protected/v1/1033/100/1/authenticator/staff?wsid=3",
+                string.Empty);
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_ProtectedRequest_UsesProtectedTokenSecret()
+        {
+            var client = CreateClient();
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "protected-token",
+                AccessSecret = "protected-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(1)
+            };
+            var request = new PapiRestRequest(HttpMethod.Get, "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
+            request.QueryParameters.Add("q", "name = Smith");
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
+            AssertPapiAuthorization(
+                formatted,
+                "GET",
+                "https://example.test/PAPIService/REST/protected/v1/1033/100/1/protected-token/search/patrons/Boolean?q=name%20%3D%20Smith",
+                "protected-secret");
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_StaffOverrideAllowedAndUnblocked_AddsTokenHeaderAndUsesTokenSecret()
+        {
+            var client = CreateClient();
+            client.AllowStaffOverrideRequests = true;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "staff-token",
+                AccessSecret = "staff-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(1)
+            };
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/apikeyvalidate");
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            Assert.AreEqual("staff-token", formatted.Headers["X-PAPI-AccessToken"]);
+            AssertPapiAuthorization(
+                formatted,
+                "GET",
+                "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate",
+                "staff-secret");
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_StaffOverrideBlocked_DoesNotAddTokenHeaderOrUseTokenSecret()
+        {
+            var client = CreateClient();
+            client.AllowStaffOverrideRequests = true;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "staff-token",
+                AccessSecret = "staff-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(1)
+            };
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/apikeyvalidate")
+            {
+                BlockStaffOverride = true
+            };
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
+            AssertPapiAuthorization(
+                formatted,
+                "GET",
+                "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate",
+                string.Empty);
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_StaffOverrideDisabled_DoesNotAddTokenHeaderOrUseTokenSecret()
+        {
+            var client = CreateClient();
+            client.AllowStaffOverrideRequests = false;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "staff-token",
+                AccessSecret = "staff-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(1)
+            };
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/apikeyvalidate");
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
+            AssertPapiAuthorization(
+                formatted,
+                "GET",
+                "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate",
+                string.Empty);
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_CanBeCalledTwice_WithoutDuplicatingHeadersOrChangingBody()
+        {
+            var client = CreateClient();
+            client.AllowStaffOverrideRequests = true;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "staff-token",
+                AccessSecret = "staff-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(1)
+            };
+            var body = new { Value = "unchanged" };
+            var request = new PapiRestRequest(HttpMethod.Post, "/public/v1/1033/100/1/foo", body: body);
+            request.Headers.Add("X-Test", "original");
+
+            var first = (PapiRestRequest)client.PreformatRestRequest(request);
+            var second = (PapiRestRequest)client.PreformatRestRequest(first);
+
+            Assert.AreSame(first, second);
+            Assert.AreSame(body, second.Body);
+            Assert.AreEqual("original", second.Headers["X-Test"]);
+            Assert.AreEqual("staff-token", second.Headers["X-PAPI-AccessToken"]);
+            Assert.AreEqual(4, second.Headers.Count);
+            AssertPapiAuthorization(
+                second,
+                "POST",
+                "https://example.test/PAPIService/REST/public/v1/1033/100/1/foo",
+                "staff-secret");
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_AuthorizationChanges_WhenQueryParameterValuesChange()
+        {
+            var client = CreateClient();
+            var first = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            first.QueryParameters.Add("q", "alpha");
+            var second = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            second.QueryParameters.Add("q", "beta");
+
+            var formattedFirst = (PapiRestRequest)client.PreformatRestRequest(first);
+            var formattedSecond = (PapiRestRequest)client.PreformatRestRequest(second);
+
+            AssertPapiAuthorization(
+                formattedFirst,
+                "GET",
+                "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=alpha",
+                string.Empty);
+            AssertPapiAuthorization(
+                formattedSecond,
+                "GET",
+                "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=beta",
+                string.Empty);
+            Assert.AreNotEqual(formattedFirst.Headers["Authorization"], formattedSecond.Headers["Authorization"]);
+        }
+
         [TestMethod]
         public void ApiKeyValidate_RequestShape_IsStable()
         {
@@ -271,6 +484,33 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
         }
 
+
+        [TestMethod]
+        public void ExecutedRequest_AuthorizationHashesTheSameQueryParameterUriSentByRestClient()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var options = new BibSearchOptions
+            {
+                Branch = 1,
+                SearchType = BibSearchTypes.keyword,
+                Qualifier = SearchQualifiers.KW,
+                Term = "harry potter & stone",
+                SortOption = SearchSortOptions.MP,
+                Page = 2,
+                PageSize = 15,
+                Limit = "3"
+            };
+
+            var response = client.BibSearch(options);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(handler.LastRequest);
+            var date = handler.LastRequest.Headers.GetValues("PolarisDate").Single();
+            var expectedHash = ComputePapiHash("GET", handler.LastRequest.RequestUri!.AbsoluteUri, date, string.Empty, "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", handler.LastRequest.Headers.GetValues("Authorization").Single());
+        }
+
         [TestMethod]
         public void PreformatRestRequest_HashesQueryParameters_WithOutgoingUriEncoding()
         {
@@ -297,6 +537,16 @@ namespace Clc.Polaris.Api.Tests
             };
         }
 
+
+
+        private static void AssertPapiAuthorization(PapiRestRequest request, string httpMethod, string expectedUri, string password)
+        {
+            Assert.IsTrue(request.Headers.ContainsKey("PolarisDate"));
+            Assert.IsTrue(request.Headers.ContainsKey("Authorization"));
+            var date = request.Headers["PolarisDate"];
+            var expectedHash = ComputePapiHash(httpMethod, expectedUri, date, password, "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", request.Headers["Authorization"]);
+        }
 
         private static Dictionary<string, string> ParseQuery(string query)
         {


### PR DESCRIPTION
### Motivation
- Ensure PAPI authorization headers and hash URI remain stable after the QueryParameters migration and that repeated formatting does not duplicate or throw when `PreformatRestRequest` is called multiple times.
- Characterize the highest-risk auth paths (public/protected/staff override) and confirm query-parameter hashing matches the actual outgoing URI produced by rest-client v3.

### Description
- Make header assignment idempotent in `PapiClient.PreformatRestRequest` by setting `X-PAPI-AccessToken`, `PolarisDate`, and `Authorization` via indexer instead of using `Dictionary.Add` to avoid duplicate keys when called multiple times.  (src/polaris-api-csharp/PapiClient.cs)
- Preserve existing header names and Authorization format (`PolarisDate`, `Authorization`, `X-PAPI-AccessToken`, `PWS {AccessID}:{hash}`) and keep public API signatures and the synchronous `Execute<T>` shim unchanged. (no public signature changes)
- Add extensive RestClient migration characterization tests covering: public authenticated GETs (with/without query parameters), body-bearing PUT/POST with query parameters (ensuring bodies are preserved), protected-token secret usage, staff-override allowed/blocked/disabled behavior, idempotent `PreformatRestRequest` behavior, and a test verifying that the Authorization header changes when query parameter values change. (src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs)
- Add an executed-request test that asserts the `Authorization` hash is computed from the same QueryParameters URI that rest-client v3 sends, plus a shared helper `AssertPapiAuthorization` to validate expected hash values. (tests file)

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` which completed successfully. (Succeeded)
- Built the solution with `dotnet build src/polaris-api-csharp.sln --no-restore` which completed successfully. (Succeeded)
- Ran the targeted migration characterization tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter RestClientMigration --no-build` and all added/related tests passed (23 tests in the migration group passed). (Succeeded)
- Ran non-integration unit tests via `dotnet test --filter "TestCategory!=Integration" --no-build` and the suite passed (54 tests passed). (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1a43a202048323b0cec79050bac3f5)