### PR TITLE
Fix PAPI Authorization hash query parameter filtering

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -11,6 +11,7 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Clc.Polaris.Api
 {
@@ -125,6 +126,17 @@ namespace Clc.Polaris.Api
             var query = new StringBuilder();
             foreach (KeyValuePair<string, object> parameter in request.QueryParameters)
             {
+                if (string.IsNullOrWhiteSpace(parameter.Key) || parameter.Value == null)
+                {
+                    continue;
+                }
+
+                var value = Convert.ToString(parameter.Value, CultureInfo.InvariantCulture);
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    continue;
+                }
+
                 if (query.Length > 0)
                 {
                     query.Append('&');
@@ -132,7 +144,12 @@ namespace Clc.Polaris.Api
 
                 query.Append(Uri.EscapeDataString(parameter.Key));
                 query.Append('=');
-                query.Append(Uri.EscapeDataString(parameter.Value?.ToString() ?? string.Empty));
+                query.Append(Uri.EscapeDataString(value));
+            }
+
+            if (query.Length == 0)
+            {
+                return url;
             }
 
             return $"{url}{(url.Contains("?") ? "&" : "?")}{query}";

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -4,6 +4,7 @@ using Clc.Rest.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -525,6 +526,93 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNull(handler.LastRequest.Content);
             Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
             Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
+            AssertAuthorizationHashesRequestUri(handler.LastRequest);
+        }
+
+        [TestMethod]
+        public async Task BibSearch_WithDefaultLimit_OmitsLimitFromSentUriAndAuthorizationHash()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var options = new BibSearchOptions
+            {
+                Branch = 1,
+                SearchType = BibSearchTypes.keyword,
+                Qualifier = SearchQualifiers.KW,
+                Term = "harry potter",
+                SortOption = SearchSortOptions.MP,
+                Page = 1,
+                PageSize = 10
+            };
+
+            var response = await client.BibSearchAsync(options);
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter&sort=MP&page=1&bibsperpage=10", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.IsFalse(query.ContainsKey("limit"));
+            AssertAuthorizationHashesRequestUri(handler.LastRequest);
+        }
+
+        [TestMethod]
+        public async Task QueryParameter_WithNullValue_IsOmittedFromSentUriAndAuthorizationHash()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.QueryParameters.Add("q", "harry potter");
+            request.QueryParameters.Add("limit", null!);
+
+            await ExecutePapiResponseAsync(client, request);
+
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.IsFalse(query.ContainsKey("limit"));
+            AssertAuthorizationHashesRequestUri(handler.LastRequest);
+        }
+
+        [TestMethod]
+        public async Task QueryParameter_WithEmptyStringValue_IsOmittedFromSentUriAndAuthorizationHash()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.QueryParameters.Add("q", "harry potter");
+            request.QueryParameters.Add("limit", string.Empty);
+
+            await ExecutePapiResponseAsync(client, request);
+
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.IsFalse(query.ContainsKey("limit"));
+            AssertAuthorizationHashesRequestUri(handler.LastRequest);
+        }
+
+        [TestMethod]
+        public async Task QueryParameter_WithCultureSensitiveValue_UsesInvariantCultureForSentUriAndAuthorizationHash()
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            var originalUICulture = CultureInfo.CurrentUICulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+                CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+
+                var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+                var client = CreateClient(handler);
+                var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+                request.QueryParameters.Add("amount", 12.34m);
+
+                await ExecutePapiResponseAsync(client, request);
+
+                Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?amount=12.34", handler.LastRequest!.RequestUri!.AbsoluteUri);
+                AssertAuthorizationHashesRequestUri(handler.LastRequest);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+                CultureInfo.CurrentUICulture = originalUICulture;
+            }
         }
 
         [TestMethod]
@@ -638,6 +726,27 @@ namespace Clc.Polaris.Api.Tests
                 AllowStaffOverrideRequests = false,
                 UseProtectedTokenCache = false
             };
+        }
+
+
+        private static async Task ExecutePapiResponseAsync(PapiClient client, PapiRestRequest request)
+        {
+            var executePapiAsync = typeof(PapiClient)
+                .GetMethod("ExecutePapiAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .MakeGenericMethod(typeof(PapiResponseCommon));
+            var autoMode = Enum.Parse(
+                typeof(PapiClient).GetNestedType("ProtectedTokenPreloadMode", System.Reflection.BindingFlags.NonPublic)!,
+                "Auto");
+
+            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None, autoMode })!;
+            await task;
+        }
+
+        private static void AssertAuthorizationHashesRequestUri(HttpRequestMessage request, string password = "")
+        {
+            var date = request.Headers.GetValues("PolarisDate").Single();
+            var expectedHash = ComputePapiHash(request.Method.Method, request.RequestUri!.AbsoluteUri, date, password, "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", request.Headers.GetValues("Authorization").Single());
         }
 
 


### PR DESCRIPTION
### Motivation
- The PAPI Authorization hash was being computed from a URI that could differ from the actual outgoing URI when `QueryParameters` contained null/empty/default values, causing signature mismatches with Clc.Rest.Client v3 behavior.
- The intent is to make the hash URL construction mirror Clc.Rest.Client v3 parameter handling so signed URIs and outgoing URIs are identical for query-parameter requests.

### Description
- Update `BuildUrlForPapiHash` in `src/polaris-api-csharp/PapiClient.cs` to skip blank keys, skip null values, convert values with `Convert.ToString(value, CultureInfo.InvariantCulture)`, skip blank converted values, escape key/value with `Uri.EscapeDataString`, return the base URL when no effective query parameters remain, and append query using `?` or `&` as appropriate.
- Add `using System.Globalization;` to support invariant-culture conversions.
- Add characterization tests in `src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs` that verify the Authorization hash is computed from the exact same URI the rest-client sends, including tests for default `Limit` omission, null query values, empty-string query values, culture-sensitive value conversion (invariant culture), and preserved hashing of existing non-empty params.
- Add test helpers to execute private `ExecutePapiAsync` and to assert the computed Authorization header matches the expected hash derived from `handler.LastRequest.RequestUri.AbsoluteUri`.

### Testing
- Restored and built the solution with `dotnet restore src/polaris-api-csharp.sln` and `dotnet build src/polaris-api-csharp.sln --no-restore`, which completed successfully.
- Ran unit tests (non-integration) with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration" --no-build`, and all non-integration tests passed (79 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b6790dcb48323a443175a6682ee18)