### PR TITLE
Add ProtectedToken.Placeholder and centralize protected-token path handling

### DIFF
--- a/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
+++ b/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<CreatePatronBlocksResult>> CreatePatronBlocksAsync(string barcode, BlockType blockType, string blockValue, int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/blocks";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/blocks";
             var body = new CreatePatronBlocksRequest((int)blockType, blockValue);
             var request = new PapiRestRequest(HttpMethod.Post, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
@@ -14,8 +14,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<HoldRequestGetListResult>> HoldRequestGetListAsync(int branchId, RequestListBranchType branchType = RequestListBranchType.PickupBranch, HoldStatus status = HoldStatus.Held, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/circulation/requests/list";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/circulation/requests/list";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("branch", branchId);
             request.QueryParameters.Add("branchtype", (int)branchType);

--- a/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
+++ b/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
@@ -13,8 +13,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<PapiResponseCommon>> ItemUpdateBarcodeAsync(string newBarcode, int? itemRecordId = null, int? transactionBranchId = null, string oldBarcode = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/cataloging/items/{(itemRecordId.HasValue ? itemRecordId.Value.ToString() : oldBarcode)}/barcode";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/cataloging/items/{(itemRecordId.HasValue ? itemRecordId.Value.ToString() : oldBarcode)}/barcode";
             var body = new ItemUpdateBarcodeData { ItemBarcode = newBarcode, TransactionBranchId = transactionBranchId ?? OrganizationId };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", transactionBranchId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
+++ b/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
@@ -13,8 +13,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PapiResponseCommon>> NotificationQueueGetAsync(int orgId = 1, CancellationToken cancellationToken = default)
         {
             //"protected/{Version}/{LangID}/{AppID}/{OrgID}/{AccessToken}/notification
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/24/{orgId}/{Token.AccessToken}/notification/";
+            var url = $"/protected/v1/1033/24/{orgId}/{ProtectedToken.Placeholder}/notification/";
             var request = new PapiRestRequest(url);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/NotificationUpdate.cs
+++ b/src/polaris-api-csharp/Methods/NotificationUpdate.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<NotificationUpdateResult>> NotificationUpdateAsync(NotificationUpdateParams updateParams, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/notification/{updateParams.NotificationTypeId}";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/notification/{updateParams.NotificationTypeId}";
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = updateParams };
             return await ExecutePapiAsync<NotificationUpdateResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountCreateCreditAsync(string barcode, double txnAmount, PaymentMethod paymentMethod, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/createcredit";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/createcredit";
             var body = new PatronAccountCreateCreditData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountDepositCreditAsync(string barcode, double txnAmount, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumdepositcredit";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumdepositcredit";
             var body = new PatronAccountDepositCreditData { TxnAmount = txnAmount, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountPay.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPay.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountPayAsync(string barcode, int txnId, double txnAmount, PaymentMethod paymentMethod, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/{txnId}/pay";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/{txnId}/pay";
             var body = new PatronAccountPayData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountPayAllAsync(string barcode, double txnAmount, PaymentMethod paymentMethod, int? workstationId = 1, int? userId = 1, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumpayment";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumpayment";
             var body = new PatronAccountPayData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountRefundCreditAsync(string barcode, double txnAmount, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumrefundcredit";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumrefundcredit";
             var body = new PatronAccountRefundCreditData { TxnAmount = txnAmount, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountVoidAsync(string barcode, int paymentTxnId, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/{paymentTxnId}/void/payment";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/{paymentTxnId}/void/payment";
             var request = new PapiRestRequest(HttpMethod.Delete, url);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);

--- a/src/polaris-api-csharp/Methods/PatronRenewBlocksGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronRenewBlocksGet.cs
@@ -15,8 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronRenewBlocksResult>> PatronRenewBlocksGetAsync(int patronId, int? branchId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/{branchId ?? OrganizationId}/{Token.AccessToken}/circulation/patron/{patronId}/renewblocks";
+            var url = $"/protected/v1/1033/100/{branchId ?? OrganizationId}/{ProtectedToken.Placeholder}/circulation/patron/{patronId}/renewblocks";
             var request = new PapiRestRequest(url);
             return await ExecutePapiAsync<PatronRenewBlocksResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronSearch.cs
+++ b/src/polaris-api-csharp/Methods/PatronSearch.cs
@@ -12,8 +12,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronSearchResult>> PatronSearchAsync(string query, int page = 1, int pageSize = 10, PatronSortKeys sortBy = PatronSortKeys.PATN, int? orgId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/{orgId ?? OrganizationId}/{Token.AccessToken}/search/patrons/Boolean";
+            var url = $"/protected/v1/1033/100/{orgId ?? OrganizationId}/{ProtectedToken.Placeholder}/search/patrons/Boolean";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("q", query);
             request.QueryParameters.Add("patronsperpage", pageSize);

--- a/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
+++ b/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
@@ -13,8 +13,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<GetBarcodeAndPatronIDResult>> Patron_GetBarcodeFromIdAsync(int patronId, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/barcode";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/barcode";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("patronid", patronId);
             return await ExecutePapiAsync<GetBarcodeAndPatronIDResult>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> RecordSetContentPutAsync(int recordSetId, IEnumerable<int> records, RecordSetContentPutActions action, int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/recordsets/{recordSetId}";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/recordsets/{recordSetId}";
             var body = new { records = string.Join(",", records) };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("action", action);

--- a/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<RecordSetRecordsGetResult>> RecordSetRecordsGetAsync(int recordSetId, int userId = 1, int workstationId = 1, int startIndex = 0, int numRecords = 1000, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/recordsets/{recordSetId}/records";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/recordsets/{recordSetId}/records";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("startIndex", startIndex);
             request.QueryParameters.Add("numRecords", numRecords);

--- a/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
+++ b/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
@@ -15,8 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<RemoteStorageItemsGetResult>> RemoteStorageItemsGetAsync(int branchId, string startDate, string endDate, int maxItems, int listType, int? startItemRecordId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/cataloging/remotestorage/items";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/cataloging/remotestorage/items";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("branch", branchId);
             request.QueryParameters.Add("startdate", startDate);

--- a/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
+++ b/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
@@ -22,8 +22,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<StringResult>> SA_GetValueByOrgAsync(string attribute, int? organizationId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/organization/{organizationId ?? OrganizationId}/sysadmin/attribute/{attribute}";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/organization/{organizationId ?? OrganizationId}/sysadmin/attribute/{attribute}";
             var request = new PapiRestRequest(url);
             return await ExecutePapiAsync<StringResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
+++ b/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
@@ -14,8 +14,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<Sync_BibsByIdGetResult>> Synch_BibsByIdGetAsync(int[] bibIds, bool includeItems = false, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/synch/bibs/MARCxml";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/synch/bibs/MARCxml";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("bibids", string.Join(",", bibIds));
             if (includeItems)

--- a/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<PapiResponseCommon>> UpdatePatronNotesDataAsync(string barcode, string nonBlockingNote = null, string blockingNote = null, UpdateNoteMode updateMode = UpdateNoteMode.Prepend, int? workstationId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/notes";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/notes";
             var body = new UpdatePatronNotesData();
 
             if (!string.IsNullOrWhiteSpace(nonBlockingNote))

--- a/src/polaris-api-csharp/Models/ProtectedToken.cs
+++ b/src/polaris-api-csharp/Models/ProtectedToken.cs
@@ -15,6 +15,8 @@ namespace Clc.Polaris.Api.Models
     [XmlRoot(ElementName = "AuthenticationResult")]
     public class ProtectedToken : PapiResponseCommon
     {
+        public const string Placeholder = "__PAPI_PROTECTED_ACCESS_TOKEN__";
+
         /// <summary>
         /// Access token
         /// </summary>

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -147,14 +147,42 @@ namespace Clc.Polaris.Api
 
         private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default, ProtectedTokenPreloadMode tokenPreloadMode = ProtectedTokenPreloadMode.Auto)
         {
+            var pathContainsProtectedTokenPlaceholder = PathContainsProtectedTokenPlaceholder(request);
+
             if (tokenPreloadMode == ProtectedTokenPreloadMode.Auto &&
-                request.AuthRequired &&
-                ((request.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(request.Password) && !request.BlockStaffOverride) || request.IsProtectedMethod))
+                (pathContainsProtectedTokenPlaceholder ||
+                 (request.AuthRequired &&
+                  ((request.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(request.Password) && !request.BlockStaffOverride) || request.IsProtectedMethod))))
             {
                 await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
             }
 
+            if (pathContainsProtectedTokenPlaceholder)
+            {
+                ReplaceProtectedTokenPlaceholder(request);
+            }
+
             return await ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static bool PathContainsProtectedTokenPlaceholder(PapiRestRequest request)
+        {
+            return request?.Path?.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) >= 0;
+        }
+
+        private void ReplaceProtectedTokenPlaceholder(PapiRestRequest request)
+        {
+            if (!PathContainsProtectedTokenPlaceholder(request))
+            {
+                return;
+            }
+
+            if (IsProtectedTokenMissingOrExpired(Token) || string.IsNullOrWhiteSpace(Token.AccessToken))
+            {
+                throw new InvalidOperationException($"Cannot execute a PAPI request whose path contains {nameof(ProtectedToken)}.{nameof(ProtectedToken.Placeholder)} without a valid protected access token.");
+            }
+
+            request.Path = request.Path.Replace(ProtectedToken.Placeholder, Token.AccessToken, StringComparison.Ordinal);
         }
 
         private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -312,6 +313,101 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public void ProtectedToken_Placeholder_HasExpectedSentinelValue()
+        {
+            Assert.AreEqual("__PAPI_PROTECTED_ACCESS_TOKEN__", ProtectedToken.Placeholder);
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_WithPlaceholderPath_SendsRealAccessTokenAndNeverPlaceholder()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateProtectedClient(handler);
+
+            await client.PatronSearchAsync("name=Smith");
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            var protectedRequestPath = handler.ProtectedRequestPaths.Single();
+            StringAssert.Contains(protectedRequestPath, "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
+            Assert.IsFalse(protectedRequestPath.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
+            Assert.IsFalse(handler.RequestPaths.Any(path => path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal)));
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_WithPlaceholderPath_ComputesAuthorizationHashWithReplacedUrl()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateProtectedClient(handler);
+
+            await client.PatronSearchAsync("name=Smith");
+
+            Assert.IsNotNull(handler.LastProtectedAuthorization);
+            Assert.IsNotNull(handler.LastProtectedPolarisDate);
+            Assert.IsNotNull(handler.LastProtectedPathAndQuery);
+            var replacedRequest = CreatePatronSearchRequest("protected-token");
+            var placeholderRequest = CreatePatronSearchRequest(ProtectedToken.Placeholder);
+            var replacedHashUrl = BuildUrlForPapiHash(client, replacedRequest);
+            var placeholderHashUrl = BuildUrlForPapiHash(client, placeholderRequest);
+            var expectedAuthorization = BuildAuthorizationHeader(client.AccessID, client.AccessKey, HttpMethod.Get.Method, replacedHashUrl, handler.LastProtectedPolarisDate!, "protected-secret");
+            var placeholderAuthorization = BuildAuthorizationHeader(client.AccessID, client.AccessKey, HttpMethod.Get.Method, placeholderHashUrl, handler.LastProtectedPolarisDate!, "protected-secret");
+
+            Assert.AreEqual(expectedAuthorization, handler.LastProtectedAuthorization);
+            Assert.AreNotEqual(placeholderAuthorization, handler.LastProtectedAuthorization);
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_WithPlaceholderPathAndNoCachedToken_AcquiresProtectedTokenAutomatically()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateProtectedClient(handler);
+
+            await client.PatronSearchAsync("name=Smith");
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.IsNotNull(client.Token);
+            Assert.AreEqual("protected-token", client.Token.AccessToken);
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_WithPlaceholderPathAndCachedToken_UsesCachedProtectedTokenForReplacement()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateProtectedClient(handler);
+            SetCachedToken(client.Hostname, client.StaffOverrideAccount, new ProtectedToken
+            {
+                AccessToken = "cached-token",
+                AccessSecret = "cached-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            });
+
+            await client.PatronSearchAsync("name=Smith");
+
+            Assert.AreEqual(0, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual("cached-token", client.Token.AccessToken);
+            var protectedRequestPath = handler.ProtectedRequestPaths.Single();
+            StringAssert.Contains(protectedRequestPath, "/protected/v1/1033/100/1/cached-token/search/patrons/Boolean");
+            Assert.IsFalse(protectedRequestPath.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_WithPlaceholderPathAndSkipPreload_FailsClearlyAndDoesNotSendPlaceholder()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateProtectedClient(handler);
+            var request = new PapiRestRequest($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/search/patrons/Boolean");
+
+            var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => ExecutePapiWithSkipAsync<PapiResponseCommon>(client, request));
+
+            StringAssert.Contains(exception.Message, nameof(ProtectedToken.Placeholder));
+            Assert.AreEqual(0, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.IsFalse(handler.RequestPaths.Any(path => path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal)));
+        }
+
+        [TestMethod]
         public void PreformatRestRequest_ManualToken_UsesProtectedAndPublicOverrideFormatting()
         {
             var handler = new CapturingHttpMessageHandler();
@@ -424,10 +520,15 @@ namespace Clc.Polaris.Api.Tests
             private int _authenticationRequestCount;
             private int _protectedRequestCount;
             private readonly ConcurrentQueue<string> _requestPaths = new ConcurrentQueue<string>();
+            private readonly ConcurrentQueue<string> _protectedRequestPaths = new ConcurrentQueue<string>();
 
             public int AuthenticationRequestCount => _authenticationRequestCount;
             public int ProtectedRequestCount => _protectedRequestCount;
             public string[] RequestPaths => _requestPaths.ToArray();
+            public string[] ProtectedRequestPaths => _protectedRequestPaths.ToArray();
+            public string? LastProtectedAuthorization { get; private set; }
+            public string? LastProtectedPolarisDate { get; private set; }
+            public string? LastProtectedPathAndQuery { get; private set; }
 
             public ProtectedTokenHttpMessageHandler(HttpStatusCode authenticationStatusCode = HttpStatusCode.OK, string? authenticationResponseJson = null)
             {
@@ -450,11 +551,50 @@ namespace Clc.Polaris.Api.Tests
                 }
 
                 Interlocked.Increment(ref _protectedRequestCount);
+                _protectedRequestPaths.Enqueue(request.RequestUri!.AbsolutePath);
+                LastProtectedPathAndQuery = request.RequestUri!.PathAndQuery;
+                LastProtectedAuthorization = request.Headers.TryGetValues("Authorization", out var authorizationValues) ? authorizationValues.SingleOrDefault() : null;
+                LastProtectedPolarisDate = request.Headers.TryGetValues("PolarisDate", out var dateValues) ? dateValues.SingleOrDefault() : null;
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
                 };
             }
+        }
+
+        private static PapiRestRequest CreatePatronSearchRequest(string accessTokenPathSegment)
+        {
+            var request = new PapiRestRequest($"/protected/v1/1033/100/1/{accessTokenPathSegment}/search/patrons/Boolean");
+            request.QueryParameters.Add("q", "name=Smith");
+            request.QueryParameters.Add("patronsperpage", 10);
+            request.QueryParameters.Add("page", 1);
+            request.QueryParameters.Add("sort", PatronSortKeys.PATN);
+            return request;
+        }
+
+        private static string BuildUrlForPapiHash(PapiClient client, PapiRestRequest request)
+        {
+            var buildUrlForPapiHashMethod = typeof(PapiClient).GetMethod("BuildUrlForPapiHash", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(buildUrlForPapiHashMethod);
+            return (string)buildUrlForPapiHashMethod!.Invoke(client, new object[] { request })!;
+        }
+
+        private static async Task ExecutePapiWithSkipAsync<T>(PapiClient client, PapiRestRequest request)
+        {
+            var preloadModeType = typeof(PapiClient).GetNestedType("ProtectedTokenPreloadMode", BindingFlags.NonPublic);
+            Assert.IsNotNull(preloadModeType);
+            var skipPreload = Enum.Parse(preloadModeType!, "Skip");
+            var executeMethod = typeof(PapiClient).GetMethod("ExecutePapiAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(executeMethod);
+            var task = (Task)executeMethod!.MakeGenericMethod(typeof(T)).Invoke(client, new object[] { request, CancellationToken.None, skipPreload })!;
+            await task.ConfigureAwait(false);
+        }
+
+        private static string BuildAuthorizationHeader(string accessId, string accessKey, string httpMethod, string uri, string date, string password)
+        {
+            var hashString = httpMethod + uri + date + password;
+            var computedHash = new HMACSHA1(Encoding.UTF8.GetBytes(accessKey)).ComputeHash(Encoding.UTF8.GetBytes(hashString));
+            return $"PWS {accessId}:{Convert.ToBase64String(computedHash)}";
         }
 
         private static void ClearProtectedTokenState()


### PR DESCRIPTION
### Motivation
- Some PAPI endpoints required embedding the protected token into the URL path and were preloading the token ad-hoc; the goal is to centralize insertion of the protected access token and avoid per-method token preloads. 
- Introduce an explicit sentinel placeholder so methods can request replacement without owning acquisition logic. 

### Description
- Add `public const string Placeholder = "__PAPI_PROTECTED_ACCESS_TOKEN__";` to `ProtectedToken` as the canonical sentinel value. 
- Add helper logic in `PapiClient`: `PathContainsProtectedTokenPlaceholder(PapiRestRequest)` to detect the placeholder and `ReplaceProtectedTokenPlaceholder(PapiRestRequest)` to replace only `request.Path` (using `StringComparison.Ordinal`) and throw a clear `InvalidOperationException` if no valid token is available. 
- Update `ExecutePapiAsync` to detect placeholder usage, trigger `EnsureProtectedTokenAsync` when `ProtectedTokenPreloadMode` is `Auto` (or when existing public/protected preload conditions apply), perform placeholder replacement before `ExecuteAsync`, and preserve `Skip` semantics by failing when a placeholder is present under `Skip`. 
- Convert protected-token-in-path methods to use `ProtectedToken.Placeholder` instead of manually calling `EnsureProtectedTokenAsync` and interpolating `Token.AccessToken` (multiple `Methods/*.cs` files updated). 
- Add focused tests and test harness changes in `PapiClientTokenTests` to verify: placeholder sentinel value, that requests never send the literal placeholder, Authorization hash is computed with the replaced URL, automatic acquisition and cached replacement behavior, and that `Skip` preload mode fails clearly without sending the placeholder. 

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` and `dotnet build src/polaris-api-csharp.sln --no-restore` successfully. 
- Ran unit tests targeting the migration category with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"` and all tests passed. 
- Ran the rest of the test suite with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory!=Integration"` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b2fc4d65c8323b40f0eca3f53c0b5)