### PR TITLE
Use RestClient BuildRequestUri for PAPI authorization hashes

### DIFF
--- a/src/polaris-api-csharp/Clc.Polaris.Api.csproj
+++ b/src/polaris-api-csharp/Clc.Polaris.Api.csproj
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Clc.Rest.Client" Version="3.0.0-alpha.1" />
+		<PackageReference Include="Clc.Rest.Client" Version="3.0.0-alpha.3" />
 	</ItemGroup>
 
 </Project>

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -10,8 +10,6 @@ using System.Text;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Globalization;
 
 namespace Clc.Polaris.Api
 {
@@ -107,54 +105,15 @@ namespace Clc.Polaris.Api
                 }
 
                 var date = DateTime.Now.ToUniversalTime().ToString("R");
-                var hash = GetPAPIHash(papiRequest.Method.ToString(), date, BuildUrlForPapiHash(papiRequest), password);
+                var requestUri = BuildRequestUri(papiRequest);
+                var hashUri = requestUri.IsAbsoluteUri ? requestUri.AbsoluteUri : requestUri.OriginalString;
+                var hash = GetPAPIHash(papiRequest.Method.ToString(), date, hashUri, password);
                 papiRequest.Headers["PolarisDate"] = date;
                 papiRequest.Headers["Authorization"] = string.Format("PWS {0}:{1}", AccessID, hash);
             }
 
             return papiRequest;
         }
-
-        private string BuildUrlForPapiHash(RestRequest request)
-        {
-            var url = BuildUrl(request);
-            if (request.QueryParameters.Count == 0)
-            {
-                return url;
-            }
-
-            var query = new StringBuilder();
-            foreach (KeyValuePair<string, object> parameter in request.QueryParameters)
-            {
-                if (string.IsNullOrWhiteSpace(parameter.Key) || parameter.Value == null)
-                {
-                    continue;
-                }
-
-                var convertedValue = Convert.ToString(parameter.Value, CultureInfo.InvariantCulture);
-                if (string.IsNullOrWhiteSpace(convertedValue))
-                {
-                    continue;
-                }
-
-                if (query.Length > 0)
-                {
-                    query.Append('&');
-                }
-
-                query.Append(Uri.EscapeDataString(parameter.Key));
-                query.Append('=');
-                query.Append(Uri.EscapeDataString(convertedValue));
-            }
-
-            if (query.Length == 0)
-            {
-                return url;
-            }
-
-            return $"{url}{(url.Contains("?") ? "&" : "?")}{query}";
-        }
-
 
         private enum ProtectedTokenPreloadMode
         {

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -592,6 +592,24 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public async Task ExecutePapiAsync_QueryParameterWithWhitespaceValue_OmitsParameterAndHashesSentUri()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.QueryParameters.Add("q", "harry potter");
+            request.QueryParameters.Add("limit", "   ");
+
+            await ExecuteRawPapiRequestAsync(client, request);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.IsFalse(query.ContainsKey("limit"));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
         public async Task ExecutePapiAsync_OnlyIneffectiveQueryParameters_OmitsQueryStringAndHashesSentUri()
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
@@ -649,6 +667,24 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.IsNotNull(handler.LastRequest);
             Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&limit=branch%3A1", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_ExistingQueryString_AppendsQueryParametersAndHashesSentUri()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW?existing=1");
+            request.QueryParameters.Add("q", "harry potter");
+
+            await ExecuteRawPapiRequestAsync(client, request);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?existing=1&q=harry%20potter", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.AreEqual("1", query["existing"]);
+            Assert.AreEqual("harry potter", query["q"]);
             AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
         }
 


### PR DESCRIPTION
### Motivation
- Remove Polaris-side duplication of rest-client query-string construction so the PAPI Authorization hash is computed from the exact URI that the rest-client will send.
- Ensure signing logic matches outgoing requests precisely to avoid subtle mismatches from query-parameter encoding/omissions.

### Description
- `PreformatRestRequest` in `PapiClient` now uses the rest-client helper `BuildRequestUri(papiRequest)` and derives the string to hash using `AbsoluteUri` for absolute URIs or `OriginalString` for relative URIs, then calls the existing `GetPAPIHash` with that value.
- The local `BuildUrlForPapiHash` helper and its supporting query-building logic were removed and now-unused `using` directives were cleaned up so Polaris no longer duplicates query construction.
- The `Clc.Rest.Client` package reference was bumped to `3.0.0-alpha.3`, which is the minimum prerelease verified here that exposes `BuildRequestUri(RestRequest request)`.
- Added characterization tests exercising whitespace query values and requests with existing query strings so Authorization is asserted against the `handler.LastRequest.RequestUri` observed by the HTTP handler, while preserving existing behavior such as staff override token handling and header formatting.

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln`, `dotnet build src/polaris-api-csharp.sln --no-restore`, and `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration" --no-build`.
- Build succeeded and the non-integration test run passed (83 tests passed, 0 failed).
- Verified that the new `Clc.Rest.Client` version containing `BuildRequestUri` is required (minimum `3.0.0-alpha.3`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b70891d68832393e474db57727b40)