### PR TITLE
Invalidate expired ProtectedToken and update token auth/cache behavior in PapiClient

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -99,12 +99,10 @@ namespace Clc.Polaris.Api
 
                 if (papiRequest.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(password) && !papiRequest.BlockStaffOverride)
                 {
-                    var accessSecret = Token?.AccessSecret;
-                    var accessToken = Token?.AccessToken;
-                    if (!string.IsNullOrWhiteSpace(accessSecret) && !string.IsNullOrWhiteSpace(accessToken))
+                    if (!string.IsNullOrWhiteSpace(Token?.AccessSecret) && !string.IsNullOrWhiteSpace(Token?.AccessToken))
                     {
-                        password = accessSecret;
-                        papiRequest.Headers["X-PAPI-AccessToken"] = accessToken;
+                        password = Token.AccessSecret;
+                        papiRequest.Headers["X-PAPI-AccessToken"] = Token.AccessToken;
                     }
                 }
 
@@ -161,13 +159,12 @@ namespace Clc.Polaris.Api
 
         private void ReplaceProtectedTokenPlaceholderInPath(PapiRestRequest request)
         {
-            var accessToken = Token?.AccessToken;
-            if (string.IsNullOrWhiteSpace(accessToken))
+            if (string.IsNullOrWhiteSpace(Token?.AccessToken))
             {
                 throw new InvalidOperationException("A valid protected access token is required to replace ProtectedToken.Placeholder in the request path.");
             }
 
-            request.Path = request.Path.Replace(ProtectedToken.Placeholder, accessToken, StringComparison.Ordinal);
+            request.Path = request.Path.Replace(ProtectedToken.Placeholder, Token.AccessToken, StringComparison.Ordinal);
         }
 
         private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -52,7 +52,15 @@ namespace Clc.Polaris.Api
         /// </summary>
         public ProtectedToken Token
         {
-            get { return _token; }
+            get
+            {
+                if (IsProtectedTokenMissingOrExpired(_token))
+                {
+                    _token = null;
+                }
+
+                return _token;
+            }
             set { _token = value; }
         }
 
@@ -99,9 +107,9 @@ namespace Clc.Polaris.Api
                     }
                 }
 
-                if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password) && Token != null)
+                if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password))
                 {
-                    password = Token.AccessSecret;
+                    password = Token?.AccessSecret ?? password;
                 }
 
                 var date = DateTime.Now.ToUniversalTime().ToString("R");
