### PR TITLE
Harden protected token acquisition

### DIFF
--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -17,8 +17,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<ProtectedToken>> AuthenticateStaffUserAsync(PolarisUser staffUser, CancellationToken cancellationToken = default)
         {
             var url = "/protected/v1/1033/100/1/authenticator/staff";
-            var response = await PostAsync<ProtectedToken>(url, body: staffUser, cancellationToken: cancellationToken).ConfigureAwait(false);
-            _token = response?.Data;
+            var response = await ExecuteStaffAuthenticationPostAsync<ProtectedToken>(url, body: staffUser, cancellationToken: cancellationToken).ConfigureAwait(false);
+            Token = response?.Data;
             return response;
         }
 

--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -17,9 +17,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<ProtectedToken>> AuthenticateStaffUserAsync(PolarisUser staffUser, CancellationToken cancellationToken = default)
         {
             var url = "/protected/v1/1033/100/1/authenticator/staff";
-            var response = await ExecuteStaffAuthenticationPostAsync<ProtectedToken>(url, body: staffUser, cancellationToken: cancellationToken).ConfigureAwait(false);
-            Token = response?.Data;
-            return response;
+            return await ExecuteStaffAuthenticationPostAsync<ProtectedToken>(url, body: staffUser, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -44,23 +44,16 @@ namespace Clc.Polaris.Api
 
         public bool UseProtectedTokenCache { get; set; } = true;
         private static ConcurrentDictionary<string, ProtectedToken> ProtectedTokenCache { get; set; } = new ConcurrentDictionary<string, ProtectedToken>();
+        private static ConcurrentDictionary<string, SemaphoreSlim> ProtectedTokenCacheLocks { get; set; } = new ConcurrentDictionary<string, SemaphoreSlim>();
 
-        public ProtectedToken _token;
+        private ProtectedToken _token;
 
         /// <summary>
         /// Used for protected methods and public method overrides
         /// </summary>
         public ProtectedToken Token
         {
-            get
-            {
-                if (UseProtectedTokenCache && (_token == null || _token.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
-                {
-                    ProtectedTokenCache.TryGetValue($"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}", out _token);
-                }
-
-                return _token;
-            }
+            get { return _token; }
             set { _token = value; }
         }
 
@@ -107,7 +100,7 @@ namespace Clc.Polaris.Api
                     }
                 }
 
-                if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password) && _token != null)
+                if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password) && Token != null)
                 {
                     password = Token.AccessSecret;
                 }
