### PR TITLE
Use RestClient BuildRequestUri for PAPI authorization hashes

### DIFF
--- a/src/polaris-api-csharp/Clc.Polaris.Api.csproj
+++ b/src/polaris-api-csharp/Clc.Polaris.Api.csproj
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Clc.Rest.Client" Version="3.0.0-alpha.1" />
+		<PackageReference Include="Clc.Rest.Client" Version="3.0.0-alpha.3" />
 	</ItemGroup>
 
 </Project>

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -10,8 +10,6 @@ using System.Text;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Globalization;
 
 namespace Clc.Polaris.Api
 {
@@ -107,7 +105,7 @@ namespace Clc.Polaris.Api
                 }
 
                 var date = DateTime.Now.ToUniversalTime().ToString("R");
-                var hash = GetPAPIHash(papiRequest.Method.ToString(), date, BuildUrlForPapiHash(papiRequest), password);
+                var hash = GetPAPIHash(papiRequest.Method.ToString(), date, BuildUriForPapiHash(papiRequest), password);
                 papiRequest.Headers["PolarisDate"] = date;
                 papiRequest.Headers["Authorization"] = string.Format("PWS {0}:{1}", AccessID, hash);
             }
@@ -115,44 +113,10 @@ namespace Clc.Polaris.Api
             return papiRequest;
         }
 
-        private string BuildUrlForPapiHash(RestRequest request)
+        private string BuildUriForPapiHash(RestRequest request)
         {
-            var url = BuildUrl(request);
-            if (request.QueryParameters.Count == 0)
-            {
-                return url;
-            }
-
-            var query = new StringBuilder();
-            foreach (KeyValuePair<string, object> parameter in request.QueryParameters)
-            {
-                if (string.IsNullOrWhiteSpace(parameter.Key) || parameter.Value == null)
-                {
-                    continue;
-                }
-
-                var convertedValue = Convert.ToString(parameter.Value, CultureInfo.InvariantCulture);
-                if (string.IsNullOrWhiteSpace(convertedValue))
-                {
-                    continue;
-                }
-
-                if (query.Length > 0)
-                {
-                    query.Append('&');
-                }
-
-                query.Append(Uri.EscapeDataString(parameter.Key));
-                query.Append('=');
-                query.Append(Uri.EscapeDataString(convertedValue));
-            }
-
-            if (query.Length == 0)
-            {
-                return url;
-            }
-
-            return $"{url}{(url.Contains("?") ? "&" : "?")}{query}";
+            var requestUri = BuildRequestUri(request);
+            return requestUri.IsAbsoluteUri ? requestUri.AbsoluteUri : requestUri.OriginalString;
         }
 
 

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -592,6 +592,42 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public async Task ExecutePapiAsync_QueryParameterWithWhitespaceValue_OmitsParameterAndHashesSentUri()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.QueryParameters.Add("q", "harry potter");
+            request.QueryParameters.Add("limit", "   ");
+
+            await ExecuteRawPapiRequestAsync(client, request);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.IsFalse(query.ContainsKey("limit"));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_QueryParameterWithBlankKey_OmitsParameterAndHashesSentUri()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.QueryParameters.Add("q", "harry potter");
+            request.QueryParameters.Add(" ", "blank key");
+
+            await ExecuteRawPapiRequestAsync(client, request);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.IsFalse(query.ContainsKey(" "));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
         public async Task ExecutePapiAsync_OnlyIneffectiveQueryParameters_OmitsQueryStringAndHashesSentUri()
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
@@ -649,6 +685,24 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.IsNotNull(handler.LastRequest);
             Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&limit=branch%3A1", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_ExistingQueryString_AppendsParametersWithAmpersandAndHashesSentUri()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW?existing=true");
+            request.QueryParameters.Add("q", "harry potter");
+
+            await ExecuteRawPapiRequestAsync(client, request);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?existing=true&q=harry%20potter", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.AreEqual("true", query["existing"]);
+            Assert.AreEqual("harry potter", query["q"]);
             AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
         }
 


### PR DESCRIPTION
### Motivation
- Ensure PAPI Authorization hashes are computed from the exact URI that the RestClient sends so signatures match outgoing requests.
- Remove Polaris-side duplicated query-string construction and rely on the RestClient `BuildRequestUri(RestRequest)` helper, which centralizes query formatting.
- Upgrade to a minimum `Clc.Rest.Client` prerelease that exposes `BuildRequestUri` so Polaris does not vendor or reimplement rest-client logic.

### Description
- Bumped `Clc.Rest.Client` package to `3.0.0-alpha.3`, the minimum prerelease found that exposes `BuildRequestUri(RestRequest)`.
- Replaced `BuildUrlForPapiHash` with `BuildUriForPapiHash` that calls `BuildRequestUri(request)` and returns `AbsoluteUri` for absolute URIs or `OriginalString` for relative URIs, and switched PAPI hash generation to use that helper.
- Removed Polaris duplicate query-building logic and now rely on RestClient formatting, and removed now-unused `using` directives (`System.Globalization`, `System.Collections.Generic`).
- Added characterization tests covering whitespace query values, blank keys, existing query strings, and assertion of Authorization hashes against `handler.LastRequest.RequestUri.AbsoluteUri` to prove hashes match the sent URI.

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln`, `dotnet build src/polaris-api-csharp.sln --no-restore`, and `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration" --no-build`.
- All non-integration tests passed (84 passed, 0 failed) in this environment after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b70891d68832393e474db57727b40)