@@ -233,12 +241,12 @@ namespace Clc.Polaris.Api
 
         private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenAsync(string cacheKey, CancellationToken cancellationToken)
         {
-            var currentToken = _token;
+            var currentToken = Token;
             var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
             if (response?.Response == null || !response.Response.IsSuccessStatusCode || IsProtectedTokenMissingOrExpired(response.Data))
             {
                 _token = currentToken;
-                return _token;
+                return Token;
             }
 
             _token = response.Data;

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -99,10 +99,12 @@ namespace Clc.Polaris.Api
 
                 if (papiRequest.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(password) && !papiRequest.BlockStaffOverride)
                 {
-                    if (!string.IsNullOrWhiteSpace(Token?.AccessSecret) && !string.IsNullOrWhiteSpace(Token?.AccessToken))
+                    var accessSecret = Token?.AccessSecret;
+                    var accessToken = Token?.AccessToken;
+                    if (!string.IsNullOrWhiteSpace(accessSecret) && !string.IsNullOrWhiteSpace(accessToken))
                     {
-                        password = Token.AccessSecret;
-                        papiRequest.Headers["X-PAPI-AccessToken"] = Token.AccessToken;
+                        password = accessSecret;
+                        papiRequest.Headers["X-PAPI-AccessToken"] = accessToken;
                     }
                 }
 
@@ -159,12 +161,13 @@ namespace Clc.Polaris.Api
 
         private void ReplaceProtectedTokenPlaceholderInPath(PapiRestRequest request)
         {
-            if (string.IsNullOrWhiteSpace(Token?.AccessToken))
+            var accessToken = Token?.AccessToken;
+            if (string.IsNullOrWhiteSpace(accessToken))
             {
                 throw new InvalidOperationException("A valid protected access token is required to replace ProtectedToken.Placeholder in the request path.");
             }
 
-            request.Path = request.Path.Replace(ProtectedToken.Placeholder, Token.AccessToken, StringComparison.Ordinal);
+            request.Path = request.Path.Replace(ProtectedToken.Placeholder, accessToken, StringComparison.Ordinal);
         }
 
         private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -99,12 +99,11 @@ namespace Clc.Polaris.Api
 
                 if (papiRequest.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(password) && !papiRequest.BlockStaffOverride)
                 {
-                    var accessSecret = Token?.AccessSecret;
-                    var accessToken = Token?.AccessToken;
-                    if (!string.IsNullOrWhiteSpace(accessSecret) && !string.IsNullOrWhiteSpace(accessToken))
+                    var token = Token;
+                    if (token != null)
                     {
-                        password = accessSecret;
-                        papiRequest.Headers["X-PAPI-AccessToken"] = accessToken;
+                        password = token.AccessSecret;
+                        papiRequest.Headers["X-PAPI-AccessToken"] = token.AccessToken;
                     }
                 }
 
@@ -161,8 +160,9 @@ namespace Clc.Polaris.Api
 
         private void ReplaceProtectedTokenPlaceholderInPath(PapiRestRequest request)
         {
-            var accessToken = Token?.AccessToken;
-            if (string.IsNullOrWhiteSpace(accessToken))
+            var token = Token;
+            var accessToken = token?.AccessToken;
+            if (IsProtectedTokenMissingOrExpired(token) || string.IsNullOrWhiteSpace(accessToken))
             {
                 throw new InvalidOperationException("A valid protected access token is required to replace ProtectedToken.Placeholder in the request path.");
             }
@@ -172,15 +172,15 @@ namespace Clc.Polaris.Api
 
         private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
         {
-            if (StaffOverrideAccount == null || Token != null)
+            if (StaffOverrideAccount == null || !IsProtectedTokenMissingOrExpired(_token))
             {
-                return Token;
+                return _token;
             }
 
             var cacheKey = BuildProtectedTokenCacheKey();
             if (TryLoadProtectedTokenFromCache(cacheKey))
             {
-                return Token;
+                return _token;
             }
 
             if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
@@ -192,9 +192,9 @@ namespace Clc.Polaris.Api
             await cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                if (Token != null || TryLoadProtectedTokenFromCache(cacheKey))
+                if (!IsProtectedTokenMissingOrExpired(_token) || TryLoadProtectedTokenFromCache(cacheKey))
                 {
-                    return Token;
+                    return _token;
                 }
 
                 return await AuthenticateAndLoadProtectedTokenAsync(cacheKey, cancellationToken).ConfigureAwait(false);
@@ -241,9 +241,11 @@ namespace Clc.Polaris.Api
 
         private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenAsync(string cacheKey, CancellationToken cancellationToken)
         {
+            var currentToken = Token;
             var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
             if (response?.Response == null || !response.Response.IsSuccessStatusCode || IsProtectedTokenMissingOrExpired(response.Data))
             {
+                _token = currentToken;
                 return Token;
             }
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -99,11 +99,12 @@ namespace Clc.Polaris.Api
 
                 if (papiRequest.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(password) && !papiRequest.BlockStaffOverride)
                 {
-                    var token = Token;
-                    if (token != null)
+                    var accessSecret = Token?.AccessSecret;
+                    var accessToken = Token?.AccessToken;
+                    if (!string.IsNullOrWhiteSpace(accessSecret) && !string.IsNullOrWhiteSpace(accessToken))
                     {
-                        password = token.AccessSecret;
-                        papiRequest.Headers["X-PAPI-AccessToken"] = token.AccessToken;
+                        password = accessSecret;
+                        papiRequest.Headers["X-PAPI-AccessToken"] = accessToken;
                     }
                 }
 
@@ -160,9 +161,8 @@ namespace Clc.Polaris.Api
 
         private void ReplaceProtectedTokenPlaceholderInPath(PapiRestRequest request)
         {
-            var token = Token;
-            var accessToken = token?.AccessToken;
-            if (IsProtectedTokenMissingOrExpired(token) || string.IsNullOrWhiteSpace(accessToken))
+            var accessToken = Token?.AccessToken;
+            if (string.IsNullOrWhiteSpace(accessToken))
             {
                 throw new InvalidOperationException("A valid protected access token is required to replace ProtectedToken.Placeholder in the request path.");
             }
@@ -172,15 +172,15 @@ namespace Clc.Polaris.Api
 
         private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
         {
-            if (StaffOverrideAccount == null || !IsProtectedTokenMissingOrExpired(_token))
+            if (StaffOverrideAccount == null || Token != null)
             {
-                return _token;
+                return Token;
             }
 
             var cacheKey = BuildProtectedTokenCacheKey();
             if (TryLoadProtectedTokenFromCache(cacheKey))
             {
-                return _token;
+                return Token;
             }
 
             if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
@@ -192,9 +192,9 @@ namespace Clc.Polaris.Api
             await cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                if (!IsProtectedTokenMissingOrExpired(_token) || TryLoadProtectedTokenFromCache(cacheKey))
+                if (Token != null || TryLoadProtectedTokenFromCache(cacheKey))
                 {
-                    return _token;
+                    return Token;
                 }
 
                 return await AuthenticateAndLoadProtectedTokenAsync(cacheKey, cancellationToken).ConfigureAwait(false);
@@ -241,11 +241,9 @@ namespace Clc.Polaris.Api
 
         private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenAsync(string cacheKey, CancellationToken cancellationToken)
         {
-            var currentToken = Token;
             var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
             if (response?.Response == null || !response.Response.IsSuccessStatusCode || IsProtectedTokenMissingOrExpired(response.Data))
             {
-                _token = currentToken;
                 return Token;
             }
 

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -79,7 +79,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
-        public void Token_WhenExistingTokenIsExpiredAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsExistingTokenWithoutCacheLookupOrAuthenticating()
+        public void Token_WhenExistingTokenIsExpiredAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsNullWithoutCacheLookupOrAuthenticating()
         {
             var handler = new CapturingHttpMessageHandler();
             var client = CreateClient(handler);
@@ -101,13 +101,12 @@ namespace Clc.Polaris.Api.Tests
 
             var token = client.Token;
 
-            Assert.IsNotNull(token);
-            Assert.AreEqual("expired-token", token.AccessToken);
+            Assert.IsNull(token);
             Assert.AreEqual(0, handler.RequestCount);
         }
 
         [TestMethod]
-        public void Token_WhenExistingTokenIsExpiredAndNoStaffOverrideAccount_ReturnsExistingTokenWithoutAuthenticating()
+        public void Token_WhenExistingTokenIsExpiredAndNoStaffOverrideAccount_ReturnsNullWithoutAuthenticating()
         {
             var handler = new CapturingHttpMessageHandler();
             var client = CreateClient(handler);
@@ -120,8 +119,7 @@ namespace Clc.Polaris.Api.Tests
 
             var token = client.Token;
 
-            Assert.IsNotNull(token);
-            Assert.AreEqual("expired-token", token.AccessToken);
+            Assert.IsNull(token);
             Assert.AreEqual(0, handler.RequestCount);
         }
 
@@ -270,7 +268,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
-        public async Task PatronAccountGetAsync_FailedStaffAuthentication_DoesNotOverwriteExistingToken()
+        public async Task PatronAccountGetAsync_FailedStaffAuthentication_ClearsExpiredExistingToken()
         {
             var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
             var client = CreateProtectedClient(handler);
@@ -285,13 +283,12 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.IsNotNull(client.Token);
-            Assert.AreEqual("existing-token", client.Token.AccessToken);
+            Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
         }
 
         [TestMethod]
-        public async Task PatronAccountGetAsync_NullDataStaffAuthentication_DoesNotOverwriteExistingToken()
+        public async Task PatronAccountGetAsync_NullDataStaffAuthentication_ClearsExpiredExistingToken()
         {
             var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, "{}");
             var client = CreateProtectedClient(handler);
@@ -306,8 +303,7 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.IsNotNull(client.Token);
-            Assert.AreEqual("existing-token", client.Token.AccessToken);
+            Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
         }
 

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -438,6 +438,57 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public async Task ProtectedTokenPathRequest_ClearsExpiredToken_WhenStaffReauthenticationFails()
+        {
+            var handler = new FailingStaffAuthenticationHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = "failed-refresh",
+                Password = "secret"
+            };
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "expired-token",
+                AccessSecret = "expired-secret",
+                ExpirationDate = DateTime.UtcNow.AddMinutes(-5)
+            };
+
+            var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => client.PatronSearchAsync("name=Smith", orgId: 9));
+
+            Assert.IsNull(client.Token);
+            StringAssert.Contains(exception.Message, "valid protected access token");
+            Assert.AreEqual(1, handler.Requests.Count);
+            StringAssert.Contains(handler.Requests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_ProtectedGet_DoesNotUseExpiredProtectedTokenSecretForHash()
+        {
+            var client = CreateClient();
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "expired-token",
+                AccessSecret = "expired-secret",
+                ExpirationDate = DateTime.UtcNow.AddMinutes(-5)
+            };
+            var request = new PapiRestRequest(HttpMethod.Get, "/protected/v1/1033/100/1/expired-token/search/patrons/Boolean");
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            var date = formatted.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/protected/v1/1033/100/1/expired-token/search/patrons/Boolean";
+            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
+            var expiredSecretHash = ComputePapiHash("GET", expectedUri, date, "expired-secret", "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
+            Assert.AreNotEqual($"PWS access-id:{expiredSecretHash}", formatted.Headers["Authorization"]);
+            Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
+        }
+
+        [TestMethod]
         public async Task ProtectedTokenPathRequest_UsesCachedProtectedTokenForPlaceholderReplacement()
         {
             var handler = new ProtectedTokenCancellationHttpMessageHandler();
@@ -886,6 +937,21 @@ namespace Clc.Polaris.Api.Tests
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+                });
+            }
+        }
+
+        private sealed class FailingStaffAuthenticationHttpMessageHandler : HttpMessageHandler
+        {
+            public List<HttpRequestMessage> Requests { get; } = new();
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Requests.Add(request);
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Content = new StringContent("{\"PAPIErrorCode\":-1}", Encoding.UTF8, "application/json")
                 });
             }
         }