@@ -159,27 +152,96 @@ namespace Clc.Polaris.Api
 
         private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
         {
-            if (UseProtectedTokenCache && (_token == null || _token.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
+            if (StaffOverrideAccount == null || !IsProtectedTokenMissingOrExpired(_token))
             {
-                ProtectedTokenCache.TryGetValue($"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}", out _token);
+                return _token;
             }
 
-            if ((_token == null || _token.ExpirationDate <= DateTime.Now) && StaffOverrideAccount != null)
+            var cacheKey = BuildProtectedTokenCacheKey();
+            if (TryLoadProtectedTokenFromCache(cacheKey))
             {
-                var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
-                _token = response?.Data;
+                return _token;
+            }
 
-                if (UseProtectedTokenCache && response.Response.IsSuccessStatusCode && _token != null)
+            if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
+            {
+                return await AuthenticateAndLoadProtectedTokenAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+            }
+
+            var cacheLock = ProtectedTokenCacheLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
+            await cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (!IsProtectedTokenMissingOrExpired(_token) || TryLoadProtectedTokenFromCache(cacheKey))
                 {
-                    ProtectedTokenCache[$"{Hostname}{StaffOverrideAccount.Domain}{StaffOverrideAccount.Username}"] = new ProtectedToken(_token);
+                    return _token;
                 }
+
+                return await AuthenticateAndLoadProtectedTokenAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                cacheLock.Release();
+            }
+        }
+
+        private string BuildProtectedTokenCacheKey()
+        {
+            if (StaffOverrideAccount == null ||
+                string.IsNullOrWhiteSpace(Hostname) ||
+                string.IsNullOrWhiteSpace(StaffOverrideAccount.Domain) ||
+                string.IsNullOrWhiteSpace(StaffOverrideAccount.Username))
+            {
+                return null;
+            }
+
+            return $"{Hostname}|{StaffOverrideAccount.Domain}|{StaffOverrideAccount.Username}";
+        }
+
+        private static bool IsProtectedTokenMissingOrExpired(ProtectedToken token)
+        {
+            return token == null || !token.ExpirationDate.HasValue || token.ExpirationDate <= DateTime.Now;
+        }
+
+        private bool TryLoadProtectedTokenFromCache(string cacheKey)
+        {
+            if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
+            {
+                return false;
+            }
+
+            if (ProtectedTokenCache.TryGetValue(cacheKey, out var cachedToken) && !IsProtectedTokenMissingOrExpired(cachedToken))
+            {
+                _token = new ProtectedToken(cachedToken);
+                return true;
+            }
+
+            return false;
+        }
+
+        private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenAsync(string cacheKey, CancellationToken cancellationToken)
+        {
+            var currentToken = _token;
+            var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
+            if (response?.Response == null || !response.Response.IsSuccessStatusCode || IsProtectedTokenMissingOrExpired(response.Data))
+            {
+                _token = currentToken;
+                return _token;
+            }
+
+            _token = response.Data;
+
+            if (UseProtectedTokenCache && !string.IsNullOrWhiteSpace(cacheKey))
+            {
+                ProtectedTokenCache[cacheKey] = new ProtectedToken(_token);
             }
 
             return _token;
         }
 
-        private async Task<IRestResponse<T>> PostAsync<T>(string url, object body = null, CancellationToken cancellationToken = default)
+        private async Task<IRestResponse<T>> ExecuteStaffAuthenticationPostAsync<T>(string url, object body = null, CancellationToken cancellationToken = default)
         {
+            // Staff authentication obtains the protected token, so this intentionally bypasses ExecutePapiAsync<T>.
             return await ExecuteAsync<T>(new PapiRestRequest(HttpMethod.Post, url) { Body = body }, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -141,6 +141,27 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public async Task AuthenticateStaffUserAsync_ReturnsTokenButDoesNotSetClientToken()
+        {
+            var handler = new CapturingHttpMessageHandler(CreateProtectedTokenJson("returned-token", "returned-secret", DateTime.Now.AddHours(1)));
+            var client = CreateClient(handler);
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "existing-token",
+                AccessSecret = "existing-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            };
+
+            var response = await client.AuthenticateStaffUserAsync(CreateStaffUser());
+
+            Assert.IsNotNull(response.Data);
+            Assert.AreEqual("returned-token", response.Data.AccessToken);
+            Assert.IsNotNull(client.Token);
+            Assert.AreEqual("existing-token", client.Token.AccessToken);
+            Assert.AreEqual(1, handler.RequestCount);
+        }
+
+        [TestMethod]
         public async Task PatronSearchAsync_ConcurrentProtectedRequestsForSameCacheKey_AuthenticateOnce()
         {
             var handler = new ProtectedTokenHttpMessageHandler();
@@ -178,6 +199,24 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public async Task PatronSearchAsync_SuccessfulStaffAuthentication_LoadsTokenAndCachesIt()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateProtectedClient(handler);
+
+            await client.PatronSearchAsync("name=Smith");
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.IsNotNull(client.Token);
+            Assert.AreEqual("protected-token", client.Token.AccessToken);
+            Assert.IsTrue(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out var cachedToken));
+            Assert.IsNotNull(cachedToken);
+            Assert.AreEqual("protected-token", cachedToken.AccessToken);
+            Assert.AreNotSame(client.Token, cachedToken);
+        }
+
+        [TestMethod]
         public async Task PatronAccountGetAsync_FailedStaffAuthentication_DoesNotPopulateProtectedTokenCache()
         {
             var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
@@ -202,6 +241,48 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+        }
+
+        [TestMethod]
+        public async Task PatronAccountGetAsync_FailedStaffAuthentication_DoesNotOverwriteExistingToken()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var client = CreateProtectedClient(handler);
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "existing-token",
+                AccessSecret = "existing-secret",
+                ExpirationDate = DateTime.Now.AddHours(-1)
+            };
+
+            var response = await client.PatronAccountGetAsync("ABC123");
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.IsNotNull(client.Token);
+            Assert.AreEqual("existing-token", client.Token.AccessToken);
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+        }
+
+        [TestMethod]
+        public async Task PatronAccountGetAsync_NullDataStaffAuthentication_DoesNotOverwriteExistingToken()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, "{}");
+            var client = CreateProtectedClient(handler);
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "existing-token",
+                AccessSecret = "existing-secret",
+                ExpirationDate = DateTime.Now.AddHours(-1)
+            };
+
+            var response = await client.PatronAccountGetAsync("ABC123");
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.IsNotNull(client.Token);
+            Assert.AreEqual("existing-token", client.Token.AccessToken);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
         }
 

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -1,219 +1,383 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Concurrent;
-using System.Reflection;
 using Clc.Polaris.Api;
 using Clc.Polaris.Api.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Clc.Polaris.Api.Tests
 {
-    [TestClass()]
+    [TestClass]
     [DoNotParallelize]
+    [TestCategory("RestClientMigration")]
     public class PapiClientTokenTests
     {
-    [TestInitialize]
-    public void TestInitialize()
-    {
-        ClearProtectedTokenCache();
-    }
-
-    [TestMethod]
-    public void Token_WhenTokenIsNullAndNoStaffOverrideAccount_ReturnsNullWithoutAuthenticating()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-
-        var token = client.Token;
-
-        Assert.IsNull(token);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenTokenIsNullAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsCachedToken()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        var staff = CreateStaffUser();
-        client.StaffOverrideAccount = staff;
-        client.UseProtectedTokenCache = true;
-        SetCachedToken(client.Hostname, staff, new ProtectedToken
+        [TestInitialize]
+        public void TestInitialize()
         {
-            AccessToken = "cached-token",
-            AccessSecret = "cached-secret",
-            ExpirationDate = DateTime.Now.AddHours(1)
-        });
-
-        var token = client.Token;
-
-        Assert.IsNotNull(token);
-        Assert.AreEqual("cached-token", token.AccessToken);
-        Assert.AreEqual("cached-secret", token.AccessSecret);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenExistingTokenIsNotExpired_ReturnsExistingTokenWithoutAuthenticating()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        client.StaffOverrideAccount = CreateStaffUser();
-        client.Token = new ProtectedToken
-        {
-            AccessToken = "existing-token",
-            AccessSecret = "existing-secret",
-            ExpirationDate = DateTime.Now.AddHours(1)
-        };
-
-        var token = client.Token;
-
-        Assert.IsNotNull(token);
-        Assert.AreEqual("existing-token", token.AccessToken);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenExistingTokenIsExpiredAndStaffOverrideAccountExistsAndCacheHasValidToken_UsesCachedToken()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        var staff = CreateStaffUser();
-        client.StaffOverrideAccount = staff;
-        client.UseProtectedTokenCache = true;
-        client.Token = new ProtectedToken
-        {
-            AccessToken = "expired-token",
-            AccessSecret = "expired-secret",
-            ExpirationDate = DateTime.Now.AddHours(-1)
-        };
-        SetCachedToken(client.Hostname, staff, new ProtectedToken
-        {
-            AccessToken = "cached-token",
-            AccessSecret = "cached-secret",
-            ExpirationDate = DateTime.Now.AddHours(1)
-        });
-
-        var token = client.Token;
-
-        Assert.IsNotNull(token);
-        Assert.AreEqual("cached-token", token.AccessToken);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenExistingTokenIsExpiredAndNoStaffOverrideAccount_ReturnsExistingTokenWithoutAuthenticating()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        client.Token = new ProtectedToken
-        {
-            AccessToken = "expired-token",
-            AccessSecret = "expired-secret",
-            ExpirationDate = DateTime.Now.AddHours(-1)
-        };
-
-        var token = client.Token;
-
-        Assert.IsNotNull(token);
-        Assert.AreEqual("expired-token", token.AccessToken);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    [TestMethod]
-    public void Token_WhenCacheEnabledTokenNullAndNoStaffOverrideAccount_ReturnsNullWithoutThrowing()
-    {
-        var handler = new CapturingHttpMessageHandler();
-        var client = CreateClient(handler);
-        client.UseProtectedTokenCache = true;
-        client.StaffOverrideAccount = null;
-        client.Token = null;
-
-        var token = client.Token;
-
-        Assert.IsNull(token);
-        Assert.AreEqual(0, handler.RequestCount);
-    }
-
-    private static PapiClient CreateClient(CapturingHttpMessageHandler handler)
-    {
-        var hostname = $"https://example-{Guid.NewGuid():N}.test";
-        var httpClient = new HttpClient(handler)
-        {
-            BaseAddress = new Uri($"{hostname}/")
-        };
-
-        return new PapiClient(httpClient, null)
-        {
-            Hostname = hostname,
-            AccessID = "access-id",
-            AccessKey = "access-key",
-            UseProtectedTokenCache = false,
-            AllowStaffOverrideRequests = false
-        };
-    }
-
-    private static PolarisUser CreateStaffUser()
-    {
-        return new PolarisUser
-        {
-            Domain = "domain",
-            Username = "user",
-            Password = "password"
-        };
-    }
-
-    private static string CreateProtectedTokenJson(string accessToken, string accessSecret, DateTime expirationDate)
-    {
-        return
-            "{" +
-            $"\"PAPIErrorCode\":0," +
-            $"\"AccessToken\":\"{accessToken}\"," +
-            $"\"AccessSecret\":\"{accessSecret}\"," +
-            $"\"AuthExpDate\":\"{expirationDate:O}\"" +
-            "}";
-    }
-
-    private sealed class CapturingHttpMessageHandler : HttpMessageHandler
-    {
-        private readonly string _responseJson;
-
-        public int RequestCount { get; private set; }
-        public HttpRequestMessage? LastRequest { get; private set; }
-
-        public CapturingHttpMessageHandler(string? responseJson = null)
-        {
-            _responseJson = responseJson ?? CreateProtectedTokenJson("new-token", "new-secret", DateTime.UtcNow.AddHours(1));
+            ClearProtectedTokenState();
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        [TestMethod]
+        public void Token_WhenTokenIsNullAndNoStaffOverrideAccount_ReturnsNullWithoutAuthenticating()
         {
-            RequestCount++;
-            LastRequest = request;
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
 
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            var token = client.Token;
+
+            Assert.IsNull(token);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenTokenIsNullAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsNullWithoutCacheLookupOrAuthenticating()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            var staff = CreateStaffUser();
+            client.StaffOverrideAccount = staff;
+            client.UseProtectedTokenCache = true;
+            SetCachedToken(client.Hostname, staff, new ProtectedToken
             {
-                Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                AccessToken = "cached-token",
+                AccessSecret = "cached-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
             });
+
+            var token = client.Token;
+
+            Assert.IsNull(token);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenExistingTokenIsNotExpired_ReturnsExistingTokenWithoutAuthenticating()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.StaffOverrideAccount = CreateStaffUser();
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "existing-token",
+                AccessSecret = "existing-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            };
+
+            var token = client.Token;
+
+            Assert.IsNotNull(token);
+            Assert.AreEqual("existing-token", token.AccessToken);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenExistingTokenIsExpiredAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsExistingTokenWithoutCacheLookupOrAuthenticating()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            var staff = CreateStaffUser();
+            client.StaffOverrideAccount = staff;
+            client.UseProtectedTokenCache = true;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "expired-token",
+                AccessSecret = "expired-secret",
+                ExpirationDate = DateTime.Now.AddHours(-1)
+            };
+            SetCachedToken(client.Hostname, staff, new ProtectedToken
+            {
+                AccessToken = "cached-token",
+                AccessSecret = "cached-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            });
+
+            var token = client.Token;
+
+            Assert.IsNotNull(token);
+            Assert.AreEqual("expired-token", token.AccessToken);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenExistingTokenIsExpiredAndNoStaffOverrideAccount_ReturnsExistingTokenWithoutAuthenticating()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "expired-token",
+                AccessSecret = "expired-secret",
+                ExpirationDate = DateTime.Now.AddHours(-1)
+            };
+
+            var token = client.Token;
+
+            Assert.IsNotNull(token);
+            Assert.AreEqual("expired-token", token.AccessToken);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenCacheEnabledTokenNullAndNoStaffOverrideAccount_ReturnsNullWithoutThrowing()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.UseProtectedTokenCache = true;
+            client.StaffOverrideAccount = null;
+            client.Token = null;
+
+            var token = client.Token;
+
+            Assert.IsNull(token);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_ConcurrentProtectedRequestsForSameCacheKey_AuthenticateOnce()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateProtectedClient(handler);
+
+            var requests = Enumerable.Range(0, 8)
+                .Select(index => client.PatronSearchAsync($"name={index}"))
+                .ToArray();
+
+            await Task.WhenAll(requests);
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(8, handler.ProtectedRequestCount);
+            Assert.IsNotNull(client.Token);
+            Assert.AreEqual("protected-token", client.Token.AccessToken);
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_WithCachedValidToken_AvoidsStaffAuthentication()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateProtectedClient(handler);
+            SetCachedToken(client.Hostname, client.StaffOverrideAccount, new ProtectedToken
+            {
+                AccessToken = "cached-token",
+                AccessSecret = "cached-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            });
+
+            await client.PatronSearchAsync("name=Smith");
+
+            Assert.AreEqual(0, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual("cached-token", client.Token.AccessToken);
+        }
+
+        [TestMethod]
+        public async Task PatronAccountGetAsync_FailedStaffAuthentication_DoesNotPopulateProtectedTokenCache()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var client = CreateProtectedClient(handler);
+
+            var response = await client.PatronAccountGetAsync("ABC123");
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.IsNull(client.Token);
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+        }
+
+        [TestMethod]
+        public async Task PatronAccountGetAsync_NullDataStaffAuthentication_DoesNotPopulateProtectedTokenCache()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, "{}");
+            var client = CreateProtectedClient(handler);
+
+            var response = await client.PatronAccountGetAsync("ABC123");
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.IsNull(client.Token);
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_ManualToken_UsesProtectedAndPublicOverrideFormatting()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "manual-token",
+                AccessSecret = "manual-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            };
+
+            var publicRequest = (PapiRestRequest)client.PreformatRestRequest(new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/patron/ABC"));
+            var protectedRequest = (PapiRestRequest)client.PreformatRestRequest(new PapiRestRequest(HttpMethod.Get, "/protected/v1/1033/100/1/manual-token/search/patrons/Boolean"));
+
+            Assert.AreEqual("manual-token", publicRequest.Headers["X-PAPI-AccessToken"]);
+            Assert.IsTrue(publicRequest.Headers.ContainsKey("Authorization"));
+            Assert.IsFalse(protectedRequest.Headers.ContainsKey("X-PAPI-AccessToken"));
+            Assert.IsTrue(protectedRequest.Headers.ContainsKey("Authorization"));
+        }
+
+        private static PapiClient CreateClient(CapturingHttpMessageHandler handler)
+        {
+            var hostname = $"https://example-{Guid.NewGuid():N}.test";
+            var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri($"{hostname}/")
+            };
+
+            return new PapiClient(httpClient, null)
+            {
+                Hostname = hostname,
+                AccessID = "access-id",
+                AccessKey = "access-key",
+                UseProtectedTokenCache = false,
+                AllowStaffOverrideRequests = false
+            };
+        }
+
+        private static PapiClient CreateProtectedClient(ProtectedTokenHttpMessageHandler handler)
+        {
+            var hostname = $"https://example-{Guid.NewGuid():N}.test";
+            var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri($"{hostname}/")
+            };
+
+            return new PapiClient(httpClient, null)
+            {
+                Hostname = hostname,
+                AccessID = "access-id",
+                AccessKey = "access-key",
+                OrganizationId = 1,
+                UseProtectedTokenCache = true,
+                AllowStaffOverrideRequests = true,
+                StaffOverrideAccount = CreateStaffUser()
+            };
+        }
+
+        private static PolarisUser CreateStaffUser()
+        {
+            return new PolarisUser
+            {
+                Domain = "domain",
+                Username = "user",
+                Password = "password"
+            };
+        }
+
+        private static string CreateProtectedTokenJson(string accessToken, string accessSecret, DateTime expirationDate)
+        {
+            return
+                "{" +
+                $"\"PAPIErrorCode\":0," +
+                $"\"AccessToken\":\"{accessToken}\"," +
+                $"\"AccessSecret\":\"{accessSecret}\"," +
+                $"\"AuthExpDate\":\"{expirationDate:O}\"" +
+                "}";
+        }
+
+        private sealed class CapturingHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly string _responseJson;
+            private int _requestCount;
+
+            public int RequestCount => _requestCount;
+            public HttpRequestMessage? LastRequest { get; private set; }
+
+            public CapturingHttpMessageHandler(string? responseJson = null)
+            {
+                _responseJson = responseJson ?? CreateProtectedTokenJson("new-token", "new-secret", DateTime.UtcNow.AddHours(1));
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref _requestCount);
+                LastRequest = request;
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                });
+            }
+        }
+
+        private sealed class ProtectedTokenHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly HttpStatusCode _authenticationStatusCode;
+            private readonly string _authenticationResponseJson;
+            private int _authenticationRequestCount;
+            private int _protectedRequestCount;
+
+            public int AuthenticationRequestCount => _authenticationRequestCount;
+            public int ProtectedRequestCount => _protectedRequestCount;
+
+            public ProtectedTokenHttpMessageHandler(HttpStatusCode authenticationStatusCode = HttpStatusCode.OK, string? authenticationResponseJson = null)
+            {
+                _authenticationStatusCode = authenticationStatusCode;
+                _authenticationResponseJson = authenticationResponseJson ?? CreateProtectedTokenJson("protected-token", "protected-secret", DateTime.Now.AddHours(1));
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (request.RequestUri!.AbsolutePath.Contains("/authenticator/staff"))
+                {
+                    Interlocked.Increment(ref _authenticationRequestCount);
+                    await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+                    return new HttpResponseMessage(_authenticationStatusCode)
+                    {
+                        Content = new StringContent(_authenticationResponseJson, Encoding.UTF8, "application/json")
+                    };
+                }
+
+                Interlocked.Increment(ref _protectedRequestCount);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                };
+            }
+        }
+
+        private static void ClearProtectedTokenState()
+        {
+            var cache = GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache");
+            cache?.Clear();
+
+            var locks = GetPrivateStaticProperty<ConcurrentDictionary<string, SemaphoreSlim>>("ProtectedTokenCacheLocks");
+            locks?.Clear();
+        }
+
+        private static void SetCachedToken(string hostname, PolarisUser staffUser, ProtectedToken token)
+        {
+            var cache = GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache");
+            cache?.TryAdd(BuildCacheKey(hostname, staffUser), token);
+        }
+
+        private static bool TryGetCachedToken(string hostname, PolarisUser staffUser, out ProtectedToken? token)
+        {
+            token = null;
+            var cache = GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache");
+            return cache?.TryGetValue(BuildCacheKey(hostname, staffUser), out token) == true;
+        }
+
+        private static T? GetPrivateStaticProperty<T>(string propertyName) where T : class
+        {
+            var cacheProperty = typeof(PapiClient).GetProperty(propertyName, BindingFlags.NonPublic | BindingFlags.Static);
+            return cacheProperty?.GetValue(null) as T;
+        }
+
+        private static string BuildCacheKey(string hostname, PolarisUser staffUser)
+        {
+            return $"{hostname}|{staffUser.Domain}|{staffUser.Username}";
         }
     }
