### PR TITLE
Harden protected token acquisition

### DIFF
--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<ProtectedToken>> AuthenticateStaffUserAsync(PolarisUser staffUser, CancellationToken cancellationToken = default)
         {
             var url = "/protected/v1/1033/100/1/authenticator/staff";
-            var response = await PostAsync<ProtectedToken>(url, body: staffUser, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var response = await ExecuteStaffAuthenticationPostAsync<ProtectedToken>(url, body: staffUser, cancellationToken: cancellationToken).ConfigureAwait(false);
             _token = response?.Data;
             return response;
         }

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -44,23 +44,16 @@ namespace Clc.Polaris.Api
 
         public bool UseProtectedTokenCache { get; set; } = true;
         private static ConcurrentDictionary<string, ProtectedToken> ProtectedTokenCache { get; set; } = new ConcurrentDictionary<string, ProtectedToken>();
+        private static ConcurrentDictionary<string, SemaphoreSlim> ProtectedTokenLocks { get; set; } = new ConcurrentDictionary<string, SemaphoreSlim>();
 
-        public ProtectedToken _token;
+        private ProtectedToken _token;
 
         /// <summary>
         /// Used for protected methods and public method overrides
         /// </summary>
         public ProtectedToken Token
         {
-            get
-            {
-                if (UseProtectedTokenCache && (_token == null || _token.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
-                {
-                    ProtectedTokenCache.TryGetValue($"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}", out _token);
-                }
-
-                return _token;
-            }
+            get { return _token; }
             set { _token = value; }
         }
 
@@ -107,7 +100,7 @@ namespace Clc.Polaris.Api
                     }
                 }
 
-                if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password) && _token != null)
+                if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password) && Token != null)
                 {
                     password = Token.AccessSecret;
                 }
