### PR TITLE
Harden async migration cancellation coverage

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,25 @@
+# 4.0.0-alpha.1 async migration
+
+Polaris API 4.0.0-alpha.1 is an async-first breaking release. It keeps the existing request semantics, authentication behavior, and response models, but changes the public client surface so downstream callers can consistently await I/O and pass cancellation through every request path.
+
+## Client method changes
+
+All public `PapiClient`/`IPapiClient` methods are now `*Async` methods and return `Task<IRestResponse<T>>`.
+
+```csharp
+// 3.x
+var response = client.BibSearch(options);
+
+// 4.0
+var response = await client.BibSearchAsync(options, cancellationToken);
+```
+
+Every public client method accepts `CancellationToken cancellationToken = default`, and the token is propagated through public, protected, and staff-authentication requests.
+
+## Removed synchronous compatibility wrappers
+
+The previous synchronous compatibility wrappers, including sync `Execute<T>`/`Post<T>` paths, were intentionally removed rather than retained as blocking shims. Consumers should migrate call sites to `await` the new async methods.
+
+## Reading history overloads
+
+`PatronReadingHistoryClear` overloads that previously accepted `params int[]` now accept `IEnumerable<int>`. This allows `CancellationToken` to remain the final optional parameter across the public API.

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -353,6 +353,34 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsTrue(handler.LastCancellationToken.CanBeCanceled);
         }
 
+
+        [TestMethod]
+        public async Task ProtectedRequestTokenAcquisitionAsync_PassesCancellationTokenToStaffAuthentication()
+        {
+            var handler = new CapturingHttpMessageHandler(
+                "{\"PAPIErrorCode\":0,\"AccessToken\":\"protected-token\",\"AccessSecret\":\"protected-secret\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}",
+                "{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            client.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = "staff",
+                Password = "secret"
+            };
+            using var cts = new CancellationTokenSource();
+
+            var response = await client.PatronSearchAsync("smith", cancellationToken: cts.Token);
+
+            Assert.IsNotNull(response);
+            Assert.IsTrue(handler.Requests.Count >= 2);
+            Assert.AreEqual(HttpMethod.Post, handler.Requests[0].Method);
+            StringAssert.Contains(handler.Requests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
+            Assert.IsTrue(handler.CancellationTokens[0].CanBeCanceled);
+            Assert.AreEqual(HttpMethod.Get, handler.Requests[1].Method);
+            StringAssert.Contains(handler.Requests[1].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
+            Assert.IsTrue(handler.CancellationTokens[1].CanBeCanceled);
+        }
+
         [TestMethod]
         public async Task BibSearch_RequestShape_IsStable()
         {
@@ -529,28 +557,36 @@ namespace Clc.Polaris.Api.Tests
 
         private sealed class CapturingHttpMessageHandler : HttpMessageHandler
         {
-            private readonly string _responseJson;
+            private readonly Queue<string> _responseJson;
 
             public HttpRequestMessage? LastRequest { get; private set; }
             public string? LastRequestContent { get; private set; }
             public CancellationToken LastCancellationToken { get; private set; }
+            public List<HttpRequestMessage> Requests { get; } = new List<HttpRequestMessage>();
+            public List<CancellationToken> CancellationTokens { get; } = new List<CancellationToken>();
 
-            public CapturingHttpMessageHandler(string responseJson)
+            public CapturingHttpMessageHandler(params string[] responseJson)
             {
-                _responseJson = responseJson;
+                _responseJson = new Queue<string>(responseJson);
             }
 
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 LastRequest = request;
                 LastCancellationToken = cancellationToken;
+                Requests.Add(request);
+                CancellationTokens.Add(cancellationToken);
                 LastRequestContent = request.Content == null
                     ? null
                     : await request.Content.ReadAsStringAsync(cancellationToken);
 
+                var responseJson = _responseJson.Count > 1
+                    ? _responseJson.Dequeue()
+                    : _responseJson.Peek();
+
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                    Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
                 };
             }
         }


### PR DESCRIPTION
### Motivation

- Provide focused coverage that proves a supplied `CancellationToken` is propagated into the staff-authentication (protected-token acquisition) request path as well as the final protected PAPI request. 
- Ship a concise migration note documenting the 4.0 async-first breaking changes so downstream consumers can migrate call sites.

### Description

- Added a new unit test `ProtectedRequestTokenAcquisitionAsync_PassesCancellationTokenToStaffAuthentication` in `src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs` that invokes `PatronSearchAsync` with no cached token and asserts the handler captured cancellable tokens for the staff-authentication request and the final protected request. 
- Extended the test `CapturingHttpMessageHandler` to accept sequenced mock responses and capture ordered `Requests` and per-request `CancellationTokens` by changing the response storage to a `Queue<string>` and adding `Requests`/`CancellationTokens` lists. 
- Added `MIGRATION.md` with a short 4.0.0-alpha.1 migration note documenting that public methods are `*Async`, return `Task<IRestResponse<T>>`, accept `CancellationToken`, that sync wrappers were removed, and that `PatronReadingHistoryClear` overloads now use `IEnumerable<int>`.
- No public API signatures were altered beyond the async migration already present, and no sync wrappers were reintroduced.

### Testing

- Restored and built the solution with `dotnet restore src/polaris-api-csharp.sln` and `dotnet build src/polaris-api-csharp.sln --no-restore`, and the build succeeded. 
- Ran targeted tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"` and `--filter "TestCategory!=Integration"`, and both runs passed. 
- Ran the full test assembly and observed all tests in the suite passed (55 tests) using the same `dotnet test` invocation; the added cancellation coverage test passed as part of these runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1a4fd0e18083239503b86215a37303)