### PR TITLE
Fold staff auth into ExecutePapiAsync with protected-token preload mode

### DIFF
--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -16,8 +16,12 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<ProtectedToken>> AuthenticateStaffUserAsync(PolarisUser staffUser, CancellationToken cancellationToken = default)
         {
-            var url = "/protected/v1/1033/100/1/authenticator/staff";
-            return await ExecuteStaffAuthenticationPostAsync<ProtectedToken>(url, body: staffUser, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var request = new PapiRestRequest(HttpMethod.Post, "/protected/v1/1033/100/1/authenticator/staff")
+            {
+                Body = staffUser
+            };
+
+            return await ExecutePapiAsync<ProtectedToken>(request, cancellationToken, ProtectedTokenPreloadMode.Skip).ConfigureAwait(false);
         }
 
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -139,9 +139,16 @@ namespace Clc.Polaris.Api
         }
 
 
-        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
+        private enum ProtectedTokenPreloadMode
         {
-            if (request.AuthRequired &&
+            Auto,
+            Skip
+        }
+
+        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default, ProtectedTokenPreloadMode tokenPreloadMode = ProtectedTokenPreloadMode.Auto)
+        {
+            if (tokenPreloadMode == ProtectedTokenPreloadMode.Auto &&
+                request.AuthRequired &&
                 ((request.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(request.Password) && !request.BlockStaffOverride) || request.IsProtectedMethod))
             {
                 await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
@@ -237,12 +244,6 @@ namespace Clc.Polaris.Api
             }
 
             return _token;
-        }
-
-        private async Task<IRestResponse<T>> ExecuteStaffAuthenticationPostAsync<T>(string url, object body = null, CancellationToken cancellationToken = default)
-        {
-            // Staff authentication obtains the protected token, so this intentionally bypasses ExecutePapiAsync<T>.
-            return await ExecuteAsync<T>(new PapiRestRequest(HttpMethod.Post, url) { Body = body }, cancellationToken).ConfigureAwait(false);
         }
 
         private string GetPAPIHash(string httpMethod, string date, string uri, string password)

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -159,6 +159,27 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(client.Token);
             Assert.AreEqual("existing-token", client.Token.AccessToken);
             Assert.AreEqual(1, handler.RequestCount);
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(HttpMethod.Post, handler.LastRequest.Method);
+            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
+            Assert.IsFalse(handler.LastRequest.Headers.Contains("X-PAPI-AccessToken"));
+        }
+
+        [TestMethod]
+        public async Task AuthenticateStaffUserAsync_WithStaffOverrideAccountAndNoToken_DoesNotRecursivelyAcquireProtectedToken()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateProtectedClient(handler);
+
+            var response = await client.AuthenticateStaffUserAsync(CreateStaffUser());
+
+            Assert.IsNotNull(response.Data);
+            Assert.AreEqual("protected-token", response.Data.AccessToken);
+            Assert.IsNull(client.Token);
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
         }
 
         [TestMethod]
@@ -210,6 +231,10 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual(1, handler.ProtectedRequestCount);
             Assert.IsNotNull(client.Token);
             Assert.AreEqual("protected-token", client.Token.AccessToken);
+            var paths = handler.RequestPaths;
+            Assert.AreEqual(2, paths.Length);
+            StringAssert.Contains(paths[0], "/protected/v1/1033/100/1/authenticator/staff");
+            StringAssert.Contains(paths[1], "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
             Assert.IsTrue(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out var cachedToken));
             Assert.IsNotNull(cachedToken);
             Assert.AreEqual("protected-token", cachedToken.AccessToken);
@@ -398,9 +423,11 @@ namespace Clc.Polaris.Api.Tests
             private readonly string _authenticationResponseJson;
             private int _authenticationRequestCount;
             private int _protectedRequestCount;
+            private readonly ConcurrentQueue<string> _requestPaths = new ConcurrentQueue<string>();
 
             public int AuthenticationRequestCount => _authenticationRequestCount;
             public int ProtectedRequestCount => _protectedRequestCount;
+            public string[] RequestPaths => _requestPaths.ToArray();
 
             public ProtectedTokenHttpMessageHandler(HttpStatusCode authenticationStatusCode = HttpStatusCode.OK, string? authenticationResponseJson = null)
             {
@@ -410,6 +437,8 @@ namespace Clc.Polaris.Api.Tests
 
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
+                _requestPaths.Enqueue(request.RequestUri!.AbsolutePath);
+
                 if (request.RequestUri!.AbsolutePath.Contains("/authenticator/staff"))
                 {
                     Interlocked.Increment(ref _authenticationRequestCount);


### PR DESCRIPTION
### Motivation
- Unify staff authentication with the normal PAPI execution path so staff auth uses `ExecutePapiAsync` rather than a one-off helper, while avoiding recursive protected-token acquisition. 
- Keep `AuthenticateStaffUserAsync` pure (it must return the auth response without mutating client `Token` or writing cache state). 

### Description
- Added a private `ProtectedTokenPreloadMode` enum with values `Auto` and `Skip` to `PapiClient` and kept it private. 
- Updated `ExecutePapiAsync<T>` to accept an optional `ProtectedTokenPreloadMode tokenPreloadMode = ProtectedTokenPreloadMode.Auto` parameter and only call `EnsureProtectedTokenAsync` when `tokenPreloadMode == Auto` and the existing auth conditions apply, while always delegating to `ExecuteAsync<T>(request, cancellationToken)` and preserving `ConfigureAwait(false)`. 
- Removed the private `ExecuteStaffAuthenticationPostAsync<T>` helper and now implement `AuthenticateStaffUserAsync` by building a `PapiRestRequest` for the staff authenticator endpoint and calling `ExecutePapiAsync<ProtectedToken>(..., ProtectedTokenPreloadMode.Skip)`. 
- Kept internal token acquisition flows intact: `EnsureProtectedTokenAsync` / `AuthenticateAndLoadProtectedTokenAsync` continue to call `AuthenticateStaffUserAsync`, assign `_token` and cache a copied token on success, and preserve prior token / avoid cache writes on failure/null data. 
- Extended tests in `PapiClientTokenTests` to assert that staff auth returns a token without mutating `client.Token`, that staff auth request formatting includes `PolarisDate` and `Authorization` but not `X-PAPI-AccessToken`, that staff auth does not trigger recursive token acquisition, and that a protected request with no cached token performs exactly one staff-auth request followed by the protected request (request-paths captured). 

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` which completed successfully. 
- Ran `dotnet build src/polaris-api-csharp.sln --no-restore` which completed successfully. 
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"` and all targeted tests passed. 
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory!=Integration"` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b26a8a2d4832386a02432443b154b)