### PR TITLE
Fix PAPI authorization hash query URL generation

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -1,4 +1,4 @@
-﻿using Clc.Rest.Models;
+using Clc.Rest.Models;
 using Clc.Polaris.Api.Configuration;
 using Clc.Polaris.Api.Models;
 using Clc.Rest;
@@ -11,6 +11,7 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Clc.Polaris.Api
 {
@@ -125,6 +126,17 @@ namespace Clc.Polaris.Api
             var query = new StringBuilder();
             foreach (KeyValuePair<string, object> parameter in request.QueryParameters)
             {
+                if (string.IsNullOrWhiteSpace(parameter.Key) || parameter.Value == null)
+                {
+                    continue;
+                }
+
+                var convertedValue = Convert.ToString(parameter.Value, CultureInfo.InvariantCulture);
+                if (string.IsNullOrWhiteSpace(convertedValue))
+                {
+                    continue;
+                }
+
                 if (query.Length > 0)
                 {
                     query.Append('&');
@@ -132,7 +144,12 @@ namespace Clc.Polaris.Api
 
                 query.Append(Uri.EscapeDataString(parameter.Key));
                 query.Append('=');
-                query.Append(Uri.EscapeDataString(parameter.Value?.ToString() ?? string.Empty));
+                query.Append(Uri.EscapeDataString(convertedValue));
+            }
+
+            if (query.Length == 0)
+            {
+                return url;
             }
 
             return $"{url}{(url.Contains("?") ? "&" : "?")}{query}";

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -1,9 +1,10 @@
-﻿using Clc.Polaris.Api.Configuration;
+using Clc.Polaris.Api.Configuration;
 using Clc.Polaris.Api.Models;
 using Clc.Rest.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -525,6 +526,118 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNull(handler.LastRequest.Content);
             Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
             Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task BibSearch_DefaultLimit_OmitsLimitFromSentUriAndAuthorizationHash()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var options = new BibSearchOptions
+            {
+                Branch = 1,
+                SearchType = BibSearchTypes.keyword,
+                Qualifier = SearchQualifiers.KW,
+                Term = "dogs",
+                SortOption = SearchSortOptions.MP,
+                Page = 1,
+                PageSize = 10
+            };
+
+            var response = await client.BibSearchAsync(options);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=dogs&sort=MP&page=1&bibsperpage=10", handler.LastRequest.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.IsFalse(query.ContainsKey("limit"));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task QueryParameterWithNullValue_IsOmittedFromSentUriAndAuthorizationHash()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.BlockStaffOverride = true;
+            request.QueryParameters.Add("q", "dogs");
+            request.QueryParameters.Add("limit", null!);
+
+            await ExecutePapiRequestWithoutProtectedTokenPreloadAsync(client, request);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=dogs", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.IsFalse(query.ContainsKey("limit"));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task QueryParameterWithEmptyStringValue_IsOmittedFromSentUriAndAuthorizationHash()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.BlockStaffOverride = true;
+            request.QueryParameters.Add("q", "dogs");
+            request.QueryParameters.Add("limit", string.Empty);
+
+            await ExecutePapiRequestWithoutProtectedTokenPreloadAsync(client, request);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=dogs", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.IsFalse(query.ContainsKey("limit"));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task OnlyIneffectiveQueryParameters_AreOmittedFromSentUriAndAuthorizationHash()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.BlockStaffOverride = true;
+            request.QueryParameters.Add("", "dogs");
+            request.QueryParameters.Add("limit", string.Empty);
+
+            await ExecutePapiRequestWithoutProtectedTokenPreloadAsync(client, request);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            Assert.AreEqual(string.Empty, handler.LastRequest.RequestUri.Query);
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task QueryParameterValueConversion_UsesInvariantCultureForSentUriAndAuthorizationHash()
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            var originalUiCulture = CultureInfo.CurrentUICulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+                CultureInfo.CurrentUICulture = new CultureInfo("fr-FR");
+                var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+                var client = CreateClient(handler);
+                var request = PapiRestRequest.Get("/public/v1/1033/100/1/search/bibs/keyword/KW");
+                request.BlockStaffOverride = true;
+                request.QueryParameters.Add("amount", 12.34m);
+
+                await ExecutePapiRequestWithoutProtectedTokenPreloadAsync(client, request);
+
+                Assert.IsNotNull(handler.LastRequest);
+                Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?amount=12.34", handler.LastRequest!.RequestUri!.AbsoluteUri);
+                AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+                CultureInfo.CurrentUICulture = originalUiCulture;
+            }
         }
 
         [TestMethod]
@@ -647,6 +760,26 @@ namespace Clc.Polaris.Api.Tests
                 .Split('&', StringSplitOptions.RemoveEmptyEntries)
                 .Select(part => part.Split('=', 2))
                 .ToDictionary(parts => WebUtility.UrlDecode(parts[0]), parts => parts.Length > 1 ? WebUtility.UrlDecode(parts[1]) : string.Empty);
+        }
+
+        private static async Task ExecutePapiRequestWithoutProtectedTokenPreloadAsync(PapiClient client, PapiRestRequest request)
+        {
+            var executePapiAsync = typeof(PapiClient)
+                .GetMethod("ExecutePapiAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .MakeGenericMethod(typeof(PapiResponseCommon));
+            var skipMode = Enum.Parse(
+                typeof(PapiClient).GetNestedType("ProtectedTokenPreloadMode", System.Reflection.BindingFlags.NonPublic)!,
+                "Skip");
+
+            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None, skipMode })!;
+            await task.ConfigureAwait(false);
+        }
+
+        private static void AssertAuthorizationHashesSentUri(HttpRequestMessage request, string password)
+        {
+            var date = request.Headers.GetValues("PolarisDate").Single();
+            var expectedHash = ComputePapiHash(request.Method.Method, request.RequestUri!.AbsoluteUri, date, password, "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", request.Headers.GetValues("Authorization").Single());
         }
 
         private static string ComputePapiHash(string httpMethod, string uri, string date, string password, string accessKey)


### PR DESCRIPTION
### Motivation
- Ensure the PAPI Authorization hash is computed from the exact same URI that Clc.Rest.Client v3 produces for requests with query parameters to avoid signature mismatches.
- The previous logic appended every `QueryParameters` entry (including null/empty), causing divergence between the signed URI and the outgoing URI for cases like default/empty `limit`.
- Add focused characterization tests to assert that omitted/converted query parameters are treated identically for both the sent URI and the Authorization hash.

### Description
- Update `BuildUrlForPapiHash` to mirror Clc.Rest.Client v3 behavior by skipping blank keys, skipping null values, converting values with `Convert.ToString(value, CultureInfo.InvariantCulture)`, skipping blank converted values, escaping keys/values with `Uri.EscapeDataString`, and returning the base URL when no effective query parameters remain, appending `?` or `&` appropriately.
- Add `using System.Globalization;` to support invariant-culture conversion.
- Add new unit tests and helpers to `RestClientMigrationCharacterizationTests` to verify parity between the outgoing request URI and the URI used to compute the Authorization hash, covering: `BibSearch` default/omitted `limit`, null-valued parameter omission, empty-string parameter omission, invariant-culture numeric conversion, ineffective parameter omission, and preservation of non-empty parameters.
- Keep public API signatures unchanged and do not modify integration-test credential behavior.

### Testing
- Restored, built, and ran non-integration tests with: `dotnet restore src/polaris-api-csharp.sln`, `dotnet build src/polaris-api-csharp.sln --no-restore`, and `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration" --no-build`.
- All non-integration tests passed (80 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b6790dcb48323a443175a6682ee18)