### PR TITLE
Fold staff-auth into ExecutePapiAsync with ProtectedToken preload mode

### DIFF
--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -16,8 +16,12 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<ProtectedToken>> AuthenticateStaffUserAsync(PolarisUser staffUser, CancellationToken cancellationToken = default)
         {
-            var url = "/protected/v1/1033/100/1/authenticator/staff";
-            return await ExecuteStaffAuthenticationPostAsync<ProtectedToken>(url, body: staffUser, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var request = new PapiRestRequest(HttpMethod.Post, "/protected/v1/1033/100/1/authenticator/staff")
+            {
+                Body = staffUser
+            };
+
+            return await ExecutePapiAsync<ProtectedToken>(request, cancellationToken, ProtectedTokenPreloadMode.Skip).ConfigureAwait(false);
         }
 
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -139,9 +139,19 @@ namespace Clc.Polaris.Api
         }
 
 
-        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
+        private enum ProtectedTokenPreloadMode
         {
-            if (request.AuthRequired &&
+            Auto,
+            Skip
+        }
+
+        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(
+            PapiRestRequest request,
+            CancellationToken cancellationToken = default,
+            ProtectedTokenPreloadMode protectedTokenPreloadMode = ProtectedTokenPreloadMode.Auto)
+        {
+            if (protectedTokenPreloadMode == ProtectedTokenPreloadMode.Auto &&
+                request.AuthRequired &&
                 ((request.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(request.Password) && !request.BlockStaffOverride) || request.IsProtectedMethod))
             {
                 await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
@@ -237,12 +247,6 @@ namespace Clc.Polaris.Api
             }
 
             return _token;
-        }
-
-        private async Task<IRestResponse<T>> ExecuteStaffAuthenticationPostAsync<T>(string url, object body = null, CancellationToken cancellationToken = default)
-        {
-            // Staff authentication obtains the protected token, so this intentionally bypasses ExecutePapiAsync<T>.
-            return await ExecuteAsync<T>(new PapiRestRequest(HttpMethod.Post, url) { Body = body }, cancellationToken).ConfigureAwait(false);
         }
 
         private string GetPAPIHash(string httpMethod, string date, string uri, string password)

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -145,20 +145,20 @@ namespace Clc.Polaris.Api.Tests
         {
             var handler = new CapturingHttpMessageHandler(CreateProtectedTokenJson("returned-token", "returned-secret", DateTime.Now.AddHours(1)));
             var client = CreateClient(handler);
-            client.Token = new ProtectedToken
-            {
-                AccessToken = "existing-token",
-                AccessSecret = "existing-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
-            };
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = CreateStaffUser();
 
             var response = await client.AuthenticateStaffUserAsync(CreateStaffUser());
 
             Assert.IsNotNull(response.Data);
             Assert.AreEqual("returned-token", response.Data.AccessToken);
-            Assert.IsNotNull(client.Token);
-            Assert.AreEqual("existing-token", client.Token.AccessToken);
+            Assert.IsNull(client.Token);
             Assert.AreEqual(1, handler.RequestCount);
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("/PAPIService/REST/protected/v1/1033/100/1/authenticator/staff", handler.LastRequest.RequestUri!.AbsolutePath);
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
+            Assert.IsFalse(handler.LastRequest.Headers.Contains("X-PAPI-AccessToken"));
         }
 
         [TestMethod]
@@ -208,6 +208,13 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.ProtectedRequestCount);
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "/PAPIService/REST/protected/v1/1033/100/1/authenticator/staff",
+                    "/PAPIService/REST/protected/v1/1033/100/1/protected-token/search/patrons/Boolean"
+                },
+                handler.RequestPaths.ToArray());
             Assert.IsNotNull(client.Token);
             Assert.AreEqual("protected-token", client.Token.AccessToken);
             Assert.IsTrue(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out var cachedToken));
@@ -401,6 +408,7 @@ namespace Clc.Polaris.Api.Tests
 
             public int AuthenticationRequestCount => _authenticationRequestCount;
             public int ProtectedRequestCount => _protectedRequestCount;
+            public ConcurrentQueue<string> RequestPaths { get; } = new ConcurrentQueue<string>();
 
             public ProtectedTokenHttpMessageHandler(HttpStatusCode authenticationStatusCode = HttpStatusCode.OK, string? authenticationResponseJson = null)
             {
@@ -410,6 +418,8 @@ namespace Clc.Polaris.Api.Tests
 
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
+                RequestPaths.Enqueue(request.RequestUri!.AbsolutePath);
+
                 if (request.RequestUri!.AbsolutePath.Contains("/authenticator/staff"))
                 {
                     Interlocked.Increment(ref _authenticationRequestCount);


### PR DESCRIPTION
### Motivation
- Prevent a one-off staff-auth code path and avoid recursive protected-token preloading by routing staff authentication through the central PAPI execution flow.
- Provide an internal switch so normal requests still preload protected tokens but staff-auth can explicitly skip that preload.
- Preserve existing protected-token acquisition, caching, and no-client-mutation semantics for staff-auth responses.

### Description
- Add a private `ProtectedTokenPreloadMode` enum with values `Auto` and `Skip` to `PapiClient` and keep it private to the client implementation.
- Extend `ExecutePapiAsync<T>` with an optional `protectedTokenPreloadMode` parameter defaulting to `Auto`, and only call `EnsureProtectedTokenAsync` when `Auto` and the existing auth/public/protected conditions hold; the request always runs via `ExecuteAsync<T>(request, cancellationToken)` with `ConfigureAwait(false)` preserved.
- Remove the one-off helper `ExecuteStaffAuthenticationPostAsync<T>` and update `AuthenticateStaffUserAsync` to build a `PapiRestRequest` for `/protected/v1/1033/100/1/authenticator/staff` and call `ExecutePapiAsync<ProtectedToken>(..., ProtectedTokenPreloadMode.Skip)` so staff-auth does not trigger protected-token preload or mutate `Token`.
- Keep internal acquisition behavior intact: `EnsureProtectedTokenAsync` / `AuthenticateAndLoadProtectedTokenAsync` still call `AuthenticateStaffUserAsync`, restore the previous `_token` on failure, and copy/cache the new token on success when `UseProtectedTokenCache` is enabled.
- Update tests to assert that `AuthenticateStaffUserAsync` returns a token without setting `client.Token`, that the PAPI headers are applied (no `X-PAPI-AccessToken` for staff auth), and that an uncached protected request performs exactly one staff-authentication request followed by the protected request and then loads/caches the protected token.

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` which completed successfully.
- Ran `dotnet build src/polaris-api-csharp.sln --no-restore` which completed successfully.
- Ran unit tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"` which passed.
- Ran unit tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory!=Integration"` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b26a8a2d4832386a02432443b154b)