### PR TITLE
Add ProtectedToken.Placeholder and centralize placeholder handling in ExecutePapiAsync

### DIFF
--- a/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
+++ b/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<CreatePatronBlocksResult>> CreatePatronBlocksAsync(string barcode, BlockType blockType, string blockValue, int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/blocks";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/blocks";
             var body = new CreatePatronBlocksRequest((int)blockType, blockValue);
             var request = new PapiRestRequest(HttpMethod.Post, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
@@ -14,8 +14,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<HoldRequestGetListResult>> HoldRequestGetListAsync(int branchId, RequestListBranchType branchType = RequestListBranchType.PickupBranch, HoldStatus status = HoldStatus.Held, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/circulation/requests/list";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/circulation/requests/list";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("branch", branchId);
             request.QueryParameters.Add("branchtype", (int)branchType);

--- a/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
+++ b/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
@@ -13,8 +13,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<PapiResponseCommon>> ItemUpdateBarcodeAsync(string newBarcode, int? itemRecordId = null, int? transactionBranchId = null, string oldBarcode = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/cataloging/items/{(itemRecordId.HasValue ? itemRecordId.Value.ToString() : oldBarcode)}/barcode";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/cataloging/items/{(itemRecordId.HasValue ? itemRecordId.Value.ToString() : oldBarcode)}/barcode";
             var body = new ItemUpdateBarcodeData { ItemBarcode = newBarcode, TransactionBranchId = transactionBranchId ?? OrganizationId };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", transactionBranchId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
+++ b/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
@@ -13,8 +13,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PapiResponseCommon>> NotificationQueueGetAsync(int orgId = 1, CancellationToken cancellationToken = default)
         {
             //"protected/{Version}/{LangID}/{AppID}/{OrgID}/{AccessToken}/notification
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/24/{orgId}/{Token.AccessToken}/notification/";
+            var url = $"/protected/v1/1033/24/{orgId}/{ProtectedToken.Placeholder}/notification/";
             var request = new PapiRestRequest(url);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/NotificationUpdate.cs
+++ b/src/polaris-api-csharp/Methods/NotificationUpdate.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<NotificationUpdateResult>> NotificationUpdateAsync(NotificationUpdateParams updateParams, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/notification/{updateParams.NotificationTypeId}";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/notification/{updateParams.NotificationTypeId}";
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = updateParams };
             return await ExecutePapiAsync<NotificationUpdateResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountCreateCreditAsync(string barcode, double txnAmount, PaymentMethod paymentMethod, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/createcredit";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/createcredit";
             var body = new PatronAccountCreateCreditData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountDepositCreditAsync(string barcode, double txnAmount, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumdepositcredit";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumdepositcredit";
             var body = new PatronAccountDepositCreditData { TxnAmount = txnAmount, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountPay.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPay.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountPayAsync(string barcode, int txnId, double txnAmount, PaymentMethod paymentMethod, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/{txnId}/pay";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/{txnId}/pay";
             var body = new PatronAccountPayData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountPayAllAsync(string barcode, double txnAmount, PaymentMethod paymentMethod, int? workstationId = 1, int? userId = 1, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumpayment";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumpayment";
             var body = new PatronAccountPayData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountRefundCreditAsync(string barcode, double txnAmount, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumrefundcredit";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumrefundcredit";
             var body = new PatronAccountRefundCreditData { TxnAmount = txnAmount, FreeTextNote = note };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
@@ -18,8 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountVoidAsync(string barcode, int paymentTxnId, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/account/{paymentTxnId}/void/payment";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/{paymentTxnId}/void/payment";
             var request = new PapiRestRequest(HttpMethod.Delete, url);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);

--- a/src/polaris-api-csharp/Methods/PatronRenewBlocksGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronRenewBlocksGet.cs
@@ -15,8 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronRenewBlocksResult>> PatronRenewBlocksGetAsync(int patronId, int? branchId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/{branchId ?? OrganizationId}/{Token.AccessToken}/circulation/patron/{patronId}/renewblocks";
+            var url = $"/protected/v1/1033/100/{branchId ?? OrganizationId}/{ProtectedToken.Placeholder}/circulation/patron/{patronId}/renewblocks";
             var request = new PapiRestRequest(url);
             return await ExecutePapiAsync<PatronRenewBlocksResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronSearch.cs
+++ b/src/polaris-api-csharp/Methods/PatronSearch.cs
@@ -12,8 +12,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronSearchResult>> PatronSearchAsync(string query, int page = 1, int pageSize = 10, PatronSortKeys sortBy = PatronSortKeys.PATN, int? orgId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/{orgId ?? OrganizationId}/{Token.AccessToken}/search/patrons/Boolean";
+            var url = $"/protected/v1/1033/100/{orgId ?? OrganizationId}/{ProtectedToken.Placeholder}/search/patrons/Boolean";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("q", query);
             request.QueryParameters.Add("patronsperpage", pageSize);

--- a/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
+++ b/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
@@ -13,8 +13,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<GetBarcodeAndPatronIDResult>> Patron_GetBarcodeFromIdAsync(int patronId, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/barcode";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/barcode";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("patronid", patronId);
             return await ExecutePapiAsync<GetBarcodeAndPatronIDResult>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> RecordSetContentPutAsync(int recordSetId, IEnumerable<int> records, RecordSetContentPutActions action, int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/recordsets/{recordSetId}";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/recordsets/{recordSetId}";
             var body = new { records = string.Join(",", records) };
             var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
             request.QueryParameters.Add("action", action);

--- a/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<RecordSetRecordsGetResult>> RecordSetRecordsGetAsync(int recordSetId, int userId = 1, int workstationId = 1, int startIndex = 0, int numRecords = 1000, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/recordsets/{recordSetId}/records";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/recordsets/{recordSetId}/records";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("startIndex", startIndex);
             request.QueryParameters.Add("numRecords", numRecords);

--- a/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
+++ b/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
@@ -15,8 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<RemoteStorageItemsGetResult>> RemoteStorageItemsGetAsync(int branchId, string startDate, string endDate, int maxItems, int listType, int? startItemRecordId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/cataloging/remotestorage/items";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/cataloging/remotestorage/items";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("branch", branchId);
             request.QueryParameters.Add("startdate", startDate);

--- a/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
+++ b/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
@@ -22,8 +22,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<StringResult>> SA_GetValueByOrgAsync(string attribute, int? organizationId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/organization/{organizationId ?? OrganizationId}/sysadmin/attribute/{attribute}";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/organization/{organizationId ?? OrganizationId}/sysadmin/attribute/{attribute}";
             var request = new PapiRestRequest(url);
             return await ExecutePapiAsync<StringResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
+++ b/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
@@ -14,8 +14,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<Sync_BibsByIdGetResult>> Synch_BibsByIdGetAsync(int[] bibIds, bool includeItems = false, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/synch/bibs/MARCxml";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/synch/bibs/MARCxml";
             var request = new PapiRestRequest(url);
             request.QueryParameters.Add("bibids", string.Join(",", bibIds));
             if (includeItems)

--- a/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
@@ -16,8 +16,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<PapiResponseCommon>> UpdatePatronNotesDataAsync(string barcode, string nonBlockingNote = null, string blockingNote = null, UpdateNoteMode updateMode = UpdateNoteMode.Prepend, int? workstationId = null, CancellationToken cancellationToken = default)
         {
-            await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-            var url = $"/protected/v1/1033/100/1/{Token.AccessToken}/patron/{WebUtility.UrlEncode(barcode)}/notes";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/notes";
             var body = new UpdatePatronNotesData();
 
             if (!string.IsNullOrWhiteSpace(nonBlockingNote))

--- a/src/polaris-api-csharp/Models/ProtectedToken.cs
+++ b/src/polaris-api-csharp/Models/ProtectedToken.cs
@@ -15,6 +15,8 @@ namespace Clc.Polaris.Api.Models
     [XmlRoot(ElementName = "AuthenticationResult")]
     public class ProtectedToken : PapiResponseCommon
     {
+        public const string Placeholder = "__PAPI_PROTECTED_ACCESS_TOKEN__";
+
         /// <summary>
         /// Access token
         /// </summary>

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -147,14 +147,44 @@ namespace Clc.Polaris.Api
 
         private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default, ProtectedTokenPreloadMode tokenPreloadMode = ProtectedTokenPreloadMode.Auto)
         {
+            var pathContainsProtectedTokenPlaceholder = RequestPathContainsProtectedTokenPlaceholder(request);
+
+            if (tokenPreloadMode == ProtectedTokenPreloadMode.Skip && pathContainsProtectedTokenPlaceholder)
+            {
+                throw new InvalidOperationException("ProtectedToken.Placeholder cannot be used when protected token preloading is skipped.");
+            }
+
             if (tokenPreloadMode == ProtectedTokenPreloadMode.Auto &&
-                request.AuthRequired &&
-                ((request.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(request.Password) && !request.BlockStaffOverride) || request.IsProtectedMethod))
+                (pathContainsProtectedTokenPlaceholder ||
+                 (request.AuthRequired &&
+                  ((request.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(request.Password) && !request.BlockStaffOverride) || request.IsProtectedMethod))))
             {
                 await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
             }
 
+            if (pathContainsProtectedTokenPlaceholder)
+            {
+                ReplaceProtectedTokenPlaceholderInPath(request);
+            }
+
             return await ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static bool RequestPathContainsProtectedTokenPlaceholder(PapiRestRequest request)
+        {
+            return request?.Path?.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) >= 0;
+        }
+
+        private void ReplaceProtectedTokenPlaceholderInPath(PapiRestRequest request)
+        {
+            var token = Token;
+            var accessToken = token?.AccessToken;
+            if (IsProtectedTokenMissingOrExpired(token) || string.IsNullOrWhiteSpace(accessToken))
+            {
+                throw new InvalidOperationException("A valid protected access token is required to replace ProtectedToken.Placeholder in the request path.");
+            }
+
+            request.Path = request.Path.Replace(ProtectedToken.Placeholder, accessToken, StringComparison.Ordinal);
         }
 
         private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -379,6 +379,120 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsTrue(handler.CancellationTokens[1].CanBeCanceled);
         }
 
+
+        [TestMethod]
+        public async Task ProtectedTokenPathRequest_ReplacesPlaceholderBeforeSending()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            client.Token = new ProtectedToken { AccessToken = "real-token", AccessSecret = "real-secret", ExpirationDate = DateTime.UtcNow.AddHours(1) };
+
+            var response = await client.PatronSearchAsync("name=Smith", orgId: 9);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.IsFalse(handler.LastRequest!.RequestUri!.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
+            StringAssert.Contains(handler.LastRequest.RequestUri.AbsolutePath, "/protected/v1/1033/100/9/real-token/search/patrons/Boolean");
+        }
+
+        [TestMethod]
+        public async Task ProtectedTokenPathRequest_HashesReplacedUrlInsteadOfPlaceholderUrl()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            client.Token = new ProtectedToken { AccessToken = "hash-token", AccessSecret = "hash-secret", ExpirationDate = DateTime.UtcNow.AddHours(1) };
+
+            await client.PatronSearchAsync("name=Smith", orgId: 9);
+
+            Assert.IsNotNull(handler.LastRequest);
+            var date = handler.LastRequest!.Headers.GetValues("PolarisDate").Single();
+            var expectedUri = "https://example.test/PAPIService/REST/protected/v1/1033/100/9/hash-token/search/patrons/Boolean?q=name%3DSmith&patronsperpage=10&page=1&sort=PATN";
+            var expectedHash = ComputePapiHash("GET", expectedUri, date, "hash-secret", "access-key");
+            var placeholderUri = expectedUri.Replace("hash-token", ProtectedToken.Placeholder, StringComparison.Ordinal);
+            var placeholderHash = ComputePapiHash("GET", placeholderUri, date, "hash-secret", "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", handler.LastRequest.Headers.GetValues("Authorization").Single());
+            Assert.AreNotEqual($"PWS access-id:{placeholderHash}", handler.LastRequest.Headers.GetValues("Authorization").Single());
+        }
+
+        [TestMethod]
+        public async Task ProtectedTokenPathRequest_AcquiresProtectedTokenAutomaticallyWhenMissing()
+        {
+            var handler = new ProtectedTokenCancellationHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = "auto-placeholder",
+                Password = "secret"
+            };
+
+            var response = await client.PatronSearchAsync("name=Smith", orgId: 9);
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(2, handler.Requests.Count);
+            StringAssert.Contains(handler.Requests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
+            StringAssert.Contains(handler.Requests[1].RequestUri!.AbsolutePath, "/protected/v1/1033/100/9/protected-token/search/patrons/Boolean");
+            Assert.IsFalse(handler.Requests[1].RequestUri!.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
+        }
+
+        [TestMethod]
+        public async Task ProtectedTokenPathRequest_UsesCachedProtectedTokenForPlaceholderReplacement()
+        {
+            var handler = new ProtectedTokenCancellationHttpMessageHandler();
+            var firstClient = CreateClient(handler);
+            firstClient.AllowStaffOverrideRequests = true;
+            firstClient.UseProtectedTokenCache = true;
+            firstClient.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = $"cached-placeholder-{Guid.NewGuid():N}",
+                Password = "secret"
+            };
+
+            await firstClient.PatronSearchAsync("name=Smith", orgId: 9);
+
+            var secondClient = CreateClient(handler);
+            secondClient.AllowStaffOverrideRequests = true;
+            secondClient.UseProtectedTokenCache = true;
+            secondClient.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = firstClient.StaffOverrideAccount.Domain,
+                Username = firstClient.StaffOverrideAccount.Username,
+                Password = "secret"
+            };
+
+            var response = await secondClient.PatronSearchAsync("name=Jones", orgId: 9);
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(3, handler.Requests.Count);
+            StringAssert.Contains(handler.Requests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
+            StringAssert.Contains(handler.Requests[1].RequestUri!.AbsolutePath, "/protected/v1/1033/100/9/protected-token/search/patrons/Boolean");
+            StringAssert.Contains(handler.Requests[2].RequestUri!.AbsolutePath, "/protected/v1/1033/100/9/protected-token/search/patrons/Boolean");
+            Assert.IsFalse(handler.Requests[2].RequestUri!.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_WithSkippedProtectedTokenPreloadAndPlaceholder_FailsBeforeSending()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/search/patrons/Boolean");
+            var executePapiAsync = typeof(PapiClient)
+                .GetMethod("ExecutePapiAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .MakeGenericMethod(typeof(PapiResponseCommon));
+            var skipMode = Enum.Parse(
+                typeof(PapiClient).GetNestedType("ProtectedTokenPreloadMode", System.Reflection.BindingFlags.NonPublic)!,
+                "Skip");
+
+            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None, skipMode })!;
+            var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await task);
+
+            StringAssert.Contains(exception.Message, "ProtectedToken.Placeholder");
+            Assert.IsNull(handler.LastRequest);
+            Assert.AreEqual($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/search/patrons/Boolean", request.Path);
+        }
+
         [TestMethod]
         public async Task BibSearch_RequestShape_IsStable()
         {


### PR DESCRIPTION
### Motivation
- Some PAPI endpoints require the protected access token embedded in the URL path and individual methods were each calling `EnsureProtectedTokenAsync` only to interpolate `Token.AccessToken`; this change centralizes that logic so token acquisition and URL insertion are handled consistently in one place.
- The goal is to avoid sending the literal placeholder string in any outgoing request and ensure PAPI auth/hash computation uses the real, replaced URL.

### Description
- Added `public const string Placeholder = "__PAPI_PROTECTED_ACCESS_TOKEN__";` to `ProtectedToken` to provide a canonical placeholder value for path insertion.
- Added private helpers on `PapiClient`: `RequestPathContainsProtectedTokenPlaceholder` to detect the placeholder in `request.Path` and `ReplaceProtectedTokenPlaceholderInPath` to replace the placeholder with `Token.AccessToken`, using `StringComparison.Ordinal` and operating only on `request.Path`.
- Updated `ExecutePapiAsync` to consider the placeholder when deciding whether to preload a protected token under `ProtectedTokenPreloadMode.Auto`, to replace the placeholder after acquisition and before calling `ExecuteAsync`, and to throw a clear `InvalidOperationException` when `Skip` mode is used while a placeholder is present or when no valid token is available for replacement.
- Converted protected-token-in-path methods to use `ProtectedToken.Placeholder` in their URL templates instead of calling `EnsureProtectedTokenAsync` and interpolating `Token.AccessToken`, preserving endpoint paths, query parameters, bodies, auth behavior, and public method signatures.
- Added focused unit tests covering placeholder replacement before send, authorization hash computation against the replaced URL, automatic acquisition when missing, cached-token reuse for replacement, and failure when `ProtectedTokenPreloadMode.Skip` is used with a placeholder.

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` successfully and `dotnet build src/polaris-api-csharp.sln --no-restore` which completed without errors.
- Ran the targeted test sets with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"` and `--filter "TestCategory!=Integration"` and all tests passed (RestClientMigration tests passed and the full non-integration suite passed).
- Added unit tests include `ProtectedTokenPathRequest_ReplacesPlaceholderBeforeSending`, `ProtectedTokenPathRequest_HashesReplacedUrlInsteadOfPlaceholderUrl`, `ProtectedTokenPathRequest_AcquiresProtectedTokenAutomaticallyWhenMissing`, `ProtectedTokenPathRequest_UsesCachedProtectedTokenForPlaceholderReplacement`, and `ExecutePapiAsync_WithSkippedProtectedTokenPreloadAndPlaceholder_FailsBeforeSending`, and they passed as part of the test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b2fc4d65c8323b40f0eca3f53c0b5)