### PR TITLE
Harden protected token acquisition

### DIFF
--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -17,8 +17,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<ProtectedToken>> AuthenticateStaffUserAsync(PolarisUser staffUser, CancellationToken cancellationToken = default)
         {
             var url = "/protected/v1/1033/100/1/authenticator/staff";
-            var response = await PostAsync<ProtectedToken>(url, body: staffUser, cancellationToken: cancellationToken).ConfigureAwait(false);
-            _token = response?.Data;
+            var response = await ExecuteStaffAuthenticationPostAsync<ProtectedToken>(url, body: staffUser, cancellationToken: cancellationToken).ConfigureAwait(false);
+            Token = response?.Data;
             return response;
         }
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -44,23 +44,16 @@ namespace Clc.Polaris.Api
 
         public bool UseProtectedTokenCache { get; set; } = true;
         private static ConcurrentDictionary<string, ProtectedToken> ProtectedTokenCache { get; set; } = new ConcurrentDictionary<string, ProtectedToken>();
+        private static ConcurrentDictionary<string, SemaphoreSlim> ProtectedTokenLocks { get; set; } = new ConcurrentDictionary<string, SemaphoreSlim>();
 
-        public ProtectedToken _token;
+        private ProtectedToken _token;
 
         /// <summary>
         /// Used for protected methods and public method overrides
         /// </summary>
         public ProtectedToken Token
         {
-            get
-            {
-                if (UseProtectedTokenCache && (_token == null || _token.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
-                {
-                    ProtectedTokenCache.TryGetValue($"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}", out _token);
-                }
-
-                return _token;
-            }
+            get { return _token; }
             set { _token = value; }
         }
 
@@ -109,7 +102,7 @@ namespace Clc.Polaris.Api
 
                 if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password) && _token != null)
                 {
-                    password = Token.AccessSecret;
+                    password = _token.AccessSecret;
                 }
 
                 var date = DateTime.Now.ToUniversalTime().ToString("R");