### PR DESCRIPTION
### Motivation
- Ensure the client does not use expired protected tokens for request signing or placeholder replacement. 
- Make token handling consistent when re-authentication or cache lookup fails so expired tokens are cleared rather than reused. 

### Description
- Change the `Token` getter in `PapiClient` to proactively clear `_token` when it is missing or expired via `IsProtectedTokenMissingOrExpired`. 
- Update protected-token preloading/auth flow to use the `Token` property consistently by reading `currentToken = Token` in `AuthenticateAndLoadProtectedTokenAsync`. 
- Adjust `PreformatRestRequest` so protected-method hashing will not use an expired token secret by using `password = Token?.AccessSecret ?? password` instead of assuming `Token` non-null. 
- Update unit tests to match new behavior, including changing expectations to `null` for expired tokens, adding tests that assert expired tokens are cleared on failed reauthentication, and adding a `FailingStaffAuthenticationHttpMessageHandler` test helper. 

### Testing
- Ran unit test suites `PapiClientTokenTests` and `RestClientMigrationCharacterizationTests` with updated expectations and new tests for expired-token handling. All modified and new tests passed. 
- Verified `PreformatRestRequest` tests to ensure expired secrets are not used for authorization hashes and that protected-token placeholder replacement triggers authentication as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b9278b74c8323ae6ca27cacc778a2)