### PR TITLE
Harden PAPI auth request formatting

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -101,10 +101,14 @@ namespace Clc.Polaris.Api
 
             if (papiRequest.AuthRequired)
             {
-                if (papiRequest.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(password) && !papiRequest.BlockStaffOverride && Token != null)
+                if (papiRequest.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(password) && !papiRequest.BlockStaffOverride)
                 {
-                    password = Token.AccessSecret;
-                    papiRequest.Headers.Add("X-PAPI-AccessToken", Token.AccessToken);
+                    var token = Token;
+                    if (token != null)
+                    {
+                        password = token.AccessSecret;
+                        papiRequest.Headers["X-PAPI-AccessToken"] = token.AccessToken;
+                    }
                 }
 
                 if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password) && _token != null)
@@ -114,8 +118,8 @@ namespace Clc.Polaris.Api
 
                 var date = DateTime.Now.ToUniversalTime().ToString("R");
                 var hash = GetPAPIHash(papiRequest.Method.ToString(), date, BuildUrlForPapiHash(papiRequest), password);
-                papiRequest.Headers.Add("PolarisDate", date);
-                papiRequest.Headers.Add("Authorization", string.Format("PWS {0}:{1}", AccessID, hash));
+                papiRequest.Headers["PolarisDate"] = date;
+                papiRequest.Headers["Authorization"] = string.Format("PWS {0}:{1}", AccessID, hash);
             }
 
             return papiRequest;

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -101,6 +101,8 @@ namespace Clc.Polaris.Api
 
             if (papiRequest.AuthRequired)
             {
+                papiRequest.Headers.Remove("X-PAPI-AccessToken");
+
                 if (papiRequest.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(password) && !papiRequest.BlockStaffOverride)
                 {
                     var token = Token;

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -93,6 +93,93 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public void PreformatRestRequest_PublicAuthenticatedGetWithoutQueryParameters_HashesOriginalUrl()
+        {
+            var client = CreateClient();
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/apikeyvalidate");
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            var date = formatted.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate";
+            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
+            Assert.AreSame(request.Body, formatted.Body);
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_ProtectedGet_UsesProtectedTokenSecretForHash()
+        {
+            var client = CreateClient();
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "protected-token",
+                AccessSecret = "protected-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(1)
+            };
+            var request = new PapiRestRequest(HttpMethod.Get, "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            var date = formatted.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/protected/v1/1033/100/1/protected-token/search/patrons/Boolean";
+            var expectedHash = ComputePapiHash("GET", expectedUri, date, "protected-secret", "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
+            Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_PublicAuthenticatedGetWithQueryParameters_HashesEffectiveOutgoingUrl()
+        {
+            var client = CreateClient();
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.QueryParameters.Add("q", "harry potter & stone");
+            request.QueryParameters.Add("limit", "branch:1");
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            var date = formatted.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&limit=branch%3A1";
+            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_AuthenticatedPutWithBodyAndQueryParameters_HashesQueryAndPreservesBody()
+        {
+            var client = CreateClient();
+            var body = new PatronUpdateParams { EmailAddress = "patron@example.test" };
+            var request = new PapiRestRequest(HttpMethod.Put, "/public/v1/1033/100/1/patron/ABC123", "1234", body);
+            request.QueryParameters.Add("ignoresa", true);
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            var date = formatted.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/patron/ABC123?ignoresa=True";
+            var expectedHash = ComputePapiHash("PUT", expectedUri, date, "1234", "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
+            Assert.AreSame(body, formatted.Body);
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_AuthenticatedPostWithBodyAndQueryParameters_HashesQueryAndPreservesBody()
+        {
+            var client = CreateClient();
+            var body = new { Amount = 12.34m };
+            var request = new PapiRestRequest(HttpMethod.Post, "/protected/v1/1033/100/1/token/patron/123/account/payment", "protected-secret", body);
+            request.QueryParameters.Add("wsid", 7);
+            request.QueryParameters.Add("userid", 8);
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            var date = formatted.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/protected/v1/1033/100/1/token/patron/123/account/payment?wsid=7&userid=8";
+            var expectedHash = ComputePapiHash("POST", expectedUri, date, "protected-secret", "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
+            Assert.AreSame(body, formatted.Body);
+        }
+
+        [TestMethod]
         public void PreformatRestRequest_AddsStaffOverrideToken_WhenAllowedAndUnblocked()
         {
             var client = CreateClient();
@@ -109,7 +196,10 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.IsTrue(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
             Assert.AreEqual("staff-token", formatted.Headers["X-PAPI-AccessToken"]);
-            Assert.IsTrue(formatted.Headers.ContainsKey("Authorization"));
+            var date = formatted.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate";
+            var expectedHash = ComputePapiHash("GET", expectedUri, date, "staff-secret", "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
         }
 
         [TestMethod]
@@ -131,7 +221,78 @@ namespace Clc.Polaris.Api.Tests
             var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
 
             Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
-            Assert.IsTrue(formatted.Headers.ContainsKey("Authorization"));
+            var date = formatted.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate";
+            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_DoesNotAddStaffOverrideToken_WhenDisabled()
+        {
+            var client = CreateClient();
+            client.AllowStaffOverrideRequests = false;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "staff-token",
+                AccessSecret = "staff-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(1)
+            };
+
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/apikeyvalidate");
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
+            var date = formatted.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate";
+            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_WhenCalledTwice_ReplacesPapiHeadersWithoutDuplicatingOrChangingBody()
+        {
+            var client = CreateClient();
+            var body = new { Value = "unchanged" };
+            var request = new PapiRestRequest(HttpMethod.Put, "/public/v1/1033/100/1/patron/ABC123", "1234", body);
+            request.Headers.Add("X-Custom", "keep");
+            request.QueryParameters.Add("ignoresa", false);
+
+            var first = (PapiRestRequest)client.PreformatRestRequest(request);
+            var firstHeaderCount = first.Headers.Count;
+            var second = (PapiRestRequest)client.PreformatRestRequest(first);
+
+            Assert.AreSame(first, second);
+            Assert.AreEqual(firstHeaderCount, second.Headers.Count);
+            Assert.AreEqual("keep", second.Headers["X-Custom"]);
+            Assert.AreSame(body, second.Body);
+            Assert.AreEqual(1, second.Headers.Keys.Count(key => key == "PolarisDate"));
+            Assert.AreEqual(1, second.Headers.Keys.Count(key => key == "Authorization"));
+            var date = second.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/patron/ABC123?ignoresa=False";
+            var expectedHash = ComputePapiHash("PUT", expectedUri, date, "1234", "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", second.Headers["Authorization"]);
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_AuthorizationChanges_WhenQueryParameterValueChanges()
+        {
+            var client = CreateClient();
+            var first = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            first.QueryParameters.Add("q", "harry potter");
+            var second = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            second.QueryParameters.Add("q", "lord of the rings");
+
+            var firstFormatted = (PapiRestRequest)client.PreformatRestRequest(first);
+            var secondFormatted = (PapiRestRequest)client.PreformatRestRequest(second);
+
+            var firstDate = firstFormatted.Headers["PolarisDate"];
+            var secondDate = secondFormatted.Headers["PolarisDate"];
+            var firstExpectedHash = ComputePapiHash("GET", "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter", firstDate, string.Empty, "access-key");
+            var secondExpectedHash = ComputePapiHash("GET", "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=lord%20of%20the%20rings", secondDate, string.Empty, "access-key");
+            Assert.AreEqual($"PWS access-id:{firstExpectedHash}", firstFormatted.Headers["Authorization"]);
+            Assert.AreEqual($"PWS access-id:{secondExpectedHash}", secondFormatted.Headers["Authorization"]);
+            Assert.AreNotEqual(firstFormatted.Headers["Authorization"], secondFormatted.Headers["Authorization"]);
         }
 
         [TestMethod]
@@ -173,6 +334,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
             StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15&limit=3", handler.LastRequest.RequestUri.AbsoluteUri);
             var query = ParseQuery(handler.LastRequest.RequestUri.Query);
             Assert.AreEqual("harry potter & stone", query["q"]);
             Assert.AreEqual("MP", query["sort"]);

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -250,6 +250,33 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public void PreformatRestRequest_RemovesStaleStaffOverrideToken_WhenOverrideBecomesBlocked()
+        {
+            var client = CreateClient();
+            client.AllowStaffOverrideRequests = true;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "staff-token",
+                AccessSecret = "staff-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(1)
+            };
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/apikeyvalidate");
+
+            var first = (PapiRestRequest)client.PreformatRestRequest(request);
+            Assert.AreEqual("staff-token", first.Headers["X-PAPI-AccessToken"]);
+
+            request.BlockStaffOverride = true;
+            var second = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            Assert.AreSame(first, second);
+            Assert.IsFalse(second.Headers.ContainsKey("X-PAPI-AccessToken"));
+            var date = second.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate";
+            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", second.Headers["Authorization"]);
+        }
+
+        [TestMethod]
         public void PreformatRestRequest_WhenCalledTwice_ReplacesPapiHeadersWithoutDuplicatingOrChangingBody()
         {
             var client = CreateClient();


### PR DESCRIPTION
### Motivation
- Ensure PAPI authorization hashes continue to match the effective URIs produced by rest-client v3 after the `QueryParameters` migration. 
- Prevent duplicate or conflicting PAPI headers when `PreformatRestRequest` is called multiple times. 
- Preserve existing public/protected/staff-override semantics, header names, and the `PWS {AccessID}:{hash}` format while adding characterization coverage for high-risk auth paths.

### Description
- Make `PreformatRestRequest` idempotent and safer by assigning headers via the header indexer (e.g. `papiRequest.Headers["PolarisDate"] = ...`) instead of `Add`, and avoid emitting duplicate keys. 
- Avoid repeated token lookups by caching `Token` into a local variable before using it for the public-method staff override and only add `X-PAPI-AccessToken` when a valid token exists and the override is allowed/unblocked. 
- Keep the existing PAPI hash inputs and ordering (HTTP method + URI + date + password/secret) and keep `BuildUrlForPapiHash` behavior to escape query components consistent with outgoing rest-client v3 URIs. 
- Add comprehensive RestClientMigration characterization tests covering: public authenticated GET (with/without `QueryParameters`), authenticated PUT/POST with body+query parameters, protected-token behavior, staff override allowed/blocked/disabled, calling `PreformatRestRequest` twice (idempotency), and that changes to query parameter values alter the Authorization hash; also assert the effective outgoing URI for migrated `QueryParameters` requests.

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` which completed successfully. 
- Ran `dotnet build src/polaris-api-csharp.sln --no-restore` which completed successfully. 
- Ran targeted characterization tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter RestClientMigration` and they passed (21 tests passed). 
- Ran non-integration unit tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter TestCategory!=Integration` and they passed (52 tests passed). 
- A full test run `dotnet test src/polaris-api-csharp.sln --no-build` exercised integration tests and failed because `appsettings.Test.json` is not present in the test output directory, which is an environment-specific issue unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1a43a202048323b0cec79050bac3f5)