@@ -159,27 +152,99 @@ namespace Clc.Polaris.Api
 
         private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
         {
-            if (UseProtectedTokenCache && (_token == null || _token.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
+            if (StaffOverrideAccount == null || !IsProtectedTokenExpired(_token))
             {
-                ProtectedTokenCache.TryGetValue($"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}", out _token);
+                return _token;
             }
 
-            if ((_token == null || _token.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
-            {
-                var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
-                _token = response?.Data;
+            var cacheKey = BuildProtectedTokenCacheKey();
 
-                if (UseProtectedTokenCache && response.Response.IsSuccessStatusCode && _token != null)
+            if (TryLoadProtectedTokenFromCache(cacheKey))
+            {
+                return _token;
+            }
+
+            if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
+            {
+                await LoadProtectedTokenAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+                return _token;
+            }
+
+            var tokenLock = ProtectedTokenLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
+            await tokenLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                if (!IsProtectedTokenExpired(_token) || TryLoadProtectedTokenFromCache(cacheKey))
                 {
-                    ProtectedTokenCache[$"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}"] = new ProtectedToken(_token);
+                    return _token;
                 }
-            }
 
-            return _token;
+                await LoadProtectedTokenAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+                return _token;
+            }
+            finally
+            {
+                tokenLock.Release();
+            }
         }
 
-        private async Task<IRestResponse<T>> PostAsync<T>(string url, object body = null, CancellationToken cancellationToken = default)
+        private string BuildProtectedTokenCacheKey()
         {
+            if (StaffOverrideAccount == null ||
+                string.IsNullOrWhiteSpace(Hostname) ||
+                string.IsNullOrWhiteSpace(StaffOverrideAccount.Domain) ||
+                string.IsNullOrWhiteSpace(StaffOverrideAccount.Username))
+            {
+                return null;
+            }
+
+            return $"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}";
+        }
+
+        private bool TryLoadProtectedTokenFromCache(string cacheKey)
+        {
+            if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
+            {
+                return false;
+            }
+
+            if (ProtectedTokenCache.TryGetValue(cacheKey, out var cachedToken) && !IsProtectedTokenExpired(cachedToken))
+            {
+                _token = cachedToken;
+                return true;
+            }
+
+            return false;
+        }
+
+        private async Task LoadProtectedTokenAsync(string cacheKey, CancellationToken cancellationToken)
+        {
+            var currentToken = _token;
+            var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
+
+            if (response?.Response == null || !response.Response.IsSuccessStatusCode || response.Data == null)
+            {
+                _token = currentToken;
+                return;
+            }
+
+            _token = response.Data;
+
+            if (UseProtectedTokenCache && !string.IsNullOrWhiteSpace(cacheKey))
+            {
+                ProtectedTokenCache[cacheKey] = new ProtectedToken(_token);
+            }
+        }
+
+        private static bool IsProtectedTokenExpired(ProtectedToken token)
+        {
+            return token == null || token.ExpirationDate <= DateTime.Now;
+        }
+
+        private async Task<IRestResponse<T>> ExecuteStaffAuthenticationPostAsync<T>(string url, object body = null, CancellationToken cancellationToken = default)
+        {
+            // Staff authentication obtains the protected token, so this intentionally bypasses ExecutePapiAsync<T> token preloading.
             return await ExecuteAsync<T>(new PapiRestRequest(HttpMethod.Post, url) { Body = body }, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -1,219 +1,341 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Concurrent;
-using System.Reflection;
 using Clc.Polaris.Api;
 using Clc.Polaris.Api.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Clc.Polaris.Api.Tests
 {
-    [TestClass()]
+    [TestClass]
     [DoNotParallelize]
+    [TestCategory("RestClientMigration")]
     public class PapiClientTokenTests
     {
-    [TestInitialize]
-    public void TestInitialize()
-    {
-        ClearProtectedTokenCache();
-    }
-
-    [TestMethod]
-    public void Token_WhenTokenIsNullAndNoStaffOverrideAccount_ReturnsNullWithoutAuthenticating()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-
-        var token = client.Token;
-
-        Assert.IsNull(token);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenTokenIsNullAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsCachedToken()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        var staff = CreateStaffUser();
-        client.StaffOverrideAccount = staff;
-        client.UseProtectedTokenCache = true;
-        SetCachedToken(client.Hostname, staff, new ProtectedToken
+        [TestInitialize]
+        public void TestInitialize()
         {
-            AccessToken = "cached-token",
-            AccessSecret = "cached-secret",
-            ExpirationDate = DateTime.Now.AddHours(1)
-        });
-
-        var token = client.Token;
-
-        Assert.IsNotNull(token);
-        Assert.AreEqual("cached-token", token.AccessToken);
-        Assert.AreEqual("cached-secret", token.AccessSecret);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenExistingTokenIsNotExpired_ReturnsExistingTokenWithoutAuthenticating()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        client.StaffOverrideAccount = CreateStaffUser();
-        client.Token = new ProtectedToken
-        {
-            AccessToken = "existing-token",
-            AccessSecret = "existing-secret",
-            ExpirationDate = DateTime.Now.AddHours(1)
-        };
-
-        var token = client.Token;
-
-        Assert.IsNotNull(token);
-        Assert.AreEqual("existing-token", token.AccessToken);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenExistingTokenIsExpiredAndStaffOverrideAccountExistsAndCacheHasValidToken_UsesCachedToken()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        var staff = CreateStaffUser();
-        client.StaffOverrideAccount = staff;
-        client.UseProtectedTokenCache = true;
-        client.Token = new ProtectedToken
-        {
-            AccessToken = "expired-token",
-            AccessSecret = "expired-secret",
-            ExpirationDate = DateTime.Now.AddHours(-1)
-        };
-        SetCachedToken(client.Hostname, staff, new ProtectedToken
-        {
-            AccessToken = "cached-token",
-            AccessSecret = "cached-secret",
-            ExpirationDate = DateTime.Now.AddHours(1)
-        });
-
-        var token = client.Token;
-
-        Assert.IsNotNull(token);
-        Assert.AreEqual("cached-token", token.AccessToken);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenExistingTokenIsExpiredAndNoStaffOverrideAccount_ReturnsExistingTokenWithoutAuthenticating()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        client.Token = new ProtectedToken
-        {
-            AccessToken = "expired-token",
-            AccessSecret = "expired-secret",
-            ExpirationDate = DateTime.Now.AddHours(-1)
-        };
-
-        var token = client.Token;
-
-        Assert.IsNotNull(token);
-        Assert.AreEqual("expired-token", token.AccessToken);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenCacheEnabledTokenNullAndNoStaffOverrideAccount_ReturnsNullWithoutThrowing()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        client.UseProtectedTokenCache = true;
-        client.StaffOverrideAccount = null;
-        client.Token = null;
-
-        var token = client.Token;
-
-        Assert.IsNull(token);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    private static PapiClient CreateClient(CapturingHttpMessageHandler handler)
-    {
-        var hostname = $"https://example-{Guid.NewGuid():N}.test";
-        var httpClient = new HttpClient(handler)
-        {
-            BaseAddress = new Uri($"{hostname}/")
-        };
-
-        return new PapiClient(httpClient, null)
-        {
-            Hostname = hostname,
-            AccessID = "access-id",
-            AccessKey = "access-key",
-            UseProtectedTokenCache = false,
-            AllowStaffOverrideRequests = false
-        };
-    }
-
-    private static PolarisUser CreateStaffUser()
-    {
-        return new PolarisUser
-        {
-            Domain = "domain",
-            Username = "user",
-            Password = "password"
-        };
-    }
-
-    private static string CreateProtectedTokenJson(string accessToken, string accessSecret, DateTime expirationDate)
-    {
-        return
-            "{" +
-            $"\"PAPIErrorCode\":0," +
-            $"\"AccessToken\":\"{accessToken}\"," +
-            $"\"AccessSecret\":\"{accessSecret}\"," +
-            $"\"AuthExpDate\":\"{expirationDate:O}\"" +
-            "}";
-    }
-
-    private sealed class CapturingHttpMessageHandler : HttpMessageHandler
-    {
-        private readonly string _responseJson;
-
-        public int RequestCount { get; private set; }
-        public HttpRequestMessage? LastRequest { get; private set; }
-
-        public CapturingHttpMessageHandler(string? responseJson = null)
-        {
-            _responseJson = responseJson ?? CreateProtectedTokenJson("new-token", "new-secret", DateTime.UtcNow.AddHours(1));
+            ClearProtectedTokenCache();
+            ClearProtectedTokenLocks();
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        [TestMethod]
+        public void Token_WhenTokenIsNullAndNoStaffOverrideAccount_ReturnsNullWithoutAuthenticating()
         {
-            RequestCount++;
-            LastRequest = request;
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
 
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            var token = client.Token;
+
+            Assert.IsNull(token);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenCacheHasValidToken_ReturnsCurrentTokenOnlyWithoutCacheLookupOrAuthenticating()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            var staff = CreateStaffUser();
+            client.StaffOverrideAccount = staff;
+            client.UseProtectedTokenCache = true;
+            SetCachedToken(client.Hostname, staff, new ProtectedToken
             {
-                Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                AccessToken = "cached-token",
+                AccessSecret = "cached-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
             });
+
+            var token = client.Token;
+
+            Assert.IsNull(token);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenExistingTokenIsNotExpired_ReturnsExistingTokenWithoutAuthenticating()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.StaffOverrideAccount = CreateStaffUser();
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "existing-token",
+                AccessSecret = "existing-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            };
+
+            var token = client.Token;
+
+            Assert.IsNotNull(token);
+            Assert.AreEqual("existing-token", token.AccessToken);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public async Task ProtectedRequest_WhenCacheHasValidToken_UsesCachedTokenWithoutStaffAuthentication()
+        {
+            var handler = new CapturingHttpMessageHandler(responseJson: "{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var staff = CreateStaffUser();
+            client.StaffOverrideAccount = staff;
+            client.UseProtectedTokenCache = true;
+            SetCachedToken(client.Hostname, staff, new ProtectedToken
+            {
+                AccessToken = "cached-token",
+                AccessSecret = "cached-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            });
+
+            var response = await client.PatronSearchAsync("name=Smith");
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(1, handler.RequestCount);
+            Assert.AreEqual(0, handler.StaffAuthenticationRequestCount);
+            StringAssert.Contains(handler.LastRequest!.RequestUri!.AbsolutePath, "/cached-token/search/patrons/Boolean");
+            Assert.AreEqual("cached-token", client.Token!.AccessToken);
+        }
+
+        [TestMethod]
+        public async Task ProtectedRequests_WhenConcurrentAndNoCachedToken_AuthenticateOnlyOnceForSameCacheKey()
+        {
+            var handler = new CapturingHttpMessageHandler(authDelay: TimeSpan.FromMilliseconds(100));
+            var hostname = $"https://example-{Guid.NewGuid():N}.test";
+            var clients = Enumerable.Range(0, 8)
+                .Select(_ =>
+                {
+                    var client = CreateClient(handler, hostname);
+                    client.StaffOverrideAccount = CreateStaffUser();
+                    client.UseProtectedTokenCache = true;
+                    client.AllowStaffOverrideRequests = true;
+                    return client;
+                })
+                .ToArray();
+
+            var tasks = clients
+                .Select((client, index) => client.PatronSearchAsync($"name=Smith{index}"))
+                .ToArray();
+
+            await Task.WhenAll(tasks);
+
+            Assert.AreEqual(1, handler.StaffAuthenticationRequestCount);
+            Assert.AreEqual(8, handler.ProtectedSearchRequestCount);
+            Assert.AreEqual(9, handler.RequestCount);
+            Assert.IsTrue(handler.Requests.All(request =>
+                IsStaffAuthenticationRequest(request) || request.RequestUri!.AbsolutePath.Contains("/new-token/search/patrons/Boolean")));
+        }
+
+        [TestMethod]
+        public async Task PublicOverride_WhenStaffAuthenticationFails_DoesNotPopulateCacheOrThrowNullReferenceException()
+        {
+            var handler = new CapturingHttpMessageHandler(
+                responseJson: "{\"PAPIErrorCode\":0}",
+                staffAuthenticationStatusCode: HttpStatusCode.InternalServerError,
+                staffAuthenticationResponseJson: "{\"PAPIErrorCode\":-1,\"AccessToken\":\"failed-token\",\"AccessSecret\":\"failed-secret\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}");
+            var client = CreateClient(handler);
+            client.StaffOverrideAccount = CreateStaffUser();
+            client.UseProtectedTokenCache = true;
+            client.AllowStaffOverrideRequests = true;
+
+            var response = await client.ApiVersionGetAsync();
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(2, handler.RequestCount);
+            Assert.AreEqual(1, handler.StaffAuthenticationRequestCount);
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+            Assert.IsNull(client.Token);
+        }
+
+        [TestMethod]
+        public async Task PublicOverride_WhenStaffAuthenticationReturnsNullData_DoesNotPopulateCache()
+        {
+            var handler = new CapturingHttpMessageHandler(
+                responseJson: "{\"PAPIErrorCode\":0}",
+                staffAuthenticationResponseJson: "null");
+            var client = CreateClient(handler);
+            client.StaffOverrideAccount = CreateStaffUser();
+            client.UseProtectedTokenCache = true;
+            client.AllowStaffOverrideRequests = true;
+
+            var response = await client.ApiVersionGetAsync();
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(2, handler.RequestCount);
+            Assert.AreEqual(1, handler.StaffAuthenticationRequestCount);
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+            Assert.IsNull(client.Token);
+        }
+
+        [TestMethod]
+        public async Task PublicOverride_WhenTokenSetManually_FormatsOverrideWithManualToken()
+        {
+            var handler = new CapturingHttpMessageHandler(responseJson: "{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = null;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "manual-token",
+                AccessSecret = "manual-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            };
+
+            var response = await client.ApiVersionGetAsync();
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(1, handler.RequestCount);
+            Assert.AreEqual(0, handler.StaffAuthenticationRequestCount);
+            Assert.IsTrue(handler.LastRequest!.Headers.TryGetValues("X-PAPI-AccessToken", out var values));
+            Assert.AreEqual("manual-token", values.Single());
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
+        }
+
+        private static PapiClient CreateClient(CapturingHttpMessageHandler handler, string? hostname = null)
+        {
+            hostname ??= $"https://example-{Guid.NewGuid():N}.test";
+            var httpClient = new HttpClient(handler, disposeHandler: false)
+            {
+                BaseAddress = new Uri($"{hostname}/")
+            };
+
+            return new PapiClient(httpClient, null)
+            {
+                Hostname = hostname,
+                AccessID = "access-id",
+                AccessKey = "access-key",
+                OrganizationId = 1,
+                UseProtectedTokenCache = false,
+                AllowStaffOverrideRequests = false
+            };
+        }
+
+        private static PolarisUser CreateStaffUser()
+        {
+            return new PolarisUser
+            {
+                Domain = "domain",
+                Username = "user",
+                Password = "password"
+            };
+        }
+
+        private static string CreateProtectedTokenJson(string accessToken, string accessSecret, DateTime expirationDate)
+        {
+            return
+                "{" +
+                $"\"PAPIErrorCode\":0," +
+                $"\"AccessToken\":\"{accessToken}\"," +
+                $"\"AccessSecret\":\"{accessSecret}\"," +
+                $"\"AuthExpDate\":\"{expirationDate:O}\"" +
+                "}";
+        }
+
+        private sealed class CapturingHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly string _responseJson;
+            private readonly string _staffAuthenticationResponseJson;
+            private readonly HttpStatusCode _staffAuthenticationStatusCode;
+            private readonly TimeSpan _authDelay;
+            private int _requestCount;
+            private int _staffAuthenticationRequestCount;
+            private int _protectedSearchRequestCount;
+
+            public int RequestCount => _requestCount;
+            public int StaffAuthenticationRequestCount => _staffAuthenticationRequestCount;
+            public int ProtectedSearchRequestCount => _protectedSearchRequestCount;
+            public HttpRequestMessage? LastRequest { get; private set; }
+            public ConcurrentBag<HttpRequestMessage> Requests { get; } = new ConcurrentBag<HttpRequestMessage>();
+
+            public CapturingHttpMessageHandler(
+                string? responseJson = null,
+                HttpStatusCode staffAuthenticationStatusCode = HttpStatusCode.OK,
+                string? staffAuthenticationResponseJson = null,
+                TimeSpan? authDelay = null)
+            {
+                _responseJson = responseJson ?? "{\"PAPIErrorCode\":0}";
+                _staffAuthenticationResponseJson = staffAuthenticationResponseJson ?? CreateProtectedTokenJson("new-token", "new-secret", DateTime.Now.AddHours(1));
+                _staffAuthenticationStatusCode = staffAuthenticationStatusCode;
+                _authDelay = authDelay ?? TimeSpan.Zero;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref _requestCount);
+                LastRequest = request;
+                Requests.Add(request);
+
+                if (IsStaffAuthenticationRequest(request))
+                {
+                    Interlocked.Increment(ref _staffAuthenticationRequestCount);
+
+                    if (_authDelay > TimeSpan.Zero)
+                    {
+                        await Task.Delay(_authDelay, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    return new HttpResponseMessage(_staffAuthenticationStatusCode)
+                    {
+                        Content = new StringContent(_staffAuthenticationResponseJson, Encoding.UTF8, "application/json")
+                    };
+                }
+
+                if (request.RequestUri!.AbsolutePath.Contains("/search/patrons/Boolean"))
+                {
+                    Interlocked.Increment(ref _protectedSearchRequestCount);
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                };
+            }
+        }
+
+        private static bool IsStaffAuthenticationRequest(HttpRequestMessage request)
+        {
+            return request.RequestUri!.AbsolutePath.EndsWith("/protected/v1/1033/100/1/authenticator/staff", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static void ClearProtectedTokenCache()
+        {
+            var cacheProperty = typeof(PapiClient).GetProperty("ProtectedTokenCache", BindingFlags.NonPublic | BindingFlags.Static);
+            var cache = cacheProperty?.GetValue(null) as ConcurrentDictionary<string, ProtectedToken>;
+            cache?.Clear();
+        }
+
+        private static void ClearProtectedTokenLocks()
+        {
+            var locksProperty = typeof(PapiClient).GetProperty("ProtectedTokenLocks", BindingFlags.NonPublic | BindingFlags.Static);
+            var locks = locksProperty?.GetValue(null) as ConcurrentDictionary<string, SemaphoreSlim>;
+            locks?.Clear();
+        }
+
+        private static void SetCachedToken(string hostname, PolarisUser staffUser, ProtectedToken token)
+        {
+            var cacheProperty = typeof(PapiClient).GetProperty("ProtectedTokenCache", BindingFlags.NonPublic | BindingFlags.Static);
+            var cache = cacheProperty?.GetValue(null) as ConcurrentDictionary<string, ProtectedToken>;
+            cache?.TryAdd($"{hostname}{staffUser.Domain}{staffUser.Username}", token);
+        }
+
+        private static bool TryGetCachedToken(string hostname, PolarisUser staffUser, out ProtectedToken? token)
+        {
+            var cacheProperty = typeof(PapiClient).GetProperty("ProtectedTokenCache", BindingFlags.NonPublic | BindingFlags.Static);
+            var cache = cacheProperty?.GetValue(null) as ConcurrentDictionary<string, ProtectedToken>;
+
+            if (cache == null)
+            {
+                token = null;
+                return false;
+            }
+
+            return cache.TryGetValue($"{hostname}{staffUser.Domain}{staffUser.Username}", out token);
         }
     }
-
-    private static void ClearProtectedTokenCache()
-    {
-        var cacheProperty = typeof(PapiClient).GetProperty("ProtectedTokenCache", BindingFlags.NonPublic | BindingFlags.Static);
-        var cache = cacheProperty?.GetValue(null) as ConcurrentDictionary<string, ProtectedToken>;
-        cache?.Clear();
-    }
-
-    private static void SetCachedToken(string hostname, PolarisUser staffUser, ProtectedToken token)
-    {
-        var cacheProperty = typeof(PapiClient).GetProperty("ProtectedTokenCache", BindingFlags.NonPublic | BindingFlags.Static);
-        var cache = cacheProperty?.GetValue(null) as ConcurrentDictionary<string, ProtectedToken>;
-        cache?.TryAdd($"{hostname}{staffUser.Domain}{staffUser.Username}", token);
-    }
-}
 }


### PR DESCRIPTION
### Motivation
- Prevent unsafe public mutable protected-token state and avoid network/cache side effects from the `Token` getter. 
- Centralize protected-token cache key construction and make cache usage safe when staff-account information is incomplete. 
- De-duplicate concurrent staff authentication for the same host/domain/username and make token acquisition defensive against null/failed responses. 
- Make the helper used for staff-auth POSTs explicit so bypassing normal token preloading is obvious and harder to misuse. 

### Description
- Encapsulated token state by making `_token` private and keeping the public `Token` property a simple read/write wrapper without performing cache or network work. (`src/polaris-api-csharp/PapiClient.cs`)  
- Centralized cache-key logic in `BuildProtectedTokenCacheKey()` and guarded cache use when `StaffOverrideAccount`, `Hostname`, `Domain`, or `Username` are missing; cache reads/writes moved into the token-acquisition flow. (`BuildProtectedTokenCacheKey`, `TryLoadProtectedTokenFromCache`)  
- Added per-cache-key async synchronization with a static `ConcurrentDictionary<string, SemaphoreSlim>` called `ProtectedTokenLocks`, acquiring the per-key lock, re-checking in-memory/cache token state after acquiring the lock, and releasing the lock in a `finally` block. (`ProtectedTokenLocks`, `EnsureProtectedTokenAsync`)  
- Made token loading defensive: `LoadProtectedTokenAsync` preserves the prior `_token` if authentication returns null/unsuccessful `Response` or null `Data`, and successful auth populates `_token` and conditionally the cache only when valid. (`LoadProtectedTokenAsync`)  
- Replaced the private `PostAsync<T>` use for staff auth with `ExecuteStaffAuthenticationPostAsync<T>` and added a comment noting it intentionally bypasses `ExecutePapiAsync<T>` because it obtains the protected token; updated `AuthenticateStaffUserAsync` to call the new helper while preserving the public API. (`Methods/AuthenticateStaffUser.cs`, `ExecuteStaffAuthenticationPostAsync`)  
- Updated/added focused in-memory unit tests in `src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs` covering: cache-hit behavior, concurrent protected requests deduping staff auth per cache key, not caching failed/null staff-auth responses, and manual `Token` override formatting; tests use existing fake `HttpMessageHandler` patterns and do not require external resources.  

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` and `dotnet build src/polaris-api-csharp.sln --no-restore` successfully.  
- Ran unit tests for the migration characterization subset with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"` and they passed.  
- Ran the full non-integration test set with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory!=Integration"` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1ac8d1c1f483239fefc92d47383bb6)