### PR TITLE
Use RestClient BuildRequestUri for PAPI signatures

### DIFF
--- a/src/polaris-api-csharp/Clc.Polaris.Api.csproj
+++ b/src/polaris-api-csharp/Clc.Polaris.Api.csproj
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Clc.Rest.Client" Version="3.0.0-alpha.1" />
+		<PackageReference Include="Clc.Rest.Client" Version="3.0.0-alpha.3" />
 	</ItemGroup>
 
 </Project>

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -10,8 +10,6 @@ using System.Text;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Globalization;
 
 namespace Clc.Polaris.Api
 {
@@ -107,54 +105,15 @@ namespace Clc.Polaris.Api
                 }
 
                 var date = DateTime.Now.ToUniversalTime().ToString("R");
-                var hash = GetPAPIHash(papiRequest.Method.ToString(), date, BuildUrlForPapiHash(papiRequest), password);
+                var requestUri = BuildRequestUri(papiRequest);
+                var uriForHash = requestUri.IsAbsoluteUri ? requestUri.AbsoluteUri : requestUri.ToString();
+                var hash = GetPAPIHash(papiRequest.Method.ToString(), date, uriForHash, password);
                 papiRequest.Headers["PolarisDate"] = date;
                 papiRequest.Headers["Authorization"] = string.Format("PWS {0}:{1}", AccessID, hash);
             }
 
             return papiRequest;
         }
-
-        private string BuildUrlForPapiHash(RestRequest request)
-        {
-            var url = BuildUrl(request);
-            if (request.QueryParameters.Count == 0)
-            {
-                return url;
-            }
-
-            var query = new StringBuilder();
-            foreach (KeyValuePair<string, object> parameter in request.QueryParameters)
-            {
-                if (string.IsNullOrWhiteSpace(parameter.Key) || parameter.Value == null)
-                {
-                    continue;
-                }
-
-                var convertedValue = Convert.ToString(parameter.Value, CultureInfo.InvariantCulture);
-                if (string.IsNullOrWhiteSpace(convertedValue))
-                {
-                    continue;
-                }
-
-                if (query.Length > 0)
-                {
-                    query.Append('&');
-                }
-
-                query.Append(Uri.EscapeDataString(parameter.Key));
-                query.Append('=');
-                query.Append(Uri.EscapeDataString(convertedValue));
-            }
-
-            if (query.Length == 0)
-            {
-                return url;
-            }
-
-            return $"{url}{(url.Contains("?") ? "&" : "?")}{query}";
-        }
-
 
         private enum ProtectedTokenPreloadMode
         {

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -592,6 +592,24 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public async Task ExecutePapiAsync_QueryParameterWithWhitespaceValue_OmitsParameterAndHashesSentUri()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
+            request.QueryParameters.Add("q", "harry potter");
+            request.QueryParameters.Add("limit", "   ");
+
+            await ExecuteRawPapiRequestAsync(client, request);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.IsFalse(query.ContainsKey("limit"));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
         public async Task ExecutePapiAsync_OnlyIneffectiveQueryParameters_OmitsQueryStringAndHashesSentUri()
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
@@ -649,6 +667,24 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.IsNotNull(handler.LastRequest);
             Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&limit=branch%3A1", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_ExistingQueryString_AppendsQueryParametersAndHashesSentUri()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW?existing=one");
+            request.QueryParameters.Add("q", "harry potter & stone");
+
+            await ExecuteRawPapiRequestAsync(client, request);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?existing=one&q=harry%20potter%20%26%20stone", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.AreEqual("one", query["existing"]);
+            Assert.AreEqual("harry potter & stone", query["q"]);
             AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
         }
 


### PR DESCRIPTION
### Motivation
- Ensure the PAPI Authorization hash is computed from the exact URI that `Clc.Rest.Client` will send by delegating URI construction to the rest-client helper instead of duplicating query-string logic in Polaris.
- Rely on the first available Rest.Client prerelease that exposes `BuildRequestUri(RestRequest)` so Polaris and RestClient share consistent query-parameter semantics.

### Description
- Update `Clc.Rest.Client` package reference to `3.0.0-alpha.3`, the minimum prerelease verified to expose `BuildRequestUri(RestRequest request)` in `Clc.Polaris.Api.csproj`.
- Replace Polaris-built query-string signing with `var requestUri = BuildRequestUri(papiRequest); var uriForHash = requestUri.IsAbsoluteUri ? requestUri.AbsoluteUri : requestUri.ToString();` and compute the PAPI hash from `uriForHash` in `PapiClient.PreformatRestRequest` so the Authorization matches the actual outgoing URI.
- Remove the duplicated `BuildUrlForPapiHash` method and its now-unused imports (`System.Collections.Generic` and `System.Globalization`) from `PapiClient.cs`.
- Add characterization test coverage to `RestClientMigrationCharacterizationTests.cs` for whitespace-only query values and for appending query parameters when the request path already contains an existing query string, while continuing to assert the Authorization header equals the hash of the sent URI.

### Testing
- Restored packages with `dotnet restore src/polaris-api-csharp.sln` and the restore succeeded.
- Built the solution with `dotnet build src/polaris-api-csharp.sln --no-restore` and the build succeeded.
- Ran unit tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration" --no-build` and all non-integration tests passed (83 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b70891d68832393e474db57727b40)