### PR TITLE
Add README and expand migration notes

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -14,6 +14,31 @@ var response = client.BibSearch(options);
 var response = await client.BibSearchAsync(options, cancellationToken);
 ```
 
+### Before and after example
+
+```csharp
+// 3.x synchronous call
+var response = client.PatronBasicDataGet(barcode, password);
+
+if (response.Response.IsSuccessStatusCode)
+{
+    var patron = response.Data;
+}
+```
+
+```csharp
+// 4.0 async call
+var response = await client.PatronBasicDataGetAsync(
+    barcode,
+    password,
+    cancellationToken: cancellationToken);
+
+if (response.Response.IsSuccessStatusCode)
+{
+    var patron = response.Data;
+}
+```
+
 ## CancellationToken support
 
 Public client methods accept `CancellationToken cancellationToken = default` so callers can cancel both the final PAPI request and any required authentication request, such as protected-token acquisition.
@@ -25,3 +50,20 @@ The former synchronous `Execute<T>` and `Post<T>` compatibility shims were inten
 ## Patron reading history overloads
 
 `PatronReadingHistoryClear` overloads that previously accepted `params int[]` now accept `IEnumerable<int>`. This keeps `CancellationToken` as the final optional parameter while still allowing callers to pass arrays or other integer sequences.
+
+```csharp
+IEnumerable<int> readingHistoryIds = new[] { 12345, 67890 };
+
+var response = await client.PatronReadingHistoryClearAsync(
+    barcode,
+    readingHistoryIds,
+    cancellationToken);
+```
+
+## Protected-token path requests
+
+Some protected PAPI endpoints include the protected access token in the URL path. In 4.0, the built-in client methods for those endpoints use `ProtectedToken.Placeholder` internally for the protected-token URL path segment.
+
+`ExecutePapiAsync` replaces the placeholder with the active protected access token before the request is sent and before PAPI hash formatting occurs. This allows the final URL and authorization hash to use the same tokenized path.
+
+Consumers generally should not need to use `ProtectedToken.Placeholder` directly unless they are constructing a `PapiRestRequest` manually.

--- a/README.md
+++ b/README.md
@@ -63,10 +63,41 @@ Protected-token-in-path endpoints use `ProtectedToken.Placeholder` internally. M
 
 ## Local tests
 
-Run the test suite from the repository root:
+Run non-integration tests from the repository root:
 
 ```bash
