### PR TITLE
Add PapiRestRequest factory helpers and refactor call sites

### DIFF
--- a/src/polaris-api-csharp/Methods/ApiKeyValidate.cs
+++ b/src/polaris-api-csharp/Methods/ApiKeyValidate.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -15,7 +14,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PapiResponseCommon>> ApiKeyValidateAsync(CancellationToken cancellationToken = default)
         {
             var url = "/public/v1/1033/100/1/apikeyvalidate";
-            var request = new PapiRestRequest(url) { BlockStaffOverride = true };// { AuthRequired = false };
+            var request = PapiRestRequest.Get(url);
+            request.BlockStaffOverride = true;
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/ApiVersionGet.cs
+++ b/src/polaris-api-csharp/Methods/ApiVersionGet.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -20,7 +19,7 @@ namespace Clc.Polaris.Api
 		public async Task<IRestResponse<ApiResult>> ApiVersionGetAsync(CancellationToken cancellationToken = default)
         {
             var url = "/public/v1/1033/100/1/api";
-            var request = new PapiRestRequest(url);// { AuthRequired = true, BlockStaffOverride = true };
+            var request = PapiRestRequest.Get(url);
             return await ExecutePapiAsync<ApiResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/AuthenticatePatron.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticatePatron.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -16,7 +15,8 @@ namespace Clc.Polaris.Api
         {
             var url = "/public/v1/1033/100/1/authenticator/patron";
             var body = new { Barcode = barcode, Password = password };
-            var request = new PapiRestRequest(HttpMethod.Post, url) { Body = body, BlockStaffOverride = true };
+            var request = PapiRestRequest.Post(url, body: body);
+            request.BlockStaffOverride = true;
             return await ExecutePapiAsync<PatronAuthenticationResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 using System.Xml.Linq;
 
@@ -16,10 +15,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<ProtectedToken>> AuthenticateStaffUserAsync(PolarisUser staffUser, CancellationToken cancellationToken = default)
         {
-            var request = new PapiRestRequest(HttpMethod.Post, "/protected/v1/1033/100/1/authenticator/staff")
-            {
-                Body = staffUser
-            };
+            var request = PapiRestRequest.Post("/protected/v1/1033/100/1/authenticator/staff", body: staffUser);
 
             return await ExecutePapiAsync<ProtectedToken>(request, cancellationToken, ProtectedTokenPreloadMode.Skip).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/BibGet.cs
+++ b/src/polaris-api-csharp/Methods/BibGet.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -22,7 +21,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<BibGetResult>> BibGetAsync(int bibId, int? branchId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/bib/{bibId}";
-            var request = new PapiRestRequest(url);
+            var request = PapiRestRequest.Get(url);
             return await ExecutePapiAsync<BibGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/BibSearch.cs
+++ b/src/polaris-api-csharp/Methods/BibSearch.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -18,7 +17,8 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/{options.Branch}/search/bibs/{options.SearchType}";
             if (options.SearchType == BibSearchTypes.keyword) { url += $"/{options.Qualifier}"; }
 
-            var request = new PapiRestRequest(url) { BlockStaffOverride = true };
+            var request = PapiRestRequest.Get(url);
+            request.BlockStaffOverride = true;
             request.QueryParameters.Add("q", options.Term ?? string.Empty);
             request.QueryParameters.Add("sort", options.SortOption);
             request.QueryParameters.Add("page", options.Page);

--- a/src/polaris-api-csharp/Methods/CollectionsGet.cs
+++ b/src/polaris-api-csharp/Methods/CollectionsGet.cs
@@ -16,7 +16,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<CollectionsGetResult>> CollectionsGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/collections";
-            var request = new PapiRestRequest(url) { BlockStaffOverride = true };
+            var request = PapiRestRequest.Get(url);
+            request.BlockStaffOverride = true;
             return await ExecutePapiAsync<CollectionsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
+++ b/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Net;
 using System.Text;
 using System.Xml.Linq;
@@ -18,7 +17,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/blocks";
             var body = new CreatePatronBlocksRequest((int)blockType, blockValue);
-            var request = new PapiRestRequest(HttpMethod.Post, url) { Body = body };
+            var request = PapiRestRequest.Post(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
 

--- a/src/polaris-api-csharp/Methods/DatesClosedGet.cs
+++ b/src/polaris-api-csharp/Methods/DatesClosedGet.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -15,7 +14,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<DatesClosedGetResult>> DatesClosedGetAsync(int organizationId, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{organizationId}/datesclosed";
-            var request = new PapiRestRequest(url) { BlockStaffOverride = true };
+            var request = PapiRestRequest.Get(url);
+            request.BlockStaffOverride = true;
             return await ExecutePapiAsync<DatesClosedGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/HoldRequestCancel.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestCancel.cs
@@ -1,7 +1,6 @@
 ﻿using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 namespace Clc.Polaris.Api
@@ -11,7 +10,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<HoldRequestCancelResult>> HoldRequestCancelAsync(string barcode, int requestId, string password = "", int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/cancelled";
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Password = password };
+            var request = PapiRestRequest.Put(url, password: password);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
             return await ExecutePapiAsync<HoldRequestCancelResult>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/HoldRequestCreate.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestCreate.cs
@@ -5,7 +5,6 @@ using System.Xml.Linq;
 using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -16,7 +15,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<HoldRequestCreateResult>> HoldRequestCreateAsync(HoldRequestCreateParams holdParams, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{holdParams.RequestingOrgID}/holdrequest";
-            var request = new PapiRestRequest(HttpMethod.Post, url) { Body = holdParams };
+            var request = PapiRestRequest.Post(url, body: holdParams);
             return await ExecutePapiAsync<HoldRequestCreateResult>(request, cancellationToken).ConfigureAwait(false);
         }
         public async Task<IRestResponse<HoldRequestCreateResult>> HoldRequestCreateAsync(int patronId, int bibId, int pickupBranchId = 0, DateTime? activationDate = null, int? userId = null, int? workstationId = null, int? requestingOrgId = null, CancellationToken cancellationToken = default)

--- a/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -15,7 +14,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<HoldRequestGetListResult>> HoldRequestGetListAsync(int branchId, RequestListBranchType branchType = RequestListBranchType.PickupBranch, HoldStatus status = HoldStatus.Held, CancellationToken cancellationToken = default)
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/circulation/requests/list";
-            var request = new PapiRestRequest(url);
+            var request = PapiRestRequest.Get(url);
             request.QueryParameters.Add("branch", branchId);
             request.QueryParameters.Add("branchtype", (int)branchType);
             request.QueryParameters.Add("requeststatus", (int)status);

--- a/src/polaris-api-csharp/Methods/HoldRequestReactivate.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestReactivate.cs
@@ -4,7 +4,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Net;
-using System.Net.Http;
 using System.Xml.Linq;
 
 namespace Clc.Polaris.Api
@@ -15,7 +14,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/active";
             var body = new { HoldRequestActivationData = new { UserId = userId ?? UserId, activationDate } };
-            var request = new PapiRestRequest(HttpMethod.Put, url, password, body);
+            var request = PapiRestRequest.Put(url, body: body, password: password);
             return await ExecutePapiAsync<HoldRequestActivationResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/HoldRequestReply.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestReply.cs
@@ -5,7 +5,6 @@ using System.Xml.Linq;
 using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -23,7 +22,7 @@ namespace Clc.Polaris.Api
                 State = (int)state
             };
 
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            var request = PapiRestRequest.Put(url, body: body);
             return await ExecutePapiAsync<HoldRequestReplyResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/HoldRequestSuspend.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestSuspend.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Net;
-using System.Net.Http;
 using System.Xml.Linq;
 
 namespace Clc.Polaris.Api
@@ -16,7 +15,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/inactive";
             var json = new { HoldRequestActivationData = new { UserId = userId ?? UserId, activationDate } };
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Password = password, Body = json };
+            var request = PapiRestRequest.Put(url, body: json, password: password);
             return await ExecutePapiAsync<HoldRequestActivationResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/HoldingsGet.cs
+++ b/src/polaris-api-csharp/Methods/HoldingsGet.cs
@@ -1,6 +1,5 @@
 ﻿using Clc.Rest;
 using Clc.Polaris.Api.Models;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 namespace Clc.Polaris.Api
@@ -18,7 +17,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<BibHoldingsGetResult>> HoldingsGetAsync(int bibId, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/bib/{bibId}/holdings";
-            var request = new PapiRestRequest(url);
+            var request = PapiRestRequest.Get(url);
             return await ExecutePapiAsync<BibHoldingsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/ItemRenew.cs
+++ b/src/polaris-api-csharp/Methods/ItemRenew.cs
@@ -2,7 +2,6 @@
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 using System.Xml.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,7 +12,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAsync(string barcode, int itemId, string password = "", ItemRenewOptions renewOptions = null, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/itemsout/{itemId}";
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Password = password, Body = renewOptions ?? new ItemRenewOptions() };
+            var request = PapiRestRequest.Put(url, body: renewOptions ?? new ItemRenewOptions(), password: password);
             return await ExecutePapiAsync<ItemRenewResultWrapper>(request, cancellationToken).ConfigureAwait(false);
         }
         public Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAllForPatronAsync(string barcode, string password = "", ItemRenewOptions renewOptions = null, CancellationToken cancellationToken = default)

--- a/src/polaris-api-csharp/Methods/ItemStatusesGet.cs
+++ b/src/polaris-api-csharp/Methods/ItemStatusesGet.cs
@@ -16,7 +16,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<ItemStatusesGetResult>> ItemStatusesGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/itemstatuses";
-            var request = new PapiRestRequest(url) { BlockStaffOverride = true };
+            var request = PapiRestRequest.Get(url);
+            request.BlockStaffOverride = true;
             return await ExecutePapiAsync<ItemStatusesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
+++ b/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
@@ -5,7 +5,6 @@ using System.Xml.Linq;
 using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -15,7 +14,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/cataloging/items/{(itemRecordId.HasValue ? itemRecordId.Value.ToString() : oldBarcode)}/barcode";
             var body = new ItemUpdateBarcodeData { ItemBarcode = newBarcode, TransactionBranchId = transactionBranchId ?? OrganizationId };
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", transactionBranchId ?? WorkstationId);
             if (!string.IsNullOrWhiteSpace(oldBarcode)) { request.QueryParameters.Add("isBarcode", 1); }
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/LimitFiltersGet.cs
+++ b/src/polaris-api-csharp/Methods/LimitFiltersGet.cs
@@ -16,7 +16,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<LimitFiltersGetResult>> LimitFiltersGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/limitfilters";
-            var request = new PapiRestRequest(url) { BlockStaffOverride = true };
+            var request = PapiRestRequest.Get(url);
+            request.BlockStaffOverride = true;
             return await ExecutePapiAsync<LimitFiltersGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/MARCTypeOfMaterialsGet.cs
+++ b/src/polaris-api-csharp/Methods/MARCTypeOfMaterialsGet.cs
@@ -16,7 +16,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<MARCTypeOfMaterialsGetResult>> MARCTypeOfMaterialsGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/marctypeofmaterials";
-            var request = new PapiRestRequest(url) { BlockStaffOverride = true };
+            var request = PapiRestRequest.Get(url);
+            request.BlockStaffOverride = true;
             return await ExecutePapiAsync<MARCTypeOfMaterialsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/MaterialTypesGet.cs
+++ b/src/polaris-api-csharp/Methods/MaterialTypesGet.cs
@@ -16,7 +16,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<MaterialTypesGetResult>> MaterialTypesGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/materialtypes";
-            var request = new PapiRestRequest(url) { BlockStaffOverride = true };
+            var request = PapiRestRequest.Get(url);
+            request.BlockStaffOverride = true;
             return await ExecutePapiAsync<MaterialTypesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
+++ b/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
@@ -14,7 +14,7 @@ namespace Clc.Polaris.Api
         {
             //"protected/{Version}/{LangID}/{AppID}/{OrgID}/{AccessToken}/notification
             var url = $"/protected/v1/1033/24/{orgId}/{ProtectedToken.Placeholder}/notification/";
-            var request = new PapiRestRequest(url);
+            var request = PapiRestRequest.Get(url);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/NotificationUpdate.cs
+++ b/src/polaris-api-csharp/Methods/NotificationUpdate.cs
@@ -6,7 +6,6 @@ using System.Xml.Linq;
 using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
-using System.Net.Http;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -17,7 +16,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<NotificationUpdateResult>> NotificationUpdateAsync(NotificationUpdateParams updateParams, CancellationToken cancellationToken = default)
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/notification/{updateParams.NotificationTypeId}";
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Body = updateParams };
+            var request = PapiRestRequest.Put(url, body: updateParams);
             return await ExecutePapiAsync<NotificationUpdateResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/OrganizationsGet.cs
+++ b/src/polaris-api-csharp/Methods/OrganizationsGet.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -15,7 +14,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<OrganizationsGetResult>> OrganizationsGetAsync(OrganizationType type = OrganizationType.All, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/organizations/{type}";
-            var request = new PapiRestRequest(url) { BlockStaffOverride = true };
+            var request = PapiRestRequest.Get(url);
+            request.BlockStaffOverride = true;
             return await ExecutePapiAsync<OrganizationsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 using System.Xml.Linq;
 
@@ -18,7 +17,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/createcredit";
             var body = new PatronAccountCreateCreditData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronAccountCreateTitleList.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountCreateTitleList.cs
@@ -6,7 +6,6 @@ using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -18,7 +17,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patronaccountcreatetitlelist";
             var body = new PatronAccountCreateTitleListData { RecordStoreName = listName };
-            var request = new PapiRestRequest(HttpMethod.Post, url) { Password = password, Body = body };
+            var request = PapiRestRequest.Post(url, body: body, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronAccountDeleteTitleList.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDeleteTitleList.cs
@@ -6,7 +6,6 @@ using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -17,7 +16,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountDeleteTitleListAsync(string barcode, int listId, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patronaccountdeletetitlelist";
-            var request = new PapiRestRequest(HttpMethod.Delete, url) { Password = password };
+            var request = PapiRestRequest.Delete(url, password: password);
             request.QueryParameters.Add("list", listId);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 using System.Xml.Linq;
 
@@ -20,7 +19,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumdepositcredit";
             var body = new PatronAccountDepositCreditData { TxnAmount = txnAmount, FreeTextNote = note };
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronAccountGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountGet.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -18,7 +17,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronAccountGetResult>> PatronAccountGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/account/outstanding";
-            var request = new PapiRestRequest(url) { Password = password };
+            var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronAccountGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronAccountGetTitleLists.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountGetTitleLists.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronAccountGetTitleListsResult>> PatronAccountGetTitleListsAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patronaccountgettitlelists";
-            var request = new PapiRestRequest(url) { Password = password };
+            var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronAccountGetTitleListsResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronAccountPay.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPay.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 using System.Xml.Linq;
 
@@ -20,7 +19,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/{txnId}/pay";
             var body = new PatronAccountPayData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 using System.Xml.Linq;
 
@@ -20,7 +19,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumpayment";
             var body = new PatronAccountPayData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 using System.Xml.Linq;
 
@@ -20,7 +19,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumrefundcredit";
             var body = new PatronAccountRefundCreditData { TxnAmount = txnAmount, FreeTextNote = note };
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 using System.Xml.Linq;
 
@@ -19,7 +18,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountVoidAsync(string barcode, int paymentTxnId, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/{paymentTxnId}/void/payment";
-            var request = new PapiRestRequest(HttpMethod.Delete, url);
+            var request = PapiRestRequest.Delete(url);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronBasicDataGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronBasicDataGet.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -18,7 +17,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronBasicDataGetResult>> PatronBasicDataGetAsync(string barcode, string password = "", bool addresses = false, bool notes = false, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/basicdata";
-            var request = new PapiRestRequest(url) { Password = password };
+            var request = PapiRestRequest.Get(url, password: password);
             request.QueryParameters.Add("addresses", Convert.ToInt32(addresses));
             request.QueryParameters.Add("notes", Convert.ToInt32(notes));
             return await ExecutePapiAsync<PatronBasicDataGetResult>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronCirculateBlocksGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronCirculateBlocksGet.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -18,7 +17,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronCirculateBlocksResult>> PatronCirculateBlocksGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/circulationblocks";
-            var request = new PapiRestRequest(url) { Password = password };
+            var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronCirculateBlocksResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronCodesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronCodesGet.cs
@@ -16,7 +16,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronCodesGetResult>> PatronCodesGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/patroncodes";
-            var request = new PapiRestRequest(url) { BlockStaffOverride = true };
+            var request = PapiRestRequest.Get(url);
+            request.BlockStaffOverride = true;
             return await ExecutePapiAsync<PatronCodesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronHoldRequestsGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronHoldRequestsGet.cs
@@ -2,7 +2,6 @@
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 namespace Clc.Polaris.Api
@@ -14,7 +13,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronHoldRequestsGetResult>> PatronHoldRequestsGetAsync(string barcode, PatronHoldStatus status = PatronHoldStatus.all, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{status}";
-            var request = new PapiRestRequest(url) { Password = password };
+            var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronHoldRequestsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronILLRequestsGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronILLRequestsGet.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -18,7 +17,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronILLRequestsGetResult>> PatronILLRequestsGetAsync(string barcode, ILLStatus status = ILLStatus.All, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/illrequests/{status}";
-            var request = new PapiRestRequest(url) { Password = password };
+            var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronILLRequestsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronItemsOutGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronItemsOutGet.cs
@@ -1,7 +1,6 @@
 ﻿using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 namespace Clc.Polaris.Api
@@ -13,7 +12,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronItemsOutGetResult>> PatronItemsOutGetAsync(string barcode, PatronItemsOutGetStatus status = PatronItemsOutGetStatus.All, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/itemsout/{status}";
-            var request = new PapiRestRequest(url) { Password = password };
+            var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronItemsOutGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronMessageDelete.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessageDelete.cs
@@ -6,7 +6,6 @@ using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -17,7 +16,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PapiResponseCommon>> PatronMessageDeleteAsync(string barcode, PatronMessageType messageType, int messageId, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/messages/{messageType}/{messageId}";
-            var request = new PapiRestRequest(HttpMethod.Delete, url) { Password = password };
+            var request = PapiRestRequest.Delete(url, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronMessageUpdateStatus.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessageUpdateStatus.cs
@@ -6,7 +6,6 @@ using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -17,7 +16,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PapiResponseCommon>> PatronMessageUpdateStatusAsync(string barcode, PatronMessageType messageType, int messageId, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/messages/{messageType}/{messageId}";
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Password = password };
+            var request = PapiRestRequest.Put(url, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronMessagesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessagesGet.cs
@@ -6,7 +6,6 @@ using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -17,7 +16,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronMessagesGetResult>> PatronMessagesGetAsync(string barcode, bool unreadOnly = false, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/messages";
-            var request = new PapiRestRequest(url) { Password = password };
+            var request = PapiRestRequest.Get(url, password: password);
             request.QueryParameters.Add("unreadonly", unreadOnly ? 1 : 0);
             return await ExecutePapiAsync<PatronMessagesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronPreferencesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronPreferencesGet.cs
@@ -6,7 +6,6 @@ using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -17,7 +16,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronPreferencesGetResult>> PatronPreferencesGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/preferences";
-            var request = new PapiRestRequest(url) { Password = password };
+            var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronPreferencesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
+++ b/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
@@ -6,7 +6,6 @@ using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -20,7 +19,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PapiResponseCommon>> PatronReadingHistoryClearAsync(string barcode, string password, IEnumerable<int> ids, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/readinghistory";
-            var request = new PapiRestRequest(HttpMethod.Delete, url) { Password = password };
+            var request = PapiRestRequest.Delete(url, password: password);
             if (ids.Any()) { request.QueryParameters.Add("ids", string.Join(",", ids)); }
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronReadingHistoryGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronReadingHistoryGet.cs
@@ -6,7 +6,6 @@ using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -17,7 +16,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronReadingHistoryGetResult>> PatronReadingHistoryGetAsync(string barcode, int page = 1, int rowsPerPage = 50, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/readinghistory";
-            var request = new PapiRestRequest(url) { Password = password };
+            var request = PapiRestRequest.Get(url, password: password);
             request.QueryParameters.Add("page", page);
             request.QueryParameters.Add("rowsperpage", rowsPerPage);
             return await ExecutePapiAsync<PatronReadingHistoryGetResult>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronRegistrationCreate.cs
+++ b/src/polaris-api-csharp/Methods/PatronRegistrationCreate.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 
-using System.Net.Http;
 using Clc.Polaris.Models;
 
 namespace Clc.Polaris.Api
@@ -19,14 +18,16 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronRegistrationCreateResult>> PatronRegistrationCreateAsync(PatronRegistrationParams _params, CancellationToken cancellationToken = default)
         {
             var url = "/public/v1/1033/100/1/patron";
-            var request = new PapiRestRequest(HttpMethod.Post, url) { BlockStaffOverride = true, Body = _params };
+            var request = PapiRestRequest.Post(url, body: _params);
+            request.BlockStaffOverride = true;
             return await ExecutePapiAsync<PatronRegistrationCreateResult>(request, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<IRestResponse<PatronRegistrationCreateResult>> PatronRegistrationCreateV2Async(PatronRegistrationData _params, CancellationToken cancellationToken = default)
         {
             var url = "/public/v2/1033/100/1/patron";
-            var request = new PapiRestRequest(HttpMethod.Post, url) { BlockStaffOverride = true, Body = _params };
+            var request = PapiRestRequest.Post(url, body: _params);
+            request.BlockStaffOverride = true;
             return await ExecutePapiAsync<PatronRegistrationCreateResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronRenewBlocksGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronRenewBlocksGet.cs
@@ -5,7 +5,6 @@ using System.Xml.Linq;
 using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -16,7 +15,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronRenewBlocksResult>> PatronRenewBlocksGetAsync(int patronId, int? branchId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/protected/v1/1033/100/{branchId ?? OrganizationId}/{ProtectedToken.Placeholder}/circulation/patron/{patronId}/renewblocks";
-            var request = new PapiRestRequest(url);
+            var request = PapiRestRequest.Get(url);
             return await ExecutePapiAsync<PatronRenewBlocksResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronSavedSearchesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronSavedSearchesGet.cs
@@ -6,7 +6,6 @@ using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -17,7 +16,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronSavedSearchesGetResult>> PatronSavedSearchesGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/savedsearches";
-            var request = new PapiRestRequest(url) { Password = password };
+            var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronSavedSearchesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronSearch.cs
+++ b/src/polaris-api-csharp/Methods/PatronSearch.cs
@@ -1,7 +1,6 @@
 ﻿using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 namespace Clc.Polaris.Api
@@ -13,7 +12,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronSearchResult>> PatronSearchAsync(string query, int page = 1, int pageSize = 10, PatronSortKeys sortBy = PatronSortKeys.PATN, int? orgId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/protected/v1/1033/100/{orgId ?? OrganizationId}/{ProtectedToken.Placeholder}/search/patrons/Boolean";
-            var request = new PapiRestRequest(url);
+            var request = PapiRestRequest.Get(url);
             request.QueryParameters.Add("q", query);
             request.QueryParameters.Add("patronsperpage", pageSize);
             request.QueryParameters.Add("page", page);

--- a/src/polaris-api-csharp/Methods/PatronTitleListAddTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListAddTitle.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -20,7 +19,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistaddtitle/";
             var body = new PatronTitleListAddTitleData { RecordStoreId = recordStoreId, LocalControlNumber = localControlNumber };
-            var request = new PapiRestRequest(HttpMethod.Post, url) { Password = password, Body = body };
+            var request = PapiRestRequest.Post(url, body: body, password: password);
             return await ExecutePapiAsync<PatronTitleListAddTitleResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronTitleListCopyAllTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListCopyAllTitles.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -20,7 +19,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistcopyalltitles/";
             var body = new PatronTitleListCopyAllTitlesData { FromRecordStoreId = fromRecordStoreId, ToRecordStoreId = toRecordStoreId };
-            var request = new PapiRestRequest(HttpMethod.Post, url) { Password = password, Body = body };
+            var request = PapiRestRequest.Post(url, body: body, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronTitleListCopyTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListCopyTitle.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -26,7 +25,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistcopytitle/";
             var body = new PatronTitleListCopyTitleData { FromRecordStoreId = fromRecordStoreId, FromPosition = fromPosition, ToRecordStoreId = toRecordStoreId };
-            var request = new PapiRestRequest(HttpMethod.Post, url) { Password = password, Body = body };
+            var request = PapiRestRequest.Post(url, body: body, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronTitleListDeleteAllTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListDeleteAllTitles.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -19,7 +18,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PapiResponseCommon>> PatronTitleListDeleteAllTitlesAsync(string barcode, int listId, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistdeletealltitles";
-            var request = new PapiRestRequest(HttpMethod.Delete, url) { Password = password };
+            var request = PapiRestRequest.Delete(url, password: password);
             request.QueryParameters.Add("list", listId);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -27,7 +26,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PapiResponseCommon>> PatronTitleListDeleteTitleAsync(string barcode, int listId, int position, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistdeletetitle";
-            var request = new PapiRestRequest(HttpMethod.Delete, url) { Password = password };
+            var request = PapiRestRequest.Delete(url, password: password);
             request.QueryParameters.Add("list", listId);
             request.QueryParameters.Add("position", position);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronTitleListGetTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListGetTitles.cs
@@ -6,7 +6,6 @@ using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -17,7 +16,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronTitleListGetTitlesResult>> PatronTitleListGetTitlesAsync(string barcode, int listId, int startPosition = 1, int endPosition = 100, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistgettitles";
-            var request = new PapiRestRequest(url) { Password = password };
+            var request = PapiRestRequest.Get(url, password: password);
             request.QueryParameters.Add("list", listId);
             request.QueryParameters.Add("startPosition", startPosition);
             request.QueryParameters.Add("endPosition", endPosition);

--- a/src/polaris-api-csharp/Methods/PatronTitleListMoveTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListMoveTitle.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -29,7 +28,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistmovetitle/";
             var body = new PatronTitleListMoveTitleData { FromRecordStoreId = fromRecordStoreId, FromPosition = fromPosition, ToRecordStoreId = toRecordStoreId };
-            var request = new PapiRestRequest(HttpMethod.Post, url) { Password = password, Body = body };
+            var request = PapiRestRequest.Post(url, body: body, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronUpdate.cs
+++ b/src/polaris-api-csharp/Methods/PatronUpdate.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Net;
 using System.Text;
 using System.Xml.Linq;
@@ -20,7 +19,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronUpdateResult>> PatronUpdateAsync(string barcode, PatronUpdateParams updateParams, string password = "", bool ignoresa = true, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}";
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Password = password, Body = updateParams };
+            var request = PapiRestRequest.Put(url, body: updateParams, password: password);
             request.QueryParameters.Add("ignoresa", ignoresa);
             return await ExecutePapiAsync<PatronUpdateResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronUpdateUserName.cs
+++ b/src/polaris-api-csharp/Methods/PatronUpdateUserName.cs
@@ -6,7 +6,6 @@ using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -17,7 +16,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PapiResponseCommon>> PatronUpdateUserNameAsync(string barcode, string newUsername, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/username/{WebUtility.UrlEncode(newUsername)}";
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Password = password };
+            var request = PapiRestRequest.Put(url, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/PatronValidate.cs
+++ b/src/polaris-api-csharp/Methods/PatronValidate.cs
@@ -1,7 +1,6 @@
 ﻿using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 namespace Clc.Polaris.Api
@@ -13,7 +12,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PatronValidateResult>> PatronValidateAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}";
-            var request = new PapiRestRequest(url) { Password = password };
+            var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronValidateResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
+++ b/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
@@ -2,7 +2,6 @@
 using Clc.Polaris.Api.Models;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 namespace Clc.Polaris.Api
@@ -14,7 +13,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<GetBarcodeAndPatronIDResult>> Patron_GetBarcodeFromIdAsync(int patronId, CancellationToken cancellationToken = default)
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/barcode";
-            var request = new PapiRestRequest(url);
+            var request = PapiRestRequest.Get(url);
             request.QueryParameters.Add("patronid", patronId);
             return await ExecutePapiAsync<GetBarcodeAndPatronIDResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PickupBranchesGet.cs
+++ b/src/polaris-api-csharp/Methods/PickupBranchesGet.cs
@@ -16,7 +16,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PickupBranchesGetResult>> PickupBranchesGetAsync(int? organizationId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{organizationId ?? OrganizationId}/pickupbranches";
-            var request = new PapiRestRequest(url) { BlockStaffOverride = true };
+            var request = PapiRestRequest.Get(url);
+            request.BlockStaffOverride = true;
             return await ExecutePapiAsync<PickupBranchesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -18,7 +17,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/recordsets/{recordSetId}";
             var body = new { records = string.Join(",", records) };
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Body = body };
+            var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("action", action);
             request.QueryParameters.Add("userid", userId ?? UserId);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -17,7 +16,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<RecordSetRecordsGetResult>> RecordSetRecordsGetAsync(int recordSetId, int userId = 1, int workstationId = 1, int startIndex = 0, int numRecords = 1000, CancellationToken cancellationToken = default)
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/recordsets/{recordSetId}/records";
-            var request = new PapiRestRequest(url);
+            var request = PapiRestRequest.Get(url);
             request.QueryParameters.Add("startIndex", startIndex);
             request.QueryParameters.Add("numRecords", numRecords);
             request.QueryParameters.Add("userid", userId);

--- a/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
+++ b/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
@@ -5,7 +5,6 @@ using System.Xml.Linq;
 using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -16,7 +15,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<RemoteStorageItemsGetResult>> RemoteStorageItemsGetAsync(int branchId, string startDate, string endDate, int maxItems, int listType, int? startItemRecordId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/cataloging/remotestorage/items";
-            var request = new PapiRestRequest(url);
+            var request = PapiRestRequest.Get(url);
             request.QueryParameters.Add("branch", branchId);
             request.QueryParameters.Add("startdate", startDate);
             request.QueryParameters.Add("enddate", endDate);

--- a/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
+++ b/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -23,7 +22,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<StringResult>> SA_GetValueByOrgAsync(string attribute, int? organizationId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/organization/{organizationId ?? OrganizationId}/sysadmin/attribute/{attribute}";
-            var request = new PapiRestRequest(url);
+            var request = PapiRestRequest.Get(url);
             return await ExecutePapiAsync<StringResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/ShelfLocationsGet.cs
+++ b/src/polaris-api-csharp/Methods/ShelfLocationsGet.cs
@@ -16,7 +16,8 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<ShelfLocationsGetResult>> ShelfLocationsGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/shelflocations";
-            var request = new PapiRestRequest(url) { BlockStaffOverride = true };
+            var request = PapiRestRequest.Get(url);
+            request.BlockStaffOverride = true;
             return await ExecutePapiAsync<ShelfLocationsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
+++ b/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 
 namespace Clc.Polaris.Api
@@ -15,7 +14,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<Sync_BibsByIdGetResult>> Synch_BibsByIdGetAsync(int[] bibIds, bool includeItems = false, CancellationToken cancellationToken = default)
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/synch/bibs/MARCxml";
-            var request = new PapiRestRequest(url);
+            var request = PapiRestRequest.Get(url);
             request.QueryParameters.Add("bibids", string.Join(",", bibIds));
             if (includeItems)
             {

--- a/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
@@ -4,7 +4,6 @@ using Clc.Rest;
 using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,7 +34,7 @@ namespace Clc.Polaris.Api
                 body.BlockingNoteMode = (int)updateMode;
             }
 
-            var request = new PapiRestRequest(HttpMethod.Post, url) { Body = body };
+            var request = PapiRestRequest.Post(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/UpdatePickupBranchID.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePickupBranchID.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Net;
 using System.Text;
 
@@ -18,7 +17,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PapiResponseCommon>> UpdatePickupBranchIDAsync(string barcode, int requestId, int pickupBranchId, string password = "", int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/pickupbranch";
-            var request = new PapiRestRequest(HttpMethod.Put, url) { Password = password };
+            var request = PapiRestRequest.Put(url, password: password);
             request.QueryParameters.Add("userid", userId ?? UserId);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("pickupbranchid", pickupBranchId);

--- a/src/polaris-api-csharp/Methods/_template_get.cs
+++ b/src/polaris-api-csharp/Methods/_template_get.cs
@@ -5,7 +5,6 @@ using System.Xml.Linq;
 using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -14,7 +13,7 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<PapiResponseCommon>> PapiGetMethodAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/";
-            var request = new PapiRestRequest(url) { Password = password };
+            var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Methods/_template_post.cs
+++ b/src/polaris-api-csharp/Methods/_template_post.cs
@@ -5,7 +5,6 @@ using System.Xml.Linq;
 using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
-using System.Net.Http;
 
 namespace Clc.Polaris.Api
 {
@@ -15,7 +14,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/foo";
             var body = new object();
-            var request = new PapiRestRequest(HttpMethod.Post, url) { Password = password, Body = body };
+            var request = PapiRestRequest.Post(url, body: body, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/polaris-api-csharp/Models/PapiRestRequest.cs
+++ b/src/polaris-api-csharp/Models/PapiRestRequest.cs
@@ -1,10 +1,6 @@
 ﻿using Clc.Rest.Models;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api.Models
 {
@@ -18,6 +14,16 @@ namespace Clc.Polaris.Api.Models
 
         public bool IsPublicMethod => Path.StartsWith("/public", StringComparison.OrdinalIgnoreCase);
         public bool IsProtectedMethod => Path.StartsWith("/protected", StringComparison.OrdinalIgnoreCase);
+
+        public static PapiRestRequest Get(string path, string password = "", object body = null) => new PapiRestRequest(HttpMethod.Get, path, password, body);
+
+        public static PapiRestRequest Delete(string path, string password = "", object body = null) => new PapiRestRequest(HttpMethod.Delete, path, password, body);
+
+        public static PapiRestRequest Post(string path, object body = null, string password = "") => new PapiRestRequest(HttpMethod.Post, path, password, body);
+
+        public static PapiRestRequest Put(string path, object body = null, string password = "") => new PapiRestRequest(HttpMethod.Put, path, password, body);
+
+        public static PapiRestRequest Create(HttpMethod method, string path, object body = null, string password = "") => new PapiRestRequest(method, path, password, body);
 
         public PapiRestRequest()
         {

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -51,6 +51,41 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public void PapiRestRequest_Factories_CreateExpectedRequests()
+        {
+            var getBody = new { Name = "Get" };
+            var get = PapiRestRequest.Get("/public/get", password: "pin", body: getBody);
+            Assert.AreEqual(HttpMethod.Get, get.Method);
+            Assert.AreEqual("/public/get", get.Path);
+            Assert.AreEqual("pin", get.Password);
+            Assert.AreSame(getBody, get.Body);
+
+            var postBody = new { Name = "Post" };
+            var post = PapiRestRequest.Post("/public/post", body: postBody);
+            Assert.AreEqual(HttpMethod.Post, post.Method);
+            Assert.AreEqual("/public/post", post.Path);
+            Assert.AreSame(postBody, post.Body);
+
+            var putBody = new { Name = "Put" };
+            var put = PapiRestRequest.Put("/public/put", body: putBody, password: "put-pin");
+            Assert.AreEqual(HttpMethod.Put, put.Method);
+            Assert.AreEqual("/public/put", put.Path);
+            Assert.AreEqual("put-pin", put.Password);
+            Assert.AreSame(putBody, put.Body);
+
+            var delete = PapiRestRequest.Delete("/public/delete");
+            Assert.AreEqual(HttpMethod.Delete, delete.Method);
+            Assert.AreEqual("/public/delete", delete.Path);
+
+            var createBody = new { Name = "Create" };
+            var create = PapiRestRequest.Create(HttpMethod.Patch, "/public/create", body: createBody, password: "create-pin");
+            Assert.AreEqual(HttpMethod.Patch, create.Method);
+            Assert.AreEqual("/public/create", create.Path);
+            Assert.AreEqual("create-pin", create.Password);
+            Assert.AreSame(createBody, create.Body);
+        }
+
+        [TestMethod]
         public void PapiRestRequest_PathClassification_IsStable()
         {
             var publicRequest = new PapiRestRequest("/public/foo");


### PR DESCRIPTION
### Motivation
- Improve readability of mechanical request construction by providing static factory helpers on `PapiRestRequest` modeled after `RestRequest` without changing runtime behavior.
- Make call sites clearer by preferring named `body`/`password` arguments and removing stale commented initializer fragments.

### Description
- Added static factories to `PapiRestRequest`: `Get`, `Delete`, `Post`, `Put`, and `Create` that delegate to the existing constructor and preserved all existing constructors unchanged.
- Rewrote method files to use the new factories (e.g. `PapiRestRequest.Get(url)`, `PapiRestRequest.Post(url, body: body)`, `PapiRestRequest.Put(url, body: body, password: password)`) while keeping property initializers for non-factory properties like `BlockStaffOverride` and query/header population.
- Removed stale generated/commented initializer fragments and removed now-unused `using System.Net.Http;` lines from touched files where applicable.
- Added unit tests `PapiRestRequest_Factories_CreateExpectedRequests` to assert that the factories set `Method`, `Path`, `Password`, and `Body` as expected and left existing characterization tests intact.

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` and `dotnet build src/polaris-api-csharp.sln --no-restore` which succeeded.
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory=RestClientMigration"` and `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "TestCategory!=Integration"`, and all targeted tests passed (RestClientMigration tests and non-integration tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b36bb4a608323bdb233310d80cdfd)