### PR TITLE
Harden async migration cancellation coverage

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,29 @@
+# 4.0 async migration
+
+`Clc.Polaris.Api` 4.0.0-alpha.1 is an async-first breaking API update. This note is intentionally limited to the public client API changes consumers need when moving from 3.x.
+
+## Public client methods are async-only
+
+All public `PapiClient`/`IPapiClient` operations now use `*Async` method names and return `Task<IRestResponse<T>>`.
+
+```csharp
+// 3.x
+var response = client.BibSearch(options);
+
+// 4.0.0-alpha.1
+var response = await client.BibSearchAsync(options, cancellationToken);
+```
+
+A `CancellationToken` is accepted across the public API and is the final optional parameter where applicable. Synchronous compatibility wrappers such as `Execute<T>`/`Post<T>` and the old non-async public client methods were intentionally removed rather than retained as blocking shims.
+
+## Reading history clear overloads
+
+`PatronReadingHistoryClear` overloads that previously accepted `params int[]` now accept `IEnumerable<int>` so `CancellationToken` can remain the final optional parameter.
+
+```csharp
+// 3.x
+client.PatronReadingHistoryClear(barcode, 101, 102, 103);
+
+// 4.0.0-alpha.1
+await client.PatronReadingHistoryClearAsync(barcode, new[] { 101, 102, 103 }, cancellationToken);
+```

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -353,6 +353,49 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsTrue(handler.LastCancellationToken.CanBeCanceled);
         }
 
+
+        [TestMethod]
+        public async Task ProtectedRequestWithoutCachedToken_PassesCancellationTokenToProtectedTokenAcquisition()
+        {
+            var handler = new CapturingHttpMessageHandler(
+                "{\"PAPIErrorCode\":0,\"AccessToken\":\"staff-token\",\"AccessSecret\":\"staff-secret\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}",
+                "{\"PAPIErrorCode\":0}")
+            {
+                HoldAuthenticatorRequests = true
+            };
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = "staff",
+                Password = "secret"
+            };
+            using var cts = new CancellationTokenSource();
+
+            var requestTask = client.PatronMessagesGetAsync("ABC123", cancellationToken: cts.Token);
+            await handler.AuthenticatorRequestStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+            cts.Cancel();
+            await handler.AuthenticatorRequestCancellationObserved.WaitAsync(TimeSpan.FromSeconds(5));
+            handler.ReleaseAuthenticatorResponse();
+
+            try
+            {
+                await requestTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+
+            Assert.IsTrue(handler.Requests.Count >= 1);
+            Assert.IsTrue(handler.CancellationTokens.Count >= 1);
+            Assert.IsTrue(handler.CancellationTokens[0].CanBeCanceled);
+            Assert.IsTrue(handler.CancellationTokens[0].IsCancellationRequested);
+            Assert.AreEqual(HttpMethod.Post, handler.Requests[0].Method);
+            StringAssert.Contains(handler.Requests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
+        }
+
         [TestMethod]
         public async Task BibSearch_RequestShape_IsStable()
         {
@@ -529,28 +572,51 @@ namespace Clc.Polaris.Api.Tests
 
         private sealed class CapturingHttpMessageHandler : HttpMessageHandler
         {
-            private readonly string _responseJson;
+            private readonly Queue<string> _responseJsons;
+            private readonly TaskCompletionSource<bool> _authenticatorRequestStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource<bool> _authenticatorRequestCancellationObserved = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource<bool> _releaseAuthenticatorResponse = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             public HttpRequestMessage? LastRequest { get; private set; }
             public string? LastRequestContent { get; private set; }
             public CancellationToken LastCancellationToken { get; private set; }
+            public List<HttpRequestMessage> Requests { get; } = new List<HttpRequestMessage>();
+            public List<CancellationToken> CancellationTokens { get; } = new List<CancellationToken>();
+            public bool HoldAuthenticatorRequests { get; set; }
+            public Task AuthenticatorRequestStarted => _authenticatorRequestStarted.Task;
+            public Task AuthenticatorRequestCancellationObserved => _authenticatorRequestCancellationObserved.Task;
 
-            public CapturingHttpMessageHandler(string responseJson)
+            public CapturingHttpMessageHandler(params string[] responseJsons)
             {
-                _responseJson = responseJson;
+                _responseJsons = new Queue<string>(responseJsons);
+            }
+
+            public void ReleaseAuthenticatorResponse()
+            {
+                _releaseAuthenticatorResponse.TrySetResult(true);
             }
 
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 LastRequest = request;
                 LastCancellationToken = cancellationToken;
+                Requests.Add(request);
+                CancellationTokens.Add(cancellationToken);
                 LastRequestContent = request.Content == null
                     ? null
                     : await request.Content.ReadAsStringAsync(cancellationToken);
 
+                if (HoldAuthenticatorRequests && request.RequestUri!.AbsolutePath.Contains("/authenticator/staff"))
+                {
+                    using var registration = cancellationToken.Register(() => _authenticatorRequestCancellationObserved.TrySetResult(true));
+                    _authenticatorRequestStarted.TrySetResult(true);
+                    await _releaseAuthenticatorResponse.Task.ConfigureAwait(false);
+                }
+
+                var responseJson = _responseJsons.Count > 1 ? _responseJsons.Dequeue() : _responseJsons.Peek();
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                    Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
                 };
             }
         }


### PR DESCRIPTION
### Motivation

- Ensure caller `CancellationToken` is propagated into the protected-token (staff-authentication) acquisition path for staff-override/protected requests so cancellation is observed deterministically during the 4.0 async migration.
- Provide a short consumer-facing migration note describing the 4.0 async-first breaking API changes.

### Description

- Add a focused unit test `ProtectedRequestWithoutCachedToken_PassesCancellationTokenToProtectedTokenAcquisition` in `RestClientMigrationCharacterizationTests.cs` that drives a staff-override request with no cached token, holds the authenticator request, cancels the caller token, and asserts cancellation is observed by the authenticator call.
- Extend the test `CapturingHttpMessageHandler` to queue responses, record `Requests` and `CancellationTokens`, and expose deterministic hold/release hooks (`HoldAuthenticatorRequests`, `AuthenticatorRequestStarted`, `AuthenticatorRequestCancellationObserved`, `ReleaseAuthenticatorResponse`) to make the test deterministic.
- Add `MIGRATION.md` with a concise 4.0.0-alpha.1 migration note showing `*Async` usage, `Task<IRestResponse<T>>` return types, `CancellationToken` usage across the public API, the removal of sync wrappers, and the `PatronReadingHistoryClear` `IEnumerable<int>` change with short examples.

### Testing

- Ran `dotnet restore src/polaris-api-csharp.sln` and `dotnet build src/polaris-api-csharp.sln --no-restore`, and the solution built successfully.
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"`, which passed.
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory!=Integration"`, and the non-integration suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1a4fd0e18083239503b86215a37303)