### PR TITLE
Add ProtectedToken.Placeholder and centralize protected-token path replacement in ExecutePapiAsync

### DIFF
--- a/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
+++ b/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<CreatePatronBlocksResult>> CreatePatronBlocksAsync(string barcode, BlockType blockType, string blockValue, int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/blocks";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/blocks";
             var body = new CreatePatronBlocksRequest((int)blockType, blockValue);
             var request = new PapiRestRequest(HttpMethod.Post, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
@@ -14,8 +14,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<HoldRequestGetListResult>> HoldRequestGetListAsync(int branchId, RequestListBranchType branchType = RequestListBranchType.PickupBranch, HoldStatus status = HoldStatus.Held, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/circulation/requests/list";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/circulation/requests/list";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("branch", branchId);
             request.QueryParameters.Add("branchtype", (int)branchType);

--- a/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
+++ b/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
@@ -13,8 +13,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<PapiResponseCommon>> ItemUpdateBarcodeAsync(string newBarcode, int? itemRecordId = null, int? transactionBranchId = null, string oldBarcode = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/cataloging/items/{(itemRecordId.HasValue ? itemRecordId.Value.ToString() : oldBarcode)}/barcode";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/cataloging/items/{(itemRecordId.HasValue ? itemRecordId.Value.ToString() : oldBarcode)}/barcode";
             var body = new ItemUpdateBarcodeData { ItemBarcode = newBarcode, TransactionBranchId = transactionBranchId ?? OrganizationId };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", transactionBranchId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
+++ b/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
@@ -13,8 +13,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PapiResponseCommon>> NotificationQueueGetAsync(int orgId = 1, CancellationToken cancellationToken = default)
         {
             //"protected/{Version}/{LangID}/{AppID}/{OrgID}/{AccessToken}/notification
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/24/{orgId}/{Token.AccessToken}/notification/";
+            var url = $"/protected/v1/1033/24/{orgId}/{ProtectedToken.Placeholder}/notification/";
             var request = new PapiRestRequest(url);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/NotificationUpdate.cs
+++ b/src/polaris-api-csharp/Methods/NotificationUpdate.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<NotificationUpdateResult>> NotificationUpdateAsync(NotificationUpdateParams updateParams, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/notification/{updateParams.NotificationTypeId}";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/notification/{updateParams.NotificationTypeId}";
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = updateParams };
             return await ExecutePapiAsync<NotificationUpdateResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountCreateCreditAsync(string barcode, double txnAmount, PaymentMethod paymentMethod, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/createcredit";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/createcredit";
             var body = new PatronAccountCreateCreditData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountDepositCreditAsync(string barcode, double txnAmount, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumdepositcredit";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumdepositcredit";
             var body = new PatronAccountDepositCreditData { TxnAmount = txnAmount, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountPay.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPay.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountPayAsync(string barcode, int txnId, double txnAmount, PaymentMethod paymentMethod, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/{txnId}/pay";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/{txnId}/pay";
             var body = new PatronAccountPayData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountPayAllAsync(string barcode, double txnAmount, PaymentMethod paymentMethod, int? workstationId = 1, int? userId = 1, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumpayment";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumpayment";
             var body = new PatronAccountPayData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountRefundCreditAsync(string barcode, double txnAmount, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumrefundcredit";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumrefundcredit";
             var body = new PatronAccountRefundCreditData { TxnAmount = txnAmount, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountVoidAsync(string barcode, int paymentTxnId, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/{paymentTxnId}/void/payment";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/{paymentTxnId}/void/payment";
             var request = new PapiRestRequest(HttpMethod.Delete, url);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);

--- a/src/polaris-api-csharp/Methods/PatronRenewBlocksGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronRenewBlocksGet.cs
@@ -15,8 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronRenewBlocksResult>> PatronRenewBlocksGetAsync(int patronId, int? branchId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/{branchId ?? OrganizationId}/{Token.AccessToken}/circulation/patron/{patronId}/renewblocks";
+            var url = $"/protected/v1/1033/100/{branchId ?? OrganizationId}/{ProtectedToken.Placeholder}/circulation/patron/{patronId}/renewblocks";
             var request = new PapiRestRequest(url);
             return await ExecutePapiAsync<PatronRenewBlocksResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronSearch.cs
+++ b/src/polaris-api-csharp/Methods/PatronSearch.cs
@@ -12,8 +12,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronSearchResult>> PatronSearchAsync(string query, int page = 1, int pageSize = 10, PatronSortKeys sortBy = PatronSortKeys.PATN, int? orgId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/{orgId ?? OrganizationId}/{Token.AccessToken}/search/patrons/Boolean";
+            var url = $"/protected/v1/1033/100/{orgId ?? OrganizationId}/{ProtectedToken.Placeholder}/search/patrons/Boolean";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("q", query);
             request.QueryParameters.Add("patronsperpage", pageSize);

--- a/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
+++ b/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
@@ -13,8 +13,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<GetBarcodeAndPatronIDResult>> Patron_GetBarcodeFromIdAsync(int patronId, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/barcode";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/barcode";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("patronid", patronId);
             return await ExecutePapiAsync<GetBarcodeAndPatronIDResult>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> RecordSetContentPutAsync(int recordSetId, IEnumerable<int> records, RecordSetContentPutActions action, int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/recordsets/{recordSetId}";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/recordsets/{recordSetId}";
             var body = new { records = string.Join(",", records) };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("action", action);

--- a/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<RecordSetRecordsGetResult>> RecordSetRecordsGetAsync(int recordSetId, int userId = 1, int workstationId = 1, int startIndex = 0, int numRecords = 1000, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/recordsets/{recordSetId}/records";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/recordsets/{recordSetId}/records";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("startIndex", startIndex);
             request.QueryParameters.Add("numRecords", numRecords);

--- a/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
+++ b/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
@@ -15,8 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<RemoteStorageItemsGetResult>> RemoteStorageItemsGetAsync(int branchId, string startDate, string endDate, int maxItems, int listType, int? startItemRecordId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/cataloging/remotestorage/items";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/cataloging/remotestorage/items";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("branch", branchId);
             request.QueryParameters.Add("startdate", startDate);

--- a/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
+++ b/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
@@ -22,8 +22,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<StringResult>> SA_GetValueByOrgAsync(string attribute, int? organizationId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/organization/{organizationId ?? OrganizationId}/sysadmin/attribute/{attribute}";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/organization/{organizationId ?? OrganizationId}/sysadmin/attribute/{attribute}";
             var request = new PapiRestRequest(url);
             return await ExecutePapiAsync<StringResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
+++ b/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
@@ -14,8 +14,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<Sync_BibsByIdGetResult>> Synch_BibsByIdGetAsync(int[] bibIds, bool includeItems = false, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/synch/bibs/MARCxml";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/synch/bibs/MARCxml";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("bibids", string.Join(",", bibIds));
             if (includeItems)

--- a/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<PapiResponseCommon>> UpdatePatronNotesDataAsync(string barcode, string nonBlockingNote = null, string blockingNote = null, UpdateNoteMode updateMode = UpdateNoteMode.Prepend, int? workstationId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/notes";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/notes";
             var body = new UpdatePatronNotesData();
 
             if (!string.IsNullOrWhiteSpace(nonBlockingNote))

--- a/src/polaris-api-csharp/Models/ProtectedToken.cs
+++ b/src/polaris-api-csharp/Models/ProtectedToken.cs
@@ -15,6 +15,8 @@ namespace Clc.Polaris.Api.Models
     [XmlRoot(ElementName = "AuthenticationResult")]
     public class ProtectedToken : PapiResponseCommon
     {
+        public const string Placeholder = "__PAPI_PROTECTED_ACCESS_TOKEN__";
+
         /// <summary>
         /// Access token
         /// </summary>

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -147,14 +147,42 @@ namespace Clc.Polaris.Api
 
         private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default, ProtectedTokenPreloadMode tokenPreloadMode = ProtectedTokenPreloadMode.Auto)
         {
+            var containsProtectedTokenPlaceholder = ContainsProtectedTokenPlaceholder(request);
+
             if (tokenPreloadMode == ProtectedTokenPreloadMode.Auto &&
-                request.AuthRequired &&
-                ((request.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(request.Password) && !request.BlockStaffOverride) || request.IsProtectedMethod))
+                (containsProtectedTokenPlaceholder ||
+                (request.AuthRequired &&
+                ((request.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(request.Password) && !request.BlockStaffOverride) || request.IsProtectedMethod))))
             {
                 await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
             }
 
+            if (containsProtectedTokenPlaceholder)
+            {
+                if (tokenPreloadMode == ProtectedTokenPreloadMode.Skip)
+                {
+                    throw new InvalidOperationException("A PAPI request path contains the protected token placeholder, but protected token preloading was skipped.");
+                }
+
+                ReplaceProtectedTokenPlaceholder(request);
+            }
+
             return await ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static bool ContainsProtectedTokenPlaceholder(PapiRestRequest request)
+        {
+            return request?.Path?.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) >= 0;
+        }
+
+        private void ReplaceProtectedTokenPlaceholder(PapiRestRequest request)
+        {
+            if (Token == null || string.IsNullOrWhiteSpace(Token.AccessToken))
+            {
+                throw new InvalidOperationException("A PAPI request path contains the protected token placeholder, but no protected access token is available for replacement.");
+            }
+
+            request.Path = request.Path.Replace(ProtectedToken.Placeholder, Token.AccessToken, StringComparison.Ordinal);
         }
 
         private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -1,5 +1,6 @@
 ﻿using Clc.Polaris.Api.Configuration;
 using Clc.Polaris.Api.Models;
+using Clc.Rest;
 using Clc.Rest.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
@@ -126,6 +127,130 @@ namespace Clc.Polaris.Api.Tests
             var expectedHash = ComputePapiHash("GET", expectedUri, date, "protected-secret", "access-key");
             Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
             Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
+        }
+
+        [TestMethod]
+        public void ProtectedToken_Placeholder_IsStable()
+        {
+            Assert.AreEqual("__PAPI_PROTECTED_ACCESS_TOKEN__", ProtectedToken.Placeholder);
+        }
+
+        [TestMethod]
+        public async Task ProtectedTokenPlaceholderRequest_SendsRealAccessTokenAndNeverPlaceholder()
+        {
+            var handler = new ProtectedTokenCancellationHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = "staff",
+                Password = "secret"
+            };
+
+            var response = await client.PatronSearchAsync("name=Smith");
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(2, handler.Requests.Count);
+            StringAssert.Contains(handler.Requests[1].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
+            Assert.IsFalse(handler.Requests[1].RequestUri!.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
+        }
+
+        [TestMethod]
+        public async Task ProtectedTokenPlaceholderRequest_HashesReplacedUrlNotPlaceholderUrl()
+        {
+            var handler = new ProtectedTokenCancellationHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = "staff",
+                Password = "secret"
+            };
+
+            await client.PatronSearchAsync("name=Smith");
+
+            var finalRequest = handler.Requests[1];
+            var date = finalRequest.Headers.GetValues("PolarisDate").Single();
+            var expectedUri = "https://example.test/PAPIService/REST/protected/v1/1033/100/1/protected-token/search/patrons/Boolean?q=name%3DSmith&patronsperpage=10&page=1&sort=PATN";
+            var expectedHash = ComputePapiHash("GET", expectedUri, date, "protected-secret", "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", finalRequest.Headers.GetValues("Authorization").Single());
+        }
+
+        [TestMethod]
+        public async Task ProtectedTokenPlaceholderRequest_AcquiresProtectedTokenWhenNoCachedTokenExists()
+        {
+            var handler = new ProtectedTokenCancellationHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = "staff",
+                Password = "secret"
+            };
+
+            await client.PatronSearchAsync("name=Smith");
+
+            Assert.AreEqual(2, handler.Requests.Count);
+            StringAssert.Contains(handler.Requests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
+            StringAssert.Contains(handler.Requests[1].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
+        }
+
+        [TestMethod]
+        public async Task ProtectedTokenPlaceholderRequest_UsesCachedProtectedTokenForReplacement()
+        {
+            var cacheKeyHost = $"https://placeholder-cache-{Guid.NewGuid():N}.example.test";
+            var firstHandler = new ProtectedTokenCancellationHttpMessageHandler();
+            var firstClient = CreateClient(firstHandler);
+            firstClient.Hostname = cacheKeyHost;
+            firstClient.UseProtectedTokenCache = true;
+            firstClient.AllowStaffOverrideRequests = true;
+            firstClient.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = "staff",
+                Password = "secret"
+            };
+            await firstClient.PatronSearchAsync("name=Smith");
+
+            var secondHandler = new ProtectedTokenCancellationHttpMessageHandler();
+            var secondClient = CreateClient(secondHandler);
+            secondClient.Hostname = cacheKeyHost;
+            secondClient.UseProtectedTokenCache = true;
+            secondClient.AllowStaffOverrideRequests = true;
+            secondClient.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = "staff",
+                Password = "secret"
+            };
+
+            await secondClient.PatronSearchAsync("name=Jones");
+
+            Assert.AreEqual(1, secondHandler.Requests.Count);
+            StringAssert.Contains(secondHandler.Requests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
+            Assert.IsFalse(secondHandler.Requests[0].RequestUri!.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
+        }
+
+        [TestMethod]
+        public async Task ProtectedTokenPlaceholderRequest_WithPreloadSkipFailsClearlyAndDoesNotSendPlaceholder()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "protected-token",
+                AccessSecret = "protected-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(1)
+            };
+            var request = new PapiRestRequest($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/search/patrons/Boolean");
+
+            var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => ExecutePapiWithProtectedTokenPreloadSkipAsync<PapiResponseCommon>(client, request));
+
+            StringAssert.Contains(exception.Message, "protected token placeholder");
+            Assert.IsNull(handler.LastRequest);
         }
 
         [TestMethod]
@@ -524,6 +649,20 @@ namespace Clc.Polaris.Api.Tests
                 AllowStaffOverrideRequests = false,
                 UseProtectedTokenCache = false
             };
+        }
+
+
+        private static Task<IRestResponse<T>> ExecutePapiWithProtectedTokenPreloadSkipAsync<T>(PapiClient client, PapiRestRequest request)
+        {
+            var preloadModeType = typeof(PapiClient).GetNestedType("ProtectedTokenPreloadMode", System.Reflection.BindingFlags.NonPublic);
+            Assert.IsNotNull(preloadModeType);
+            var skip = Enum.Parse(preloadModeType, "Skip");
+            var executeMethod = typeof(PapiClient)
+                .GetMethods(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .Single(method => method.Name == "ExecutePapiAsync" && method.IsGenericMethodDefinition);
+            var task = executeMethod.MakeGenericMethod(typeof(T)).Invoke(client, new[] { request, CancellationToken.None, skip });
+            Assert.IsNotNull(task);
+            return (Task<IRestResponse<T>>)task;
         }
 
 


### PR DESCRIPTION
### Motivation
- Some PAPI endpoints require the protected access token embedded in the URL path, and many methods were manually preloading tokens just to interpolate `Token.AccessToken` into the path; this centralizes that behavior to avoid duplication and inconsistent behavior.
- Ensure placeholder-driven paths are replaced only at execution time so PAPI auth/hash computation and outgoing requests always use the real access token.

### Description
- Added `ProtectedToken.Placeholder` constant with the required value `"__PAPI_PROTECTED_ACCESS_TOKEN__"` and kept `ProtectedToken` as a DTO/model. (no mutation helpers added to the model.)
- Extended `PapiClient.ExecutePapiAsync` to detect the placeholder in `request.Path` using `StringComparison.Ordinal`, call `EnsureProtectedTokenAsync` when needed (including when the placeholder is present in `Auto` preload mode), and replace the placeholder with `Token.AccessToken` on `request.Path` before calling `ExecuteAsync`; if a placeholder exists but no token is available an `InvalidOperationException` is thrown, and if preload mode is `Skip` and a placeholder is present an `InvalidOperationException` is thrown.
- Added private helpers `ContainsProtectedTokenPlaceholder` and `ReplaceProtectedTokenPlaceholder` in `PapiClient` and ensured replacement operates only on `request.Path` (no changes to query, headers, or body) and uses `StringComparison.Ordinal`.
- Updated protected-token-in-path methods to use `ProtectedToken.Placeholder` instead of calling `EnsureProtectedTokenAsync` and interpolating `Token.AccessToken` (examples: `PatronSearchAsync`, `PatronAccountPayAsync`, and other protected methods), preserving endpoint paths, query strings, bodies and public signatures.
- Added focused unit tests to `RestClientMigrationCharacterizationTests` validating: the placeholder constant, that requests with the placeholder send the real token and never the placeholder, that the Authorization hash is computed against the replaced URL, that placeholder requests auto-acquire a protected token when none is cached, that cached protected tokens are used for replacement, and that requests with the placeholder fail clearly when `ProtectedTokenPreloadMode.Skip` is used.

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` and the restore succeeded.
- Built the solution with `dotnet build src/polaris-api-csharp.sln --no-restore` and the build succeeded with no errors.
- Ran unit tests for migration category with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"` and all tests passed (46 passed).
- Ran the full non-integration suite with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory!=Integration"` and all tests passed (71 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b2fc4d65c8323b40f0eca3f53c0b5)