-dotnet test src/polaris-api-csharp.sln
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"
+```
+
+Run integration tests only when you have local Polaris settings configured:
+
+```bash
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Integration"
+```
+
+Integration tests require local Polaris credentials and test data in `src/polaris-api-csharpTests/appsettings.Test.json`, so they are not run by default in CI. Do not commit real secrets; `appsettings.Test.json` is ignored by git.
+
+A local `appsettings.Test.json` follows this shape:
+
+```json
+{
+  "PapiSettings": {
+    "AccessId": "your-access-id",
+    "AccessKey": "your-access-key",
+    "Hostname": "https://polaris.example.org",
+    "PolarisOverrideAccount": {
+      "Domain": "LIBRARY",
+      "Username": "staff.user",
+      "Password": "staff-password"
+    }
+  },
+  "PatronId": 123456,
+  "PatronBarcode": "12345678901234",
+  "PatronPin": "1234",
+  "FreeTextBlock": "Local integration test block",
+  "PatronListName": "Local integration test list",
+  "OrgEmail": "library@example.org"
+}
 ```
 
 ## Migration guide

--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# Clc.Polaris.Api
+
+`Clc.Polaris.Api` is a .NET helper package for calling the Polaris Integrated Library System (ILS) PAPI REST API from C# applications.
+
+## Install
+
+```bash
+dotnet add package Clc.Polaris.Api --version 4.0.0-alpha.1
+```
+
+## Configure `PapiClient`
+
+```csharp
+using Clc.Polaris.Api;
+using Clc.Polaris.Api.Configuration;
+using Clc.Polaris.Api.Models;
+
+var settings = new PapiSettings
+{
+    Hostname = "https://polaris.example.org",
+    AccessId = "your-access-id",
+    AccessKey = "your-access-key",
+    OrganizationId = 100,
+    UserId = 1,
+    WorkstationId = 1,
+    PolarisOverrideAccount = new PolarisUser
+    {
+        Domain = "LIBRARY",
+        Username = "staff.user",
+        Password = "staff-password"
+    }
+};
+
+var client = new PapiClient(settings);
+```
+
+`PapiSettings.PolarisOverrideAccount` is copied to `PapiClient.StaffOverrideAccount`. When `StaffOverrideAccount` is configured, protected requests and supported staff-override requests can acquire protected tokens automatically.
+
+## Basic async usage
+
+```csharp
+using Clc.Polaris.Api.Models;
+
+using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+var response = await client.BibKeywordSearchAsync(
+    "octavia butler",
+    branchId: settings.OrganizationId,
+    page: 1,
+    pageSize: 10,
+    cancellationToken: cancellationTokenSource.Token);
+
+if (response.Response.IsSuccessStatusCode)
+{
+    var results = response.Data;
+    // Use the returned bibliographic search results.
+}
+```
+
+Public client methods are async-only in 4.0 and should be awaited; do not block on them or look for synchronous alternatives. Pass a `CancellationToken` where appropriate so callers can cancel both the PAPI request and any required authentication request.
+
+Protected-token-in-path endpoints use `ProtectedToken.Placeholder` internally. Most callers should use the provided client methods rather than constructing those paths manually.
+
+## Local tests
+
+Run the test suite from the repository root:
+
+```bash
+dotnet test src/polaris-api-csharp.sln
+```
+
+## Migration guide
+
+See [MIGRATION.md](MIGRATION.md) for 3.x-to-4.0 async migration notes.

--- a/src/polaris-api-csharp/Clc.Polaris.Api.csproj
+++ b/src/polaris-api-csharp/Clc.Polaris.Api.csproj
@@ -10,8 +10,8 @@
 		<PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
 		<Version>4.0.0-alpha.1</Version>
 		<Title>Polaris Api Library Helper Library</Title>
-		<PackageProjectUrl>https://bitbucket.org/clcdpc/polaris-api-csharp</PackageProjectUrl>
-		<RepositoryUrl>https://bitbucket.org/clcdpc/polaris-api-csharp</RepositoryUrl>
+		<PackageProjectUrl>https://github.com/clcdpc/polaris-api-csharp</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/clcdpc/polaris-api-csharp</RepositoryUrl>
 		<IncludeSymbols>True</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>


### PR DESCRIPTION
### Motivation

- Prepare `Clc.Polaris.Api` for the `4.0.0-alpha.1` release.
- Add consumer-facing documentation for the async-only 4.0 API.
- Clarify migration guidance for callers moving from the 3.x synchronous API to awaited `*Async` methods.
- Document protected-token path placeholder behavior and local integration-test setup.
- Update stale package metadata so NuGet points to the GitHub repository instead of Bitbucket.

### Description

- Added a root `README.md` with:
  - package purpose,
  - install command for `4.0.0-alpha.1`,
  - basic `PapiClient` configuration example,
  - basic async usage example,
  - async-only usage guidance,
  - `CancellationToken` guidance,
  - protected/staff-override token acquisition note,
  - `ProtectedToken.Placeholder` note for protected-token-in-path endpoints,
  - local non-integration and integration test commands,
  - local `appsettings.Test.json` example shape,
  - link to `MIGRATION.md`.
- Expanded `MIGRATION.md` with:
  - a 3.x synchronous call to 4.0 async call before/after example,
  - `PatronReadingHistoryClearAsync` `IEnumerable<int>` example,
  - protected-token path request guidance explaining that `ExecutePapiAsync` replaces `ProtectedToken.Placeholder` before sending and before PAPI hash formatting.
- Updated package metadata in `Clc.Polaris.Api.csproj`:
  - `PackageProjectUrl` now points to `https://github.com/clcdpc/polaris-api-csharp`.
  - `RepositoryUrl` now points to `https://github.com/clcdpc/polaris-api-csharp`.

### Testing

- Ran `dotnet build src/polaris-api-csharp.sln --no-restore` successfully.
- Updated documentation to show the supported local test commands:
  - `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"`
  - `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Integration"`
- Documented that integration tests require local `appsettings.Test.json` Polaris credentials and should not be run by default in CI.