@@ -159,26 +152,99 @@ namespace Clc.Polaris.Api
 
         private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
         {
-            if (UseProtectedTokenCache && (_token == null || _token.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
+            if (StaffOverrideAccount == null)
             {
-                ProtectedTokenCache.TryGetValue($"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}", out _token);
+                return _token;
             }
 
-            if ((_token == null || _token.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
+            var cacheKey = BuildProtectedTokenCacheKey();
+            if (!IsTokenMissingOrExpired(_token))
             {
-                var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
-                _token = response?.Data;
+                return _token;
+            }
 
-                if (UseProtectedTokenCache && response.Response.IsSuccessStatusCode && _token != null)
+            if (TryLoadProtectedTokenFromCache(cacheKey))
+            {
+                return _token;
+            }
+
+            if (string.IsNullOrEmpty(cacheKey))
+            {
+                return await AuthenticateAndCacheProtectedTokenAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+            }
+
+            var protectedTokenLock = ProtectedTokenLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
+            await protectedTokenLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (!IsTokenMissingOrExpired(_token))
                 {
-                    ProtectedTokenCache[$"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}"] = new ProtectedToken(_token);
+                    return _token;
                 }
+
+                if (TryLoadProtectedTokenFromCache(cacheKey))
+                {
+                    return _token;
+                }
+
+                return await AuthenticateAndCacheProtectedTokenAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                protectedTokenLock.Release();
+            }
+        }
+
+        private string BuildProtectedTokenCacheKey()
+        {
+            if (StaffOverrideAccount == null ||
+                string.IsNullOrWhiteSpace(Hostname) ||
+                string.IsNullOrWhiteSpace(StaffOverrideAccount.Domain) ||
+                string.IsNullOrWhiteSpace(StaffOverrideAccount.Username))
+            {
+                return null;
+            }
+
+            return $"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}";
+        }
+
+        private bool TryLoadProtectedTokenFromCache(string cacheKey)
+        {
+            if (!UseProtectedTokenCache || string.IsNullOrEmpty(cacheKey) || !IsTokenMissingOrExpired(_token))
+            {
+                return false;
+            }
+
+            return ProtectedTokenCache.TryGetValue(cacheKey, out _token) && !IsTokenMissingOrExpired(_token);
+        }
+
+        private async Task<ProtectedToken> AuthenticateAndCacheProtectedTokenAsync(string cacheKey, CancellationToken cancellationToken)
+        {
+            var previousToken = _token;
+            var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
+            if (response?.Response?.IsSuccessStatusCode != true || response.Data == null)
+            {
+                _token = previousToken;
+                return _token;
+            }
+
+            _token = response.Data;
+            if (UseProtectedTokenCache && !string.IsNullOrEmpty(cacheKey))
+            {
+                ProtectedTokenCache[cacheKey] = new ProtectedToken(_token);
             }
 
             return _token;
         }
 
-        private async Task<IRestResponse<T>> PostAsync<T>(string url, object body = null, CancellationToken cancellationToken = default)
+        private static bool IsTokenMissingOrExpired(ProtectedToken token)
+        {
+            return token == null || token.ExpirationDate <= DateTime.Now;
+        }
+
+        // Staff authentication intentionally bypasses ExecutePapiAsync<T> because it is
+        // the request that obtains the protected token ExecutePapiAsync<T> preloads.
+        private async Task<IRestResponse<T>> ExecuteStaffAuthenticationPostAsync<T>(string url, object body = null, CancellationToken cancellationToken = default)
         {
             return await ExecuteAsync<T>(new PapiRestRequest(HttpMethod.Post, url) { Body = body }, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -35,7 +35,7 @@ namespace Clc.Polaris.Api.Tests
     }
 
     [TestMethod]
-    public void Token_WhenTokenIsNullAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsCachedToken()
+    public void Token_WhenTokenIsNullAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsNullWithoutCacheLookup()
     {
         var handler = new CapturingHttpMessageHandler();
         var client = CreateClient(handler);
@@ -51,9 +51,7 @@ namespace Clc.Polaris.Api.Tests
 
         var token = client.Token;
 
-        Assert.IsNotNull(token);
-        Assert.AreEqual("cached-token", token.AccessToken);
-        Assert.AreEqual("cached-secret", token.AccessSecret);
+        Assert.IsNull(token);
         Assert.AreEqual(0, handler.RequestCount);
     }
 
@@ -78,7 +76,7 @@ namespace Clc.Polaris.Api.Tests
     }
 
     [TestMethod]
-    public void Token_WhenExistingTokenIsExpiredAndStaffOverrideAccountExistsAndCacheHasValidToken_UsesCachedToken()
+    public void Token_WhenExistingTokenIsExpiredAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsExistingTokenWithoutCacheLookup()
     {
         var handler = new CapturingHttpMessageHandler();
         var client = CreateClient(handler);
@@ -101,7 +99,7 @@ namespace Clc.Polaris.Api.Tests
         var token = client.Token;
 
         Assert.IsNotNull(token);
-        Assert.AreEqual("cached-token", token.AccessToken);
+        Assert.AreEqual("expired-token", token.AccessToken);
         Assert.AreEqual(0, handler.RequestCount);
     }
 

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -379,6 +379,92 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsTrue(handler.CancellationTokens[1].CanBeCanceled);
         }
 
+
+        [TestMethod]
+        public async Task ConcurrentProtectedRequests_WithSameCacheKey_AuthenticateStaffOnlyOnce()
+        {
+            var handler = new ProtectedTokenCacheHttpMessageHandler(authDelay: TimeSpan.FromMilliseconds(100));
+            var client = CreateClient(handler);
+            ConfigureStaffTokenCache(client, $"https://concurrent-{Guid.NewGuid():N}.example.test");
+
+            var tasks = Enumerable.Range(0, 8)
+                .Select(index => client.PatronSearchAsync($"name=Smith{index}"))
+                .ToArray();
+
+            await Task.WhenAll(tasks);
+
+            Assert.AreEqual(1, handler.AuthenticateStaffRequestCount);
+            Assert.AreEqual(8, handler.ProtectedSearchRequestCount);
+        }
+
+        [TestMethod]
+        public async Task ProtectedTokenCache_WithValidCachedToken_AvoidsStaffAuthentication()
+        {
+            var hostname = $"https://cached-{Guid.NewGuid():N}.example.test";
+            var primingHandler = new ProtectedTokenCacheHttpMessageHandler();
+            var primingClient = CreateClient(primingHandler);
+            ConfigureStaffTokenCache(primingClient, hostname);
+            await primingClient.PatronSavedSearchesGetAsync("ABC123");
+            Assert.AreEqual(1, primingHandler.AuthenticateStaffRequestCount);
+
+            var cachedHandler = new ProtectedTokenCacheHttpMessageHandler();
+            var cachedClient = CreateClient(cachedHandler);
+            ConfigureStaffTokenCache(cachedClient, hostname);
+
+            await cachedClient.PatronSavedSearchesGetAsync("ABC123");
+
+            Assert.AreEqual(0, cachedHandler.AuthenticateStaffRequestCount);
+            Assert.AreEqual(1, cachedHandler.PublicSavedSearchesRequestCount);
+            Assert.AreEqual("cache-token", cachedHandler.LastRequest?.Headers.GetValues("X-PAPI-AccessToken").Single());
+        }
+
+        [TestMethod]
+        public async Task FailedStaffAuthentication_DoesNotPopulateProtectedTokenCache()
+        {
+            var hostname = $"https://failed-auth-{Guid.NewGuid():N}.example.test";
+            var failedHandler = new ProtectedTokenCacheHttpMessageHandler(authStatusCode: HttpStatusCode.InternalServerError, authResponseJson: "{\"PAPIErrorCode\":1}");
+            var failedClient = CreateClient(failedHandler);
+            ConfigureStaffTokenCache(failedClient, hostname);
+
+            await failedClient.PatronSavedSearchesGetAsync("ABC123");
+
+            Assert.AreEqual(1, failedHandler.AuthenticateStaffRequestCount);
+
+            var retryHandler = new ProtectedTokenCacheHttpMessageHandler();
+            var retryClient = CreateClient(retryHandler);
+            ConfigureStaffTokenCache(retryClient, hostname);
+
+            await retryClient.PatronSavedSearchesGetAsync("ABC123");
+
+            Assert.AreEqual(1, retryHandler.AuthenticateStaffRequestCount);
+        }
+
+        [TestMethod]
+        public void ManuallySetToken_StillFormatsProtectedAndPublicOverrideRequests()
+        {
+            var client = CreateClient();
+            client.AllowStaffOverrideRequests = true;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "manual-token",
+                AccessSecret = "manual-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            };
+
+            var protectedRequest = new PapiRestRequest(HttpMethod.Get, "/protected/v1/1033/100/1/manual-token/search/patrons/Boolean");
+            var formattedProtected = (PapiRestRequest)client.PreformatRestRequest(protectedRequest);
+            var protectedDate = formattedProtected.Headers["PolarisDate"];
+            var protectedExpectedHash = ComputePapiHash("GET", "https://example.test/PAPIService/REST/protected/v1/1033/100/1/manual-token/search/patrons/Boolean", protectedDate, "manual-secret", "access-key");
+            Assert.AreEqual($"PWS access-id:{protectedExpectedHash}", formattedProtected.Headers["Authorization"]);
+
+            var publicRequest = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/apikeyvalidate");
+            var formattedPublic = (PapiRestRequest)client.PreformatRestRequest(publicRequest);
+            var publicDate = formattedPublic.Headers["PolarisDate"];
+            var publicExpectedHash = ComputePapiHash("GET", "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate", publicDate, "manual-secret", "access-key");
+            Assert.AreEqual("manual-token", formattedPublic.Headers["X-PAPI-AccessToken"]);
+            Assert.AreEqual($"PWS access-id:{publicExpectedHash}", formattedPublic.Headers["Authorization"]);
+        }
+
         [TestMethod]
         public async Task BibSearch_RequestShape_IsStable()
         {
@@ -527,6 +613,20 @@ namespace Clc.Polaris.Api.Tests
         }
 
 
+
+        private static void ConfigureStaffTokenCache(PapiClient client, string hostname)
+        {
+            client.Hostname = hostname;
+            client.AllowStaffOverrideRequests = true;
+            client.UseProtectedTokenCache = true;
+            client.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = "staff",
+                Password = "secret"
+            };
+        }
+
         private static Dictionary<string, string> ParseQuery(string query)
         {
             return query.TrimStart('?')
@@ -551,6 +651,66 @@ namespace Clc.Polaris.Api.Tests
             public int WorkstationId { get; set; } = 1;
             public int OrganizationId { get; set; } = 1;
             public PolarisUser? PolarisOverrideAccount { get; set; }
+        }
+
+
+        private sealed class ProtectedTokenCacheHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly TimeSpan _authDelay;
+            private readonly HttpStatusCode _authStatusCode;
+            private readonly string _authResponseJson;
+            private int _authenticateStaffRequestCount;
+            private int _protectedSearchRequestCount;
+            private int _publicSavedSearchesRequestCount;
+
+            public int AuthenticateStaffRequestCount => _authenticateStaffRequestCount;
+            public int ProtectedSearchRequestCount => _protectedSearchRequestCount;
+            public int PublicSavedSearchesRequestCount => _publicSavedSearchesRequestCount;
+            public HttpRequestMessage? LastRequest { get; private set; }
+
+            public ProtectedTokenCacheHttpMessageHandler(
+                TimeSpan? authDelay = null,
+                HttpStatusCode authStatusCode = HttpStatusCode.OK,
+                string authResponseJson = "{\"PAPIErrorCode\":0,\"AccessToken\":\"cache-token\",\"AccessSecret\":\"cache-secret\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}")
+            {
+                _authDelay = authDelay ?? TimeSpan.Zero;
+                _authStatusCode = authStatusCode;
+                _authResponseJson = authResponseJson;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastRequest = request;
+                var path = request.RequestUri!.AbsolutePath;
+                if (path.Contains("/authenticator/staff"))
+                {
+                    Interlocked.Increment(ref _authenticateStaffRequestCount);
+                    if (_authDelay > TimeSpan.Zero)
+                    {
+                        await Task.Delay(_authDelay, cancellationToken);
+                    }
+
+                    return new HttpResponseMessage(_authStatusCode)
+                    {
+                        Content = new StringContent(_authResponseJson, Encoding.UTF8, "application/json")
+                    };
+                }
+
+                if (path.Contains("/search/patrons/Boolean"))
+                {
+                    Interlocked.Increment(ref _protectedSearchRequestCount);
+                }
+
+                if (path.Contains("/savedsearches"))
+                {
+                    Interlocked.Increment(ref _publicSavedSearchesRequestCount);
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                };
+            }
         }
 
         private sealed class ProtectedTokenCancellationHttpMessageHandler : HttpMessageHandler