-
-    private static void ClearProtectedTokenCache()
-    {
-        var cacheProperty = typeof(PapiClient).GetProperty("ProtectedTokenCache", BindingFlags.NonPublic | BindingFlags.Static);
-        var cache = cacheProperty?.GetValue(null) as ConcurrentDictionary<string, ProtectedToken>;
-        cache?.Clear();
-    }
-
-    private static void SetCachedToken(string hostname, PolarisUser staffUser, ProtectedToken token)
-    {
-        var cacheProperty = typeof(PapiClient).GetProperty("ProtectedTokenCache", BindingFlags.NonPublic | BindingFlags.Static);
-        var cache = cacheProperty?.GetValue(null) as ConcurrentDictionary<string, ProtectedToken>;
-        cache?.TryAdd($"{hostname}{staffUser.Domain}{staffUser.Username}", token);
-    }
-}
 }


### PR DESCRIPTION
### Motivation

- Remove unsafe/mutable public token state and eliminate cache/network side effects from the `Token` getter.
- Ensure concurrent callers do not trigger duplicate staff-authentication requests for the same host/domain/username.
- Prevent caching of failed or incomplete staff-authentication responses.
- Make staff-auth POST behavior explicit and keep public staff authentication from unexpectedly mutating client token state.
- Add focused tests to validate cache, concurrency, failure, and manual-token semantics.

