### PR TITLE
Add README and expand MIGRATION.md with protected-token guidance

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -25,3 +25,35 @@ The former synchronous `Execute<T>` and `Post<T>` compatibility shims were inten
 ## Patron reading history overloads
 
 `PatronReadingHistoryClear` overloads that previously accepted `params int[]` now accept `IEnumerable<int>`. This keeps `CancellationToken` as the final optional parameter while still allowing callers to pass arrays or other integer sequences.
+
+## Protected-token path requests
+
+Some protected PAPI endpoints include the protected access token as a URL path segment. In 4.0, built-in client methods for those endpoints use `ProtectedToken.Placeholder` internally for that path segment.
+
+`ExecutePapiAsync` replaces `ProtectedToken.Placeholder` with the current protected access token before the request is sent and before the URL is formatted for the PAPI hash. Consumers generally should not need to use the placeholder directly unless constructing a `PapiRestRequest` manually.
+
+## PatronReadingHistoryClearAsync example
+
+`PatronReadingHistoryClearAsync` accepts an `IEnumerable<int>` for reading-history IDs:
+
+```csharp
+var idsToClear = new[] { 101, 102, 103 };
+
+var response = await client.PatronReadingHistoryClearAsync(
+    barcode: "21221000000000",
+    ids: idsToClear,
+    cancellationToken: cancellationToken);
+```
+
+## Before/after sync-to-async example
+
+```csharp
+// 3.x synchronous call
+var syncResponse = client.PatronReadingHistoryClear("21221000000000", 101, 102, 103);
+
+// 4.0 async call
+var asyncResponse = await client.PatronReadingHistoryClearAsync(
+    "21221000000000",
+    new[] { 101, 102, 103 },
+    cancellationToken);
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# Clc.Polaris.Api
+
+`Clc.Polaris.Api` is a .NET helper library for calling the Polaris ILS PAPI REST API. It provides a typed `PapiClient` with request signing, protected/staff-override token support, and async methods for common PAPI workflows.
+
+## Install
+
+```bash
+dotnet add package Clc.Polaris.Api --version 4.0.0-alpha.1
+```
+
+## Basic configuration
+
+Configure `PapiClient` with your PAPI host, access credentials, workstation context, and optional staff override account:
+
+```csharp
+using Clc.Polaris.Api;
+using Clc.Polaris.Api.Configuration;
+using Clc.Polaris.Api.Models;
+
+var settings = new PapiSettings
+{
+    Hostname = "https://catalog.example.org",
+    AccessId = "your-access-id",
+    AccessKey = "your-access-key",
+    OrganizationId = 100,
+    WorkstationId = 1,
+    UserId = 1,
+    PolarisOverrideAccount = new PolarisUser("LIBRARY", "staff.user", "staff-password")
+};
+
+var client = new PapiClient(settings);
+```
+
+When `PapiClient.StaffOverrideAccount` is configured directly or through `PapiSettings.PolarisOverrideAccount`, protected requests and eligible staff-override requests can acquire protected tokens automatically. Endpoints that require a protected token in the URL path use `ProtectedToken.Placeholder` internally; callers usually do not need to supply it themselves.
+
+## Basic async usage
+
+Public client methods are async-only in 4.0. Await them instead of using synchronous wrappers, and pass a `CancellationToken` where your application can cancel work:
+
+```csharp
+using Clc.Polaris.Api.Models;
+
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+var response = await client.BibKeywordSearchAsync(
+    keyword: "octavia butler",
+    branchId: 100,
+    page: 1,
+    pageSize: 10,
+    cancellationToken: cts.Token);
+
+if (response.IsSuccessStatusCode)
+{
+    var results = response.Data;
+    // Use the search results.
+}
+```
+
+## Local testing
+
+Restore and run the test project from the repository root:
+
+```bash
+dotnet restore src/polaris-api-csharp.sln
+dotnet test src/polaris-api-csharp.sln
+```
+
+Some integration-style tests may require local configuration or environment variables for a reachable Polaris PAPI instance.
+
+## Migration guide
+
+See [MIGRATION.md](MIGRATION.md) for 3.x to 4.0 migration notes, including async-only API changes and protected-token path behavior.


### PR DESCRIPTION
### Motivation

- Provide a concise root README so consumers can quickly learn package purpose, installation, basic configuration, and async usage for the 4.0 alpha release.  
- Clarify protected-token behavior and migration steps for callers moving from synchronous 3.x APIs to async 4.0 APIs.

### Description

- Add `README.md` with package name/purpose, the install command `dotnet add package Clc.Polaris.Api --version 4.0.0-alpha.1`, a compact `PapiClient` configuration example, a basic async usage example, and notes that public methods are async-only and callers should pass a `CancellationToken` where appropriate.  
- Document that protected/staff-override requests can acquire protected tokens automatically when `PapiClient.StaffOverrideAccount` (or `PapiSettings.PolarisOverrideAccount`) is configured, and that endpoints that need a protected token in the URL path use `ProtectedToken.Placeholder` internally.  
- Expand `MIGRATION.md` to preserve existing async-only migration content and add a new section explaining protected-token path requests and that `ExecutePapiAsync` replaces `ProtectedToken.Placeholder` before the request is sent and before PAPI hash formatting.  
- Add a `PatronReadingHistoryClearAsync` example showing the `IEnumerable<int>` overload and a before/after snippet demonstrating a 3.x synchronous call converted to an awaited 4.0 async call.

### Testing

- Ran `dotnet build src/polaris-api-csharp.sln --no-restore`, which succeeded.  
- Ran `dotnet test src/polaris-api-csharp.sln`, which executed tests but many tests failed during test class construction because `appsettings.Test.json` was not present in the test output directory in this environment.  
- Ran repository checks (`git diff --check`) with no reported problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b5c2bdd18832382c893130099a6fb)