### PR TITLE
Add README and expand migration guidance (protected-token, async examples)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -14,6 +14,33 @@ var response = client.BibSearch(options);
 var response = await client.BibSearchAsync(options, cancellationToken);
 ```
 
+### Before and after
+
+A synchronous 3.x call should become an awaited 4.0 async call:
+
+```csharp
+// 3.x
+var account = client.PatronAccountGet("21221012345678", "patron-password");
+
+if (account.Data.PAPIErrorCode == 0)
+{
+    Console.WriteLine(account.Data.PatronAccountGetRows.Count);
+}
+```
+
+```csharp
+// 4.0
+var account = await client.PatronAccountGetAsync(
+    "21221012345678",
+    "patron-password",
+    cancellationToken);
+
+if (account.Data.PAPIErrorCode == 0)
+{
+    Console.WriteLine(account.Data.PatronAccountGetRows.Count);
+}
+```
+
 ## CancellationToken support
 
 Public client methods accept `CancellationToken cancellationToken = default` so callers can cancel both the final PAPI request and any required authentication request, such as protected-token acquisition.
@@ -22,6 +49,23 @@ Public client methods accept `CancellationToken cancellationToken = default` so 
 
 The former synchronous `Execute<T>` and `Post<T>` compatibility shims were intentionally removed. Callers should await the async methods instead of blocking on them.
 
+## Protected-token path requests
+
+Some protected PAPI endpoints require the protected access token as a URL path segment. Public client methods for those endpoints use `ProtectedToken.Placeholder` internally when constructing the request path.
+
+`ExecutePapiAsync` replaces that placeholder with the current protected access token before the request is sent and before the PAPI hash is formatted. If `StaffOverrideAccount` is configured and a valid token is not already available, the client can acquire a protected token automatically before replacing the placeholder.
+
+Consumers generally should not need to use `ProtectedToken.Placeholder` directly unless constructing a `PapiRestRequest` manually.
+
 ## Patron reading history overloads
 
 `PatronReadingHistoryClear` overloads that previously accepted `params int[]` now accept `IEnumerable<int>`. This keeps `CancellationToken` as the final optional parameter while still allowing callers to pass arrays or other integer sequences.
+
+```csharp
+var readingHistoryIds = new[] { 101, 102, 103 };
+
+var clearResponse = await client.PatronReadingHistoryClearAsync(
+    "21221012345678",
+    readingHistoryIds,
+    cancellationToken);
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# Clc.Polaris.Api
+
+`Clc.Polaris.Api` is a .NET helper library for calling the Polaris ILS PAPI REST API. It provides a small `PapiClient` wrapper, typed request/response models, PAPI request signing, and protected/staff-override token handling.
+
+## Install
+
+Install the `4.0.0-alpha.1` prerelease package:
+
+```bash
+dotnet add package Clc.Polaris.Api --version 4.0.0-alpha.1
+```
+
+## Configure `PapiClient`
+
+Create settings with your Polaris PAPI credentials and pass them to `PapiClient`:
+
+```csharp
+using Clc.Polaris.Api;
+using Clc.Polaris.Api.Configuration;
+using Clc.Polaris.Api.Models;
+
+var settings = new PapiSettings
+{
+    Hostname = "https://polaris.example.org",
+    AccessId = "your-access-id",
+    AccessKey = "your-access-key",
+    OrganizationId = 3,
+    WorkstationId = 12,
+    UserId = 42,
+    PolarisOverrideAccount = new PolarisUser("LIBRARY", "staff.user", "password")
+};
+
+var client = new PapiClient(settings);
+```
+
+When `PolarisOverrideAccount` / `StaffOverrideAccount` is configured, protected requests and eligible staff-override requests can acquire protected tokens automatically. Endpoints that require a protected token in the URL path use `ProtectedToken.Placeholder` internally; callers normally do not need to set or replace that placeholder themselves.
+
+## Basic async usage
+
+All public client methods are async-only. Await the `*Async` method and pass a `CancellationToken` where appropriate so the PAPI request and any required authentication request can be cancelled.
+
+```csharp
+using Clc.Polaris.Api.Models;
+
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+var response = await client.BibKeywordSearchAsync(
+    keyword: "octavia butler",
+    branchId: 3,
+    page: 1,
+    pageSize: 10,
+    cancellationToken: cts.Token);
+
+if (response.Response.IsSuccessStatusCode && response.Data?.BibSearchRows != null)
+{
+    foreach (var bib in response.Data.BibSearchRows)
+    {
+        Console.WriteLine($"{bib.Title} ({bib.ControlNumber})");
+    }
+}
+```
+
+Do not block on client calls with synchronous wrappers or `.Result`; synchronous public client APIs are not supported in 4.0.
+
+## Local testing
+
+From the repository root, run:
+
+```bash
+dotnet test src/polaris-api-csharp.sln
+```
+
+## Migration guide
+
+See [MIGRATION.md](MIGRATION.md) for guidance on moving from the 3.x synchronous API to the 4.0 async-only API.


### PR DESCRIPTION
### Motivation

- Provide a concise root README that documents package purpose, install instructions for `4.0.0-alpha.1`, basic async usage, `PapiClient` configuration, and local test guidance. 
- Clarify async-only behavior and CancellationToken usage so consumers migrate from 3.x without relying on removed synchronous wrappers. 
- Explain protected-token handling and placeholder usage so callers understand protected-token-in-path endpoints without exposing implementation internals.

### Description

- Add `README.md` with package purpose, `dotnet add package ... --version 4.0.0-alpha.1`, a compact `PapiClient` settings example, a basic awaited async usage snippet, notes that public methods are async-only and callers should pass `CancellationToken`, guidance on protected/staff-override tokens and `ProtectedToken.Placeholder`, local test command, and a link to `MIGRATION.md`. 
- Expand `MIGRATION.md` to keep async-only migration guidance and add a protected-token path requests section describing internal use of `ProtectedToken.Placeholder` and when `ExecutePapiAsync` replaces it. 
- Add a before/after example showing a synchronous 3.x call converted to an awaited 4.0 async call and include a `PatronReadingHistoryClearAsync` example demonstrating the `IEnumerable<int>` overload. 
- Make a small example tweak to null-check the response in the README usage snippet (`response.Response.IsSuccessStatusCode && response.Data?.BibSearchRows != null`) for realism without documenting internal cache/semaphore behavior.

### Testing

- Ran `dotnet build src/polaris-api-csharp.sln --no-restore`, which succeeded. 
- Ran `dotnet test src/polaris-api-csharp.sln`, which exercised tests but produced multiple failures because the required `appsettings.Test.json` configuration file was not present in the test output path, causing test initialization errors. 
- Ran basic repository checks (`git diff --check`) with no style errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b5c2bdd18832382c893130099a6fb)