### PR TITLE
Harden protected token handling

### DIFF
--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -1,4 +1,4 @@
-﻿using Clc.Rest;
+using Clc.Rest;
 using Clc.Polaris.Api.Models;
 
 using System;
@@ -17,8 +17,11 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<ProtectedToken>> AuthenticateStaffUserAsync(PolarisUser staffUser, CancellationToken cancellationToken = default)
         {
             var url = "/protected/v1/1033/100/1/authenticator/staff";
-            var response = await PostAsync<ProtectedToken>(url, body: staffUser, cancellationToken: cancellationToken).ConfigureAwait(false);
-            _token = response?.Data;
+            var response = await ExecuteStaffAuthenticationPostAsync<ProtectedToken>(url, body: staffUser, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (response?.Response?.IsSuccessStatusCode == true && IsTokenValid(response.Data))
+            {
+                _token = response.Data;
+            }
             return response;
         }
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -1,4 +1,4 @@
-﻿using Clc.Rest.Models;
+using Clc.Rest.Models;
 using Clc.Polaris.Api.Configuration;
 using Clc.Polaris.Api.Models;
 using Clc.Rest;
@@ -44,23 +44,16 @@ namespace Clc.Polaris.Api
 
         public bool UseProtectedTokenCache { get; set; } = true;
         private static ConcurrentDictionary<string, ProtectedToken> ProtectedTokenCache { get; set; } = new ConcurrentDictionary<string, ProtectedToken>();
+        private static ConcurrentDictionary<string, SemaphoreSlim> ProtectedTokenLocks { get; set; } = new ConcurrentDictionary<string, SemaphoreSlim>();
 
-        public ProtectedToken _token;
+        private ProtectedToken _token;
 
         /// <summary>
         /// Used for protected methods and public method overrides
         /// </summary>
         public ProtectedToken Token
         {
-            get
-            {
-                if (UseProtectedTokenCache && (_token == null || _token.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
-                {
-                    ProtectedTokenCache.TryGetValue($"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}", out _token);
-                }
-
-                return _token;
-            }
+            get { return _token; }
             set { _token = value; }
         }
 
@@ -109,7 +102,7 @@ namespace Clc.Polaris.Api
 
                 if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password) && _token != null)
                 {
-                    password = Token.AccessSecret;
+                    password = _token.AccessSecret;
                 }
 
                 var date = DateTime.Now.ToUniversalTime().ToString("R");
@@ -159,27 +152,94 @@ namespace Clc.Polaris.Api
 
         private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
         {
-            if (UseProtectedTokenCache && (_token == null || _token.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
+            if (StaffOverrideAccount == null || IsTokenValid(_token))
             {
-                ProtectedTokenCache.TryGetValue($"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}", out _token);
+                return _token;
             }
 
-            if ((_token == null || _token.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
+            var cacheKey = BuildProtectedTokenCacheKey();
+            if (TryLoadProtectedTokenFromCache(cacheKey))
             {
-                var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
-                _token = response?.Data;
+                return _token;
+            }
 
-                if (UseProtectedTokenCache && response.Response.IsSuccessStatusCode && _token != null)
+            if (string.IsNullOrEmpty(cacheKey))
+            {
+                return await LoadProtectedTokenAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+            }
+
+            var tokenLock = ProtectedTokenLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
+            await tokenLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (IsTokenValid(_token) || TryLoadProtectedTokenFromCache(cacheKey))
                 {
-                    ProtectedTokenCache[$"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}"] = new ProtectedToken(_token);
+                    return _token;
                 }
+
+                return await LoadProtectedTokenAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                tokenLock.Release();
+            }
+        }
+
+        private async Task<ProtectedToken> LoadProtectedTokenAsync(string cacheKey, CancellationToken cancellationToken)
+        {
+            var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
+            if (response?.Response?.IsSuccessStatusCode != true || !IsTokenValid(response.Data))
+            {
+                return _token;
+            }
+
+            _token = response.Data;
+
+            if (UseProtectedTokenCache && !string.IsNullOrEmpty(cacheKey))
+            {
+                ProtectedTokenCache[cacheKey] = new ProtectedToken(_token);
             }
 
             return _token;
         }
 
-        private async Task<IRestResponse<T>> PostAsync<T>(string url, object body = null, CancellationToken cancellationToken = default)
+        private bool TryLoadProtectedTokenFromCache(string cacheKey)
         {
+            if (!UseProtectedTokenCache || string.IsNullOrEmpty(cacheKey))
+            {
+                return false;
+            }
+
+            if (!ProtectedTokenCache.TryGetValue(cacheKey, out var cachedToken) || !IsTokenValid(cachedToken))
+            {
+                return false;
+            }
+
+            _token = cachedToken;
+            return true;
+        }
+
+        private string BuildProtectedTokenCacheKey()
+        {
+            if (StaffOverrideAccount == null ||
+                string.IsNullOrWhiteSpace(Hostname) ||
+                string.IsNullOrWhiteSpace(StaffOverrideAccount.Domain) ||
+                string.IsNullOrWhiteSpace(StaffOverrideAccount.Username))
+            {
+                return null;
+            }
+
+            return $"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}";
+        }
+
+        private static bool IsTokenValid(ProtectedToken token)
+        {
+            return token != null && token.ExpirationDate > DateTime.Now;
+        }
+
+        private async Task<IRestResponse<T>> ExecuteStaffAuthenticationPostAsync<T>(string url, object body = null, CancellationToken cancellationToken = default)
+        {
+            // Staff authentication obtains the protected token, so this intentionally bypasses ExecutePapiAsync<T>'s token preload.
             return await ExecuteAsync<T>(new PapiRestRequest(HttpMethod.Post, url) { Body = body }, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -1,219 +1,322 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Concurrent;
-using System.Reflection;
 using Clc.Polaris.Api;
 using Clc.Polaris.Api.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Clc.Polaris.Api.Tests
 {
-    [TestClass()]
+    [TestClass]
+    [TestCategory("Unit")]
+    [TestCategory("RestClientMigration")]
     [DoNotParallelize]
     public class PapiClientTokenTests
     {
-    [TestInitialize]
-    public void TestInitialize()
-    {
-        ClearProtectedTokenCache();
-    }
-
-    [TestMethod]
-    public void Token_WhenTokenIsNullAndNoStaffOverrideAccount_ReturnsNullWithoutAuthenticating()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-
-        var token = client.Token;
-
-        Assert.IsNull(token);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenTokenIsNullAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsCachedToken()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        var staff = CreateStaffUser();
-        client.StaffOverrideAccount = staff;
-        client.UseProtectedTokenCache = true;
-        SetCachedToken(client.Hostname, staff, new ProtectedToken
+        [TestInitialize]
+        public void TestInitialize()
         {
-            AccessToken = "cached-token",
-            AccessSecret = "cached-secret",
-            ExpirationDate = DateTime.Now.AddHours(1)
-        });
-
-        var token = client.Token;
-
-        Assert.IsNotNull(token);
-        Assert.AreEqual("cached-token", token.AccessToken);
-        Assert.AreEqual("cached-secret", token.AccessSecret);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenExistingTokenIsNotExpired_ReturnsExistingTokenWithoutAuthenticating()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        client.StaffOverrideAccount = CreateStaffUser();
-        client.Token = new ProtectedToken
-        {
-            AccessToken = "existing-token",
-            AccessSecret = "existing-secret",
-            ExpirationDate = DateTime.Now.AddHours(1)
-        };
-
-        var token = client.Token;
-
-        Assert.IsNotNull(token);
-        Assert.AreEqual("existing-token", token.AccessToken);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenExistingTokenIsExpiredAndStaffOverrideAccountExistsAndCacheHasValidToken_UsesCachedToken()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        var staff = CreateStaffUser();
-        client.StaffOverrideAccount = staff;
-        client.UseProtectedTokenCache = true;
-        client.Token = new ProtectedToken
-        {
-            AccessToken = "expired-token",
-            AccessSecret = "expired-secret",
-            ExpirationDate = DateTime.Now.AddHours(-1)
-        };
-        SetCachedToken(client.Hostname, staff, new ProtectedToken
-        {
-            AccessToken = "cached-token",
-            AccessSecret = "cached-secret",
-            ExpirationDate = DateTime.Now.AddHours(1)
-        });
-
-        var token = client.Token;
-
-        Assert.IsNotNull(token);
-        Assert.AreEqual("cached-token", token.AccessToken);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenExistingTokenIsExpiredAndNoStaffOverrideAccount_ReturnsExistingTokenWithoutAuthenticating()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        client.Token = new ProtectedToken
-        {
-            AccessToken = "expired-token",
-            AccessSecret = "expired-secret",
-            ExpirationDate = DateTime.Now.AddHours(-1)
-        };
-
-        var token = client.Token;
-
-        Assert.IsNotNull(token);
-        Assert.AreEqual("expired-token", token.AccessToken);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenCacheEnabledTokenNullAndNoStaffOverrideAccount_ReturnsNullWithoutThrowing()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        client.UseProtectedTokenCache = true;
-        client.StaffOverrideAccount = null;
-        client.Token = null;
-
-        var token = client.Token;
-
-        Assert.IsNull(token);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    private static PapiClient CreateClient(CapturingHttpMessageHandler handler)
-    {
-        var hostname = $"https://example-{Guid.NewGuid():N}.test";
-        var httpClient = new HttpClient(handler)
-        {
-            BaseAddress = new Uri($"{hostname}/")
-        };
-
-        return new PapiClient(httpClient, null)
-        {
-            Hostname = hostname,
-            AccessID = "access-id",
-            AccessKey = "access-key",
-            UseProtectedTokenCache = false,
-            AllowStaffOverrideRequests = false
-        };
-    }
-
-    private static PolarisUser CreateStaffUser()
-    {
-        return new PolarisUser
-        {
-            Domain = "domain",
-            Username = "user",
-            Password = "password"
-        };
-    }
-
-    private static string CreateProtectedTokenJson(string accessToken, string accessSecret, DateTime expirationDate)
-    {
-        return
-            "{" +
-            $"\"PAPIErrorCode\":0," +
-            $"\"AccessToken\":\"{accessToken}\"," +
-            $"\"AccessSecret\":\"{accessSecret}\"," +
-            $"\"AuthExpDate\":\"{expirationDate:O}\"" +
-            "}";
-    }
-
-    private sealed class CapturingHttpMessageHandler : HttpMessageHandler
-    {
-        private readonly string _responseJson;
-
-        public int RequestCount { get; private set; }
-        public HttpRequestMessage? LastRequest { get; private set; }
-
-        public CapturingHttpMessageHandler(string? responseJson = null)
-        {
-            _responseJson = responseJson ?? CreateProtectedTokenJson("new-token", "new-secret", DateTime.UtcNow.AddHours(1));
+            ClearProtectedTokenCache();
+            ClearProtectedTokenLocks();
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        [TestMethod]
+        public void Token_WhenTokenIsNullAndNoStaffOverrideAccount_ReturnsNullWithoutAuthenticating()
         {
-            RequestCount++;
-            LastRequest = request;
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateClient(handler);
 
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            var token = client.Token;
+
+            Assert.IsNull(token);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenCacheContainsToken_ReturnsCurrentInMemoryTokenWithoutReadingCache()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateClient(handler);
+            var staff = CreateStaffUser();
+            client.StaffOverrideAccount = staff;
+            client.UseProtectedTokenCache = true;
+            SetCachedToken(client.Hostname, staff, new ProtectedToken
             {
-                Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                AccessToken = "cached-token",
+                AccessSecret = "cached-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
             });
+
+            var token = client.Token;
+
+            Assert.IsNull(token);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenExistingTokenIsNotExpired_ReturnsExistingTokenWithoutAuthenticating()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.StaffOverrideAccount = CreateStaffUser();
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "existing-token",
+                AccessSecret = "existing-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            };
+
+            var token = client.Token;
+
+            Assert.IsNotNull(token);
+            Assert.AreEqual("existing-token", token.AccessToken);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenExistingTokenIsExpiredAndNoStaffOverrideAccount_ReturnsExistingTokenWithoutAuthenticating()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "expired-token",
+                AccessSecret = "expired-secret",
+                ExpirationDate = DateTime.Now.AddHours(-1)
+            };
+
+            var token = client.Token;
+
+            Assert.IsNotNull(token);
+            Assert.AreEqual("expired-token", token.AccessToken);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public async Task ProtectedRequest_WhenCacheHasValidToken_DoesNotAuthenticateStaffUser()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateClient(handler);
+            var staff = CreateStaffUser();
+            client.StaffOverrideAccount = staff;
+            client.UseProtectedTokenCache = true;
+            SetCachedToken(client.Hostname, staff, new ProtectedToken
+            {
+                AccessToken = "cached-token",
+                AccessSecret = "cached-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            });
+
+            await client.PatronSearchAsync("name=Smith").ConfigureAwait(false);
+
+            Assert.AreEqual("cached-token", client.Token.AccessToken);
+            Assert.AreEqual(0, handler.StaffAuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            StringAssert.Contains(handler.Requests.Single().RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/cached-token/search/patrons/Boolean");
+        }
+
+        [TestMethod]
+        public async Task ProtectedRequest_WhenStaffAuthenticationReturnsNullData_DoesNotCacheToken()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(authResponseJson: "{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            client.StaffOverrideAccount = CreateStaffUser();
+            client.AllowStaffOverrideRequests = true;
+            client.UseProtectedTokenCache = true;
+
+            await client.PatronBasicDataGetAsync("123").ConfigureAwait(false);
+
+            Assert.IsNull(client.Token);
+            Assert.AreEqual(1, handler.StaffAuthenticationRequestCount);
+            Assert.IsNull(GetCachedToken(client.Hostname, client.StaffOverrideAccount));
+        }
+
+        [TestMethod]
+        public async Task ProtectedRequest_WhenStaffAuthenticationFails_DoesNotCacheToken()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.Unauthorized);
+            var client = CreateClient(handler);
+            client.StaffOverrideAccount = CreateStaffUser();
+            client.AllowStaffOverrideRequests = true;
+            client.UseProtectedTokenCache = true;
+
+            await client.PatronBasicDataGetAsync("123").ConfigureAwait(false);
+
+            Assert.IsNull(client.Token);
+            Assert.AreEqual(1, handler.StaffAuthenticationRequestCount);
+            Assert.IsNull(GetCachedToken(client.Hostname, client.StaffOverrideAccount));
+        }
+
+        [TestMethod]
+        public async Task ProtectedRequests_WhenConcurrentForSameCacheKey_AuthenticateStaffUserOnce()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(authResponseDelay: TimeSpan.FromMilliseconds(100));
+            var client = CreateClient(handler);
+            client.StaffOverrideAccount = CreateStaffUser();
+            client.UseProtectedTokenCache = true;
+            var requests = Enumerable.Range(0, 8)
+                .Select(i => client.PatronSearchAsync($"name=Smith{i}"))
+                .ToArray();
+
+            await Task.WhenAll(requests).ConfigureAwait(false);
+
+            Assert.AreEqual(1, handler.StaffAuthenticationRequestCount);
+            Assert.AreEqual(8, handler.ProtectedRequestCount);
+            Assert.AreEqual("new-token", client.Token.AccessToken);
+            Assert.IsNotNull(GetCachedToken(client.Hostname, client.StaffOverrideAccount));
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_WhenTokenIsSetManually_UsesTokenForStaffOverrideFormatting()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "manual-token",
+                AccessSecret = "manual-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            };
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/patron/123/basicdata");
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            Assert.AreEqual("manual-token", formatted.Headers["X-PAPI-AccessToken"]);
+            Assert.IsTrue(formatted.Headers.ContainsKey("Authorization"));
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        private static PapiClient CreateClient(ProtectedTokenHttpMessageHandler handler)
+        {
+            var hostname = $"https://example-{Guid.NewGuid():N}.test";
+            var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri($"{hostname}/")
+            };
+
+            return new PapiClient(httpClient, null)
+            {
+                Hostname = hostname,
+                AccessID = "access-id",
+                AccessKey = "access-key",
+                UseProtectedTokenCache = false,
+                AllowStaffOverrideRequests = false
+            };
+        }
+
+        private static PolarisUser CreateStaffUser()
+        {
+            return new PolarisUser
+            {
+                Domain = "domain",
+                Username = "user",
+                Password = "password"
+            };
+        }
+
+        private static string CreateProtectedTokenJson(string accessToken, string accessSecret, DateTime expirationDate)
+        {
+            return
+                "{" +
+                $"\"PAPIErrorCode\":0," +
+                $"\"AccessToken\":\"{accessToken}\"," +
+                $"\"AccessSecret\":\"{accessSecret}\"," +
+                $"\"AuthExpDate\":\"{expirationDate:O}\"" +
+                "}";
+        }
+
+        private sealed class ProtectedTokenHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly string _authResponseJson;
+            private readonly HttpStatusCode _authStatusCode;
+            private readonly TimeSpan _authResponseDelay;
+            private int _requestCount;
+            private int _staffAuthenticationRequestCount;
+            private int _protectedRequestCount;
+
+            public int RequestCount => _requestCount;
+            public int StaffAuthenticationRequestCount => _staffAuthenticationRequestCount;
+            public int ProtectedRequestCount => _protectedRequestCount;
+            public ConcurrentBag<HttpRequestMessage> Requests { get; } = new ConcurrentBag<HttpRequestMessage>();
+
+            public ProtectedTokenHttpMessageHandler(
+                HttpStatusCode authStatusCode = HttpStatusCode.OK,
+                string? authResponseJson = null,
+                TimeSpan? authResponseDelay = null)
+            {
+                _authStatusCode = authStatusCode;
+                _authResponseJson = authResponseJson ?? CreateProtectedTokenJson("new-token", "new-secret", DateTime.Now.AddHours(1));
+                _authResponseDelay = authResponseDelay ?? TimeSpan.Zero;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref _requestCount);
+                Requests.Add(request);
+
+                if (request.RequestUri!.AbsolutePath.Contains("/authenticator/staff"))
+                {
+                    Interlocked.Increment(ref _staffAuthenticationRequestCount);
+                    if (_authResponseDelay > TimeSpan.Zero)
+                    {
+                        await Task.Delay(_authResponseDelay, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    return new HttpResponseMessage(_authStatusCode)
+                    {
+                        Content = new StringContent(_authResponseJson, Encoding.UTF8, "application/json")
+                    };
+                }
+
+                Interlocked.Increment(ref _protectedRequestCount);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                };
+            }
+        }
+
+        private static void ClearProtectedTokenCache()
+        {
+            var cache = GetProtectedTokenCache();
+            cache?.Clear();
+        }
+
+        private static void ClearProtectedTokenLocks()
+        {
+            var locksProperty = typeof(PapiClient).GetProperty("ProtectedTokenLocks", BindingFlags.NonPublic | BindingFlags.Static);
+            var locks = locksProperty?.GetValue(null) as ConcurrentDictionary<string, SemaphoreSlim>;
+            locks?.Clear();
+        }
+
+        private static void SetCachedToken(string hostname, PolarisUser staffUser, ProtectedToken token)
+        {
+            GetProtectedTokenCache()?.TryAdd(BuildCacheKey(hostname, staffUser), token);
+        }
+
+        private static ProtectedToken? GetCachedToken(string hostname, PolarisUser staffUser)
+        {
+            var cache = GetProtectedTokenCache();
+            return cache != null && cache.TryGetValue(BuildCacheKey(hostname, staffUser), out var token) ? token : null;
+        }
+
+        private static ConcurrentDictionary<string, ProtectedToken>? GetProtectedTokenCache()
+        {
+            var cacheProperty = typeof(PapiClient).GetProperty("ProtectedTokenCache", BindingFlags.NonPublic | BindingFlags.Static);
+            return cacheProperty?.GetValue(null) as ConcurrentDictionary<string, ProtectedToken>;
+        }
+
+        private static string BuildCacheKey(string hostname, PolarisUser staffUser)
+        {
+            return $"{hostname}{staffUser.Domain}{staffUser.Username}";
         }
     }
-
-    private static void ClearProtectedTokenCache()
-    {
-        var cacheProperty = typeof(PapiClient).GetProperty("ProtectedTokenCache", BindingFlags.NonPublic | BindingFlags.Static);
-        var cache = cacheProperty?.GetValue(null) as ConcurrentDictionary<string, ProtectedToken>;
-        cache?.Clear();
-    }
-
-    private static void SetCachedToken(string hostname, PolarisUser staffUser, ProtectedToken token)
-    {
-        var cacheProperty = typeof(PapiClient).GetProperty("ProtectedTokenCache", BindingFlags.NonPublic | BindingFlags.Static);
-        var cache = cacheProperty?.GetValue(null) as ConcurrentDictionary<string, ProtectedToken>;
-        cache?.TryAdd($"{hostname}{staffUser.Domain}{staffUser.Username}", token);
-    }
-}
 }


### PR DESCRIPTION
### Motivation

- Prevent races, null-reference risks, and unintended network work from the previous protected-token handling by encapsulating token state and making cache/locking behavior explicit.  
- Ensure concurrent callers for the same staff account do not trigger duplicate staff-authentication requests.  
- Make staff-authentication result handling defensive so failed or malformed responses are not persisted into the cache.  

### Description

- Encapsulated protected-token state by making `_token` private and keeping the public `Token` property as a simple read/write accessor (no network side-effects).  
- Centralized cache-key logic and cache access via `BuildProtectedTokenCacheKey`, `TryLoadProtectedTokenFromCache`, and consistent cache reads/writes keyed by `Hostname + StaffOverrideAccount.Domain + StaffOverrideAccount.Username`.  
- Added per-cache-key async synchronization using a static `ProtectedTokenLocks : ConcurrentDictionary<string, SemaphoreSlim>` and re-checked in-memory/cache token after obtaining the per-key lock; lock is released in a `finally` block.  
- Reworked `EnsureProtectedTokenAsync` to be defensive (early-return when `StaffOverrideAccount` is null or token is valid; avoid caching on null/failed auth), moved authentication work into `LoadProtectedTokenAsync`, and added `IsTokenValid` helper for consistent expiration checks.  
- Clarified intent of the staff-auth POST helper by renaming it to `ExecuteStaffAuthenticationPostAsync<T>` with a comment that it intentionally bypasses `ExecutePapiAsync<T>` token preloading, and updated `AuthenticateStaffUserAsync` to only assign `_token` when auth succeeds and the returned token is valid.  
- Updated `PreformatRestRequest` to read secrets from the in-memory `_token` where appropriate to remove hidden cache/network work in the `Token` getter.  
- Added focused, in-memory unit tests under `PapiClientTokenTests` that cover: cached-token reuse, concurrency de-duplication (single staff-auth for concurrent same-key requests), failed/null staff-auth responses not populating cache, and manual `Token` formatting behavior; tests use deterministic fake `HttpMessageHandler` implementations.

### Testing

- Ran the recommended validation commands: `dotnet restore src/polaris-api-csharp.sln`, `dotnet build src/polaris-api-csharp.sln --no-restore`, `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"`, and `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory!=Integration"`.  
- All tests exercised (RestClientMigration and non-integration unit tests) passed locally after the changes.  
- New tests added in `src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs` pass and verify cache behavior, concurrency deduplication, defensive handling of failed/empty auth responses, and that manually-set `Token` still drives staff-override formatting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1ac8d1c1f483239fefc92d47383bb6)