### PR TITLE
Fold staff auth into ExecutePapiAsync with protected-token preload mode

### DIFF
--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -17,7 +17,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<ProtectedToken>> AuthenticateStaffUserAsync(PolarisUser staffUser, CancellationToken cancellationToken = default)
         {
             var url = "/protected/v1/1033/100/1/authenticator/staff";
-            return await ExecuteStaffAuthenticationPostAsync<ProtectedToken>(url, body: staffUser, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var request = new PapiRestRequest(HttpMethod.Post, url) { Body = staffUser };
+            return await ExecutePapiAsync<ProtectedToken>(request, cancellationToken, ProtectedTokenPreloadMode.Skip).ConfigureAwait(false);
         }
 
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -139,9 +139,16 @@ namespace Clc.Polaris.Api
         }
 
 
-        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
+        private enum ProtectedTokenPreloadMode
         {
-            if (request.AuthRequired &&
+            Auto,
+            Skip
+        }
+
+        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default, ProtectedTokenPreloadMode tokenPreloadMode = ProtectedTokenPreloadMode.Auto)
+        {
+            if (tokenPreloadMode == ProtectedTokenPreloadMode.Auto &&
+                request.AuthRequired &&
                 ((request.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(request.Password) && !request.BlockStaffOverride) || request.IsProtectedMethod))
             {
                 await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
@@ -237,12 +244,6 @@ namespace Clc.Polaris.Api
             }
 
             return _token;
-        }
-
-        private async Task<IRestResponse<T>> ExecuteStaffAuthenticationPostAsync<T>(string url, object body = null, CancellationToken cancellationToken = default)
-        {
-            // Staff authentication obtains the protected token, so this intentionally bypasses ExecutePapiAsync<T>.
-            return await ExecuteAsync<T>(new PapiRestRequest(HttpMethod.Post, url) { Body = body }, cancellationToken).ConfigureAwait(false);
         }
 
         private string GetPAPIHash(string httpMethod, string date, string uri, string password)

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -141,15 +141,17 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
-        public async Task AuthenticateStaffUserAsync_ReturnsTokenButDoesNotSetClientToken()
+        public async Task AuthenticateStaffUserAsync_ReturnsTokenButDoesNotSetClientTokenOrRecursivelyAuthenticate()
         {
             var handler = new CapturingHttpMessageHandler(CreateProtectedTokenJson("returned-token", "returned-secret", DateTime.Now.AddHours(1)));
             var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = CreateStaffUser();
             client.Token = new ProtectedToken
             {
                 AccessToken = "existing-token",
                 AccessSecret = "existing-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = DateTime.Now.AddHours(-1)
             };
 
             var response = await client.AuthenticateStaffUserAsync(CreateStaffUser());


### PR DESCRIPTION
### Motivation
- Consolidate staff authentication through the central PAPI execution path to remove a one-off helper and prevent recursive protected-token preloading during staff-auth.
- Allow ExecutePapiAsync to opt out of automatic protected-token acquisition for the staff-auth case while preserving existing public behavior.

### Description
- Add a private `ProtectedTokenPreloadMode` enum (`Auto`, `Skip`) to `PapiClient` to control protected-token preloading.
- Extend `ExecutePapiAsync<T>` with an optional private `tokenPreloadMode` parameter defaulting to `Auto`, and only call `EnsureProtectedTokenAsync` when mode is `Auto`, `request.AuthRequired` is true, and the existing public/protected override conditions are met; always call `ExecuteAsync<T>(...)` and keep `ConfigureAwait(false)`.
- Remove the private `ExecuteStaffAuthenticationPostAsync<T>` helper and route staff authentication through `ExecutePapiAsync` instead. 
- Update `AuthenticateStaffUserAsync` to create a `PapiRestRequest` for `/protected/v1/1033/100/1/authenticator/staff` and execute it with `ExecutePapiAsync<ProtectedToken>(..., ProtectedTokenPreloadMode.Skip)` without mutating `Token` or the protected-token cache.
- Preserve internal acquisition semantics: `EnsureProtectedTokenAsync` / `AuthenticateAndLoadProtectedTokenAsync` still call `AuthenticateStaffUserAsync`, and successful acquisitions still assign `_token` and write a copied token to the cache when enabled while failure preserves the previous token and avoids cache writes.

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` and `dotnet build src/polaris-api-csharp.sln --no-restore` successfully.
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"` and the filtered suite passed (39 tests passed).
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory!=Integration"` and the non-integration suite passed (64 tests passed).
- Updated token-focused tests to assert that `AuthenticateStaffUserAsync` returns a token response, does not set `client.Token`, and executes without triggering recursive acquisition, and existing token/cache/concurrency tests remain passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b26a8a2d4832386a02432443b154b)