### Description

- Encapsulated protected-token state by making `_token` private and keeping `Token` as a simple read/write property with no cache or network side effects.
- Centralized protected-token cache key logic in `BuildProtectedTokenCacheKey()` and safe cache usage through `TryLoadProtectedTokenFromCache()`.
- Added per-cache-key async synchronization using `ProtectedTokenCacheLocks : ConcurrentDictionary<string, SemaphoreSlim>` so concurrent protected requests for the same staff account share one token-acquisition flow.
- Hardened `EnsureProtectedTokenAsync()` and `AuthenticateAndLoadProtectedTokenAsync()` to defensively handle null responses, missing `Response`, unsuccessful status codes, null token data, and expired/missing expiration dates.
- Successful internal protected-token acquisition still assigns `_token` and caches a copied token when `UseProtectedTokenCache` is enabled.
- Updated `AuthenticateStaffUserAsync()` so it only returns the staff-auth response and no longer mutates `Token` or `_token`.
- Renamed the private staff-auth POST helper to `ExecuteStaffAuthenticationPostAsync<T>` and documented that it intentionally bypasses `ExecutePapiAsync<T>` because staff authentication obtains the protected token.
- Expanded `PapiClientTokenTests` to cover:
  - side-effect-light `Token` getter behavior,
  - `AuthenticateStaffUserAsync` returning a token without setting client token state,
  - concurrent protected requests authenticating only once for the same cache key,
  - valid cached-token reuse,
  - failed/null/incomplete auth responses not populating the cache,
  - manually assigned `Token` still formatting protected/public override requests correctly.

### Testing

- Ran `dotnet restore src/polaris-api-csharp.sln` successfully.
- Ran `dotnet build src/polaris-api-csharp.sln --no-restore` successfully.
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"` successfully.
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory!=Integration"` successfully.