### PR TITLE
Harden async migration cancellation coverage

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,21 @@
+# 4.0 async migration notes
+
+Version `4.0.0-alpha.1` is an async-first, async-only API release. This note covers the breaking client API changes consumers need when moving from 3.x.
+
+## Public client methods are async-only
+
+All public `PapiClient` methods now use the `*Async` suffix and return `Task<IRestResponse<T>>`. Pass a `CancellationToken` when the caller should be able to cancel in-flight PAPI requests.
+
+```csharp
+// 3.x
+var response = client.BibSearch(options);
+
+// 4.0.0-alpha.1
+var response = await client.BibSearchAsync(options, cancellationToken);
+```
+
+Synchronous compatibility wrappers such as `Execute<T>` and `Post<T>` were intentionally removed rather than retained as sync-over-async shims.
+
+## CancellationToken placement
+
+`CancellationToken cancellationToken = default` is accepted across the public API and remains the final optional parameter. To preserve that convention, `PatronReadingHistoryClear` overloads that previously accepted `params int[]` now accept `IEnumerable<int>` instead.

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -354,6 +354,32 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public async Task ProtectedMethodWithoutCachedToken_PassesCancellationTokenToProtectedTokenAcquisition()
+        {
+            var handler = new CapturingHttpMessageHandler(
+                "{\"PAPIErrorCode\":0,\"AccessToken\":\"staff-token\",\"AccessSecret\":\"staff-secret\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}",
+                "{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            client.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = "staff",
+                Password = "secret"
+            };
+            using var cts = new CancellationTokenSource();
+
+            var response = await client.PatronSearchAsync("name = Smith", cancellationToken: cts.Token);
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(2, handler.Requests.Count);
+            StringAssert.Contains(handler.Requests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
+            Assert.AreEqual(HttpMethod.Post, handler.Requests[0].Method);
+            Assert.IsTrue(handler.CancellationTokens[0].CanBeCanceled);
+            StringAssert.Contains(handler.Requests[1].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/staff-token/search/patrons/Boolean");
+            Assert.IsTrue(handler.CancellationTokens[1].CanBeCanceled);
+        }
+
+        [TestMethod]
         public async Task BibSearch_RequestShape_IsStable()
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
@@ -529,13 +555,16 @@ namespace Clc.Polaris.Api.Tests
 
         private sealed class CapturingHttpMessageHandler : HttpMessageHandler
         {
-            private readonly string _responseJson;
+            private readonly IReadOnlyList<string> _responseJson;
 
             public HttpRequestMessage? LastRequest { get; private set; }
             public string? LastRequestContent { get; private set; }
             public CancellationToken LastCancellationToken { get; private set; }
+            public List<HttpRequestMessage> Requests { get; } = new List<HttpRequestMessage>();
+            public List<string?> RequestContents { get; } = new List<string?>();
+            public List<CancellationToken> CancellationTokens { get; } = new List<CancellationToken>();
 
-            public CapturingHttpMessageHandler(string responseJson)
+            public CapturingHttpMessageHandler(params string[] responseJson)
             {
                 _responseJson = responseJson;
             }
@@ -547,10 +576,14 @@ namespace Clc.Polaris.Api.Tests
                 LastRequestContent = request.Content == null
                     ? null
                     : await request.Content.ReadAsStringAsync(cancellationToken);
+                Requests.Add(request);
+                RequestContents.Add(LastRequestContent);
+                CancellationTokens.Add(cancellationToken);
 
+                var responseJson = _responseJson[Math.Min(Requests.Count - 1, _responseJson.Count - 1)];
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                    Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
                 };
             }
         }


### PR DESCRIPTION
### Motivation

- Ensure `CancellationToken` passed to public protected-methods flows into the protected-token acquisition request and not only the final PAPI request. 
- Provide deterministic unit coverage for the protected-token acquisition path that naturally triggers `EnsureProtectedTokenAsync` with no cached token. 
- Add a short consumer-facing note documenting the 4.0 async-first API changes introduced by the migration.

### Description

- Added a focused test `ProtectedMethodWithoutCachedToken_PassesCancellationTokenToProtectedTokenAcquisition` in `src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs` that exercises a protected `PatronSearchAsync` path which forces protected-token acquisition and asserts cancellation token propagation. 
- Extended the test HTTP handler to record multiple requests, request contents, and `CancellationToken`s (`CapturingHttpMessageHandler` was updated) so tests can assert both the staff-authentication request and the final PAPI request were invoked with cancellable tokens. 
- Added a concise `MIGRATION.md` describing the `4.0.0-alpha.1` breaking changes including that public methods are `*Async`, return `Task<IRestResponse<T>>`, accept `CancellationToken`, synchronous wrappers were removed, and `PatronReadingHistoryClear` uses `IEnumerable<int>` to preserve token-last-parameter convention.

### Testing

- Ran `dotnet restore src/polaris-api-csharp.sln` which completed successfully. 
- Built the solution with `dotnet build src/polaris-api-csharp.sln --no-restore` which succeeded. 
- Executed the targeted suites with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"` and `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory!=Integration"`, and the filtered test runs passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1a4fd0e18083239503b86215a37303)