### PR TITLE
Use ExecutePapiAsync for staff authentication

### DIFF
--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -17,7 +17,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<ProtectedToken>> AuthenticateStaffUserAsync(PolarisUser staffUser, CancellationToken cancellationToken = default)
         {
             var url = "/protected/v1/1033/100/1/authenticator/staff";
-            return await ExecuteStaffAuthenticationPostAsync<ProtectedToken>(url, body: staffUser, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var request = new PapiRestRequest(HttpMethod.Post, url) { Body = staffUser };
+            return await ExecutePapiAsync<ProtectedToken>(request, cancellationToken, ProtectedTokenPreloadMode.Skip).ConfigureAwait(false);
         }
 
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -48,6 +48,12 @@ namespace Clc.Polaris.Api
 
         private ProtectedToken _token;
 
+        private enum ProtectedTokenPreloadMode
+        {
+            Auto,
+            Skip
+        }
+
         /// <summary>
         /// Used for protected methods and public method overrides
         /// </summary>
@@ -139,9 +145,13 @@ namespace Clc.Polaris.Api
         }
 
 
-        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
+        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(
+            PapiRestRequest request,
+            CancellationToken cancellationToken = default,
+            ProtectedTokenPreloadMode tokenPreloadMode = ProtectedTokenPreloadMode.Auto)
         {
-            if (request.AuthRequired &&
+            if (tokenPreloadMode == ProtectedTokenPreloadMode.Auto &&
+                request.AuthRequired &&
                 ((request.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(request.Password) && !request.BlockStaffOverride) || request.IsProtectedMethod))
             {
                 await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
@@ -239,11 +249,6 @@ namespace Clc.Polaris.Api
             return _token;
         }
 
-        private async Task<IRestResponse<T>> ExecuteStaffAuthenticationPostAsync<T>(string url, object body = null, CancellationToken cancellationToken = default)
-        {
-            // Staff authentication obtains the protected token, so this intentionally bypasses ExecutePapiAsync<T>.
-            return await ExecuteAsync<T>(new PapiRestRequest(HttpMethod.Post, url) { Body = body }, cancellationToken).ConfigureAwait(false);
-        }
 
         private string GetPAPIHash(string httpMethod, string date, string uri, string password)
         {

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -145,20 +145,18 @@ namespace Clc.Polaris.Api.Tests
         {
             var handler = new CapturingHttpMessageHandler(CreateProtectedTokenJson("returned-token", "returned-secret", DateTime.Now.AddHours(1)));
             var client = CreateClient(handler);
-            client.Token = new ProtectedToken
-            {
-                AccessToken = "existing-token",
-                AccessSecret = "existing-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
-            };
+            var staffUser = CreateStaffUser();
+            client.AllowStaffOverrideRequests = true;
+            client.UseProtectedTokenCache = true;
+            client.StaffOverrideAccount = staffUser;
 
-            var response = await client.AuthenticateStaffUserAsync(CreateStaffUser());
+            var response = await client.AuthenticateStaffUserAsync(staffUser);
 
             Assert.IsNotNull(response.Data);
             Assert.AreEqual("returned-token", response.Data.AccessToken);
-            Assert.IsNotNull(client.Token);
-            Assert.AreEqual("existing-token", client.Token.AccessToken);
+            Assert.IsNull(client.Token);
             Assert.AreEqual(1, handler.RequestCount);
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, staffUser, out _));
         }
 
         [TestMethod]


### PR DESCRIPTION
### Motivation
- Remove the one-off staff-auth helper and consolidate request execution paths by folding staff authentication into the main `ExecutePapiAsync` flow to simplify token handling. 
- Prevent recursive protected-token preloading when the client calls the staff-auth endpoint while preserving the existing protected-token acquisition semantics.

### Description
- Added a private enum `ProtectedTokenPreloadMode` with values `Auto` and `Skip` to `PapiClient` to control protected-token preloading. 
- Changed `ExecutePapiAsync<T>` signature to accept an optional `ProtectedTokenPreloadMode tokenPreloadMode` parameter (default `Auto`) and only call `EnsureProtectedTokenAsync` when `tokenPreloadMode == Auto` and the original auth/public/protected conditions are met, then always call `ExecuteAsync<T>` with `ConfigureAwait(false)`. 
- Removed the private `ExecuteStaffAuthenticationPostAsync<T>` helper and routed staff authentication in `AuthenticateStaffUserAsync` to build a `PapiRestRequest` for `"/protected/v1/1033/100/1/authenticator/staff"` and call `ExecutePapiAsync<ProtectedToken>(..., ProtectedTokenPreloadMode.Skip)` without mutating `Token` or `_token` and without writing to the protected-token cache. 
- Kept `EnsureProtectedTokenAsync` / `AuthenticateAndLoadProtectedTokenAsync` behavior intact so internal acquisition still calls `AuthenticateStaffUserAsync`, assigns `_token` and caches a copy on success, and preserves previous `_token` and avoids cache writes on failure/null responses. 
- Updated unit tests to assert that `AuthenticateStaffUserAsync` returns a token without changing `client.Token` or writing the cache, and kept the existing concurrency/cache tests that verify a single staff-auth call then protected request and proper token loading/caching.

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` then `dotnet build src/polaris-api-csharp.sln --no-restore` successfully. 
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"` and the filtered migration tests passed. 
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory!=Integration"` and the non-integration tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b26a8a2d4832386a02432443b154b)