### PR DESCRIPTION
### Motivation
- Remove unsafe public mutable token state and eliminate hidden network/cache side-effects from the `Token` getter.  
- Prevent duplicate staff-authentication calls when multiple callers race to obtain the same protected token.  
- Centralize protected-token cache key logic and ensure failed or malformed staff-authentication responses are not cached.  
- Make the staff-authentication POST helper's intent explicit so it remains safe to bypass `ExecutePapiAsync<T>` for token acquisition.

### Description
- Made `_token` private and kept `Token` as a simple side-effect-light public property; the getter no longer performs cache reads or network work.  
- Added `BuildProtectedTokenCacheKey`, `TryLoadProtectedTokenFromCache`, `AuthenticateAndCacheProtectedTokenAsync`, and `IsTokenMissingOrExpired` helpers to centralize cache key generation and cache interactions.  
- Added a per-cache-key async synchronization map `ProtectedTokenLocks` using `SemaphoreSlim` and updated `EnsureProtectedTokenAsync` to acquire the per-key lock, re-check in-memory/cache state, and authenticate only once per key; lock release is done in a `finally` block.  
- Made `EnsureProtectedTokenAsync` defensive: it returns early when `StaffOverrideAccount` is null, avoids dereferencing possibly-null responses, and only caches tokens for successful responses with non-null `Data`.  
- Renamed internal `PostAsync<T>` usage for staff authentication to `ExecuteStaffAuthenticationPostAsync<T>` and documented why it intentionally bypasses `ExecutePapiAsync<T>`; updated `AuthenticateStaffUserAsync` to use the new helper.  
- Added focused tests in `RestClientMigrationCharacterizationTests` to validate concurrent acquisition de-duplication, cache-hit avoidance of authentication, failed-auth behavior not populating cache, and manual `Token` formatting; updated token-getter tests in `PapiClientTokenTests` to reflect the new side-effect-light getter behavior.

### Testing
- Restored and built the solution with `dotnet restore src/polaris-api-csharp.sln` and `dotnet build src/polaris-api-csharp.sln --no-restore` which succeeded.  
- Ran token/RestClientMigration unit tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"` and the filtered RestClientMigration tests passed.  
- Ran the full unit suite excluding integration with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory!=Integration"` and all non-integration tests passed (no failures).  
- New and existing unit tests exercising protected-token cache and concurrency are included and pass in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1ac8d1c1f483239fefc92d47383bb6)