### PR TITLE
Align PAPI authorization hash query generation with RestClient v3

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -11,6 +11,7 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Clc.Polaris.Api
 {
@@ -125,6 +126,17 @@ namespace Clc.Polaris.Api
             var query = new StringBuilder();
             foreach (KeyValuePair<string, object> parameter in request.QueryParameters)
             {
+                if (string.IsNullOrWhiteSpace(parameter.Key) || parameter.Value == null)
+                {
+                    continue;
+                }
+
+                var convertedValue = Convert.ToString(parameter.Value, CultureInfo.InvariantCulture);
+                if (string.IsNullOrWhiteSpace(convertedValue))
+                {
+                    continue;
+                }
+
                 if (query.Length > 0)
                 {
                     query.Append('&');
@@ -132,7 +144,12 @@ namespace Clc.Polaris.Api
 
                 query.Append(Uri.EscapeDataString(parameter.Key));
                 query.Append('=');
-                query.Append(Uri.EscapeDataString(parameter.Value?.ToString() ?? string.Empty));
+                query.Append(Uri.EscapeDataString(convertedValue));
+            }
+
+            if (query.Length == 0)
+            {
+                return url;
             }
 
             return $"{url}{(url.Contains("?") ? "&" : "?")}{query}";

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -4,6 +4,7 @@ using Clc.Rest.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -525,6 +526,130 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNull(handler.LastRequest.Content);
             Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
             Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task BibSearchAsync_DefaultLimit_OmitsLimitAndHashesSentUri()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var options = new BibSearchOptions
+            {
+                Branch = 1,
+                SearchType = BibSearchTypes.keyword,
+                Qualifier = SearchQualifiers.KW,
+                Term = "harry potter & stone",
+                SortOption = SearchSortOptions.MP,
+                Page = 2,
+                PageSize = 15
+            };
+
+            var response = await client.BibSearchAsync(options);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.IsFalse(query.ContainsKey("limit"));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_QueryParameterWithNullValue_OmitsParameterAndHashesSentUri()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.QueryParameters.Add("q", "harry potter");
+            request.QueryParameters.Add("limit", null!);
+
+            await ExecuteRawPapiRequestAsync(client, request);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.IsFalse(query.ContainsKey("limit"));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_QueryParameterWithEmptyStringValue_OmitsParameterAndHashesSentUri()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.QueryParameters.Add("q", "harry potter");
+            request.QueryParameters.Add("limit", string.Empty);
+
+            await ExecuteRawPapiRequestAsync(client, request);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.IsFalse(query.ContainsKey("limit"));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_OnlyIneffectiveQueryParameters_OmitsQueryStringAndHashesSentUri()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.QueryParameters.Add(" ", "blank key");
+            request.QueryParameters.Add("empty", string.Empty);
+            request.QueryParameters.Add("null", null!);
+
+            await ExecuteRawPapiRequestAsync(client, request);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            Assert.AreEqual(string.Empty, handler.LastRequest.RequestUri.Query);
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_QueryParameters_UseInvariantCultureForSentUriAndHash()
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            var originalUiCulture = CultureInfo.CurrentUICulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+                CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+                var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+                var client = CreateClient(handler);
+                var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+                request.QueryParameters.Add("amount", 12.34m);
+
+                await ExecuteRawPapiRequestAsync(client, request);
+
+                Assert.IsNotNull(handler.LastRequest);
+                Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?amount=12.34", handler.LastRequest!.RequestUri!.AbsoluteUri);
+                AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+                CultureInfo.CurrentUICulture = originalUiCulture;
+            }
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_NonEmptyQueryParameters_HashesSentUri()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.QueryParameters.Add("q", "harry potter & stone");
+            request.QueryParameters.Add("limit", "branch:1");
+
+            await ExecuteRawPapiRequestAsync(client, request);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&limit=branch%3A1", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
         }
 
         [TestMethod]
@@ -638,6 +763,27 @@ namespace Clc.Polaris.Api.Tests
                 AllowStaffOverrideRequests = false,
                 UseProtectedTokenCache = false
             };
+        }
+
+
+        private static async Task ExecuteRawPapiRequestAsync(PapiClient client, PapiRestRequest request)
+        {
+            var executePapiAsync = typeof(PapiClient)
+                .GetMethod("ExecutePapiAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .MakeGenericMethod(typeof(PapiResponseCommon));
+            var autoMode = Enum.Parse(
+                typeof(PapiClient).GetNestedType("ProtectedTokenPreloadMode", System.Reflection.BindingFlags.NonPublic)!,
+                "Auto");
+
+            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None, autoMode })!;
+            await task.ConfigureAwait(false);
+        }
+
+        private static void AssertAuthorizationHashesSentUri(HttpRequestMessage request, string password)
+        {
+            var date = request.Headers.GetValues("PolarisDate").Single();
+            var expectedHash = ComputePapiHash(request.Method.Method, request.RequestUri!.AbsoluteUri, date, password, "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", request.Headers.GetValues("Authorization").Single());
         }
 
 


### PR DESCRIPTION
### Motivation
- Prevent mismatches between the URI used to compute the PAPI Authorization hash and the actual outgoing URI produced by `Clc.Rest.Client` v3 when requests include query parameters, which caused signatures to diverge (for example when `limit` is set to `string.Empty`).

### Description
- Change `BuildUrlForPapiHash` to mirror `Clc.Rest.Client` v3 behavior by skipping blank keys, skipping null values, converting values via `Convert.ToString(value, CultureInfo.InvariantCulture)`, skipping blank converted values, escaping keys and values with `Uri.EscapeDataString`, and returning the base URL unchanged when there are no effective query parameters; added `using System.Globalization`.
- Add/adjust migration-characterization tests in `RestClientMigrationCharacterizationTests` and helper methods to assert the Authorization header is computed from the exact same URI sent by the client, including tests: `BibSearchAsync_DefaultLimit_OmitsLimitAndHashesSentUri`, `ExecutePapiAsync_QueryParameterWithNullValue_OmitsParameterAndHashesSentUri`, `ExecutePapiAsync_QueryParameterWithEmptyStringValue_OmitsParameterAndHashesSentUri`, `ExecutePapiAsync_OnlyIneffectiveQueryParameters_OmitsQueryStringAndHashesSentUri`, `ExecutePapiAsync_QueryParameters_UseInvariantCultureForSentUriAndHash`, `ExecutePapiAsync_NonEmptyQueryParameters_HashesSentUri`, and an assertion addition to `BibSearch_RequestShape_IsStable`.
- No public API signatures were changed and integration-test credential behavior was not altered.

### Testing
- Restored packages with `dotnet restore src/polaris-api-csharp.sln` which completed successfully.
- Built with `dotnet build src/polaris-api-csharp.sln --no-restore` which succeeded.
- Ran unit tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration" --no-build` and all non-integration tests passed (81 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b6790dcb48323a443175a6682ee18)