### PR TITLE
Invalidate expired ProtectedToken and prevent stale token reuse

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -52,7 +52,16 @@ namespace Clc.Polaris.Api
         /// </summary>
         public ProtectedToken Token
         {
-            get { return _token; }
+            get
+            {
+                if (IsProtectedTokenMissingOrExpired(_token))
+                {
+                    _token = null;
+                    return null;
+                }
+
+                return _token;
+            }
             set { _token = value; }
         }
 
@@ -92,16 +101,23 @@ namespace Clc.Polaris.Api
                 if (papiRequest.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(password) && !papiRequest.BlockStaffOverride)
                 {
                     var token = Token;
-                    if (token != null)
+                    var accessSecret = token?.AccessSecret;
+                    var accessToken = token?.AccessToken;
+                    if (!string.IsNullOrWhiteSpace(accessSecret) && !string.IsNullOrWhiteSpace(accessToken))
                     {
-                        password = token.AccessSecret;
-                        papiRequest.Headers["X-PAPI-AccessToken"] = token.AccessToken;
+                        password = accessSecret;
+                        papiRequest.Headers["X-PAPI-AccessToken"] = accessToken;
                     }
                 }
 
-                if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password) && Token != null)
+                if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password))
                 {
-                    password = Token.AccessSecret;
+                    var token = Token;
+                    var accessSecret = token?.AccessSecret;
+                    if (!string.IsNullOrWhiteSpace(accessSecret))
+                    {
+                        password = accessSecret;
+                    }
                 }
 
                 var date = DateTime.Now.ToUniversalTime().ToString("R");
@@ -164,9 +180,10 @@ namespace Clc.Polaris.Api
 
         private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
         {
-            if (StaffOverrideAccount == null || !IsProtectedTokenMissingOrExpired(_token))
+            var token = Token;
+            if (StaffOverrideAccount == null || token != null)
             {
-                return _token;
+                return token;
             }
 
             var cacheKey = BuildProtectedTokenCacheKey();
@@ -184,7 +201,8 @@ namespace Clc.Polaris.Api
             await cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                if (!IsProtectedTokenMissingOrExpired(_token) || TryLoadProtectedTokenFromCache(cacheKey))
+                token = Token;
+                if (token != null || TryLoadProtectedTokenFromCache(cacheKey))
                 {
                     return _token;
                 }
@@ -233,9 +251,13 @@ namespace Clc.Polaris.Api
 
         private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenAsync(string cacheKey, CancellationToken cancellationToken)
         {
-            var currentToken = _token;
+            var currentToken = Token;
             var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
-            if (response?.Response == null || !response.Response.IsSuccessStatusCode || IsProtectedTokenMissingOrExpired(response.Data))
+            if (response?.Response == null ||
+                !response.Response.IsSuccessStatusCode ||
+                IsProtectedTokenMissingOrExpired(response.Data) ||
+                string.IsNullOrWhiteSpace(response.Data.AccessToken) ||
+                string.IsNullOrWhiteSpace(response.Data.AccessSecret))
             {
                 _token = currentToken;
                 return _token;

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -98,11 +98,12 @@ namespace Clc.Polaris.Api
             {
                 papiRequest.Headers.Remove("X-PAPI-AccessToken");
 
+                var token = Token;
+                var accessSecret = token?.AccessSecret;
+                var accessToken = token?.AccessToken;
+
                 if (papiRequest.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(password) && !papiRequest.BlockStaffOverride)
                 {
-                    var token = Token;
-                    var accessSecret = token?.AccessSecret;
-                    var accessToken = token?.AccessToken;
                     if (!string.IsNullOrWhiteSpace(accessSecret) && !string.IsNullOrWhiteSpace(accessToken))
                     {
                         password = accessSecret;
@@ -112,8 +113,6 @@ namespace Clc.Polaris.Api
 
                 if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password))
                 {
-                    var token = Token;
-                    var accessSecret = token?.AccessSecret;
                     if (!string.IsNullOrWhiteSpace(accessSecret))
                     {
                         password = accessSecret;

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -79,7 +80,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
-        public void Token_WhenExistingTokenIsExpiredAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsExistingTokenWithoutCacheLookupOrAuthenticating()
+        public void Token_WhenExistingTokenIsExpiredAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsNullAndClearsTokenWithoutCacheLookupOrAuthenticating()
         {
             var handler = new CapturingHttpMessageHandler();
             var client = CreateClient(handler);
@@ -101,13 +102,13 @@ namespace Clc.Polaris.Api.Tests
 
             var token = client.Token;
 
-            Assert.IsNotNull(token);
-            Assert.AreEqual("expired-token", token.AccessToken);
+            Assert.IsNull(token);
+            Assert.IsNull(client.Token);
             Assert.AreEqual(0, handler.RequestCount);
         }
 
         [TestMethod]
-        public void Token_WhenExistingTokenIsExpiredAndNoStaffOverrideAccount_ReturnsExistingTokenWithoutAuthenticating()
+        public void Token_WhenExistingTokenIsExpiredAndNoStaffOverrideAccount_ReturnsNullAndClearsTokenWithoutAuthenticating()
         {
             var handler = new CapturingHttpMessageHandler();
             var client = CreateClient(handler);
@@ -120,8 +121,26 @@ namespace Clc.Polaris.Api.Tests
 
             var token = client.Token;
 
-            Assert.IsNotNull(token);
-            Assert.AreEqual("expired-token", token.AccessToken);
+            Assert.IsNull(token);
+            Assert.IsNull(client.Token);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenExistingTokenHasNoExpiration_ReturnsNullAndClearsTokenWithoutAuthenticating()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "missing-expiration-token",
+                AccessSecret = "missing-expiration-secret"
+            };
+
+            var token = client.Token;
+
+            Assert.IsNull(token);
+            Assert.IsNull(client.Token);
             Assert.AreEqual(0, handler.RequestCount);
         }
 
@@ -270,7 +289,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
-        public async Task PatronAccountGetAsync_FailedStaffAuthentication_DoesNotOverwriteExistingToken()
+        public async Task PatronAccountGetAsync_FailedStaffAuthentication_AfterExpiredExistingTokenClearsToken()
         {
             var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
             var client = CreateProtectedClient(handler);
@@ -285,13 +304,12 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.IsNotNull(client.Token);
-            Assert.AreEqual("existing-token", client.Token.AccessToken);
+            Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
         }
 
         [TestMethod]
-        public async Task PatronAccountGetAsync_NullDataStaffAuthentication_DoesNotOverwriteExistingToken()
+        public async Task PatronAccountGetAsync_NullDataStaffAuthentication_AfterExpiredExistingTokenClearsToken()
         {
             var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, "{}");
             var client = CreateProtectedClient(handler);
@@ -306,9 +324,98 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.IsNotNull(client.Token);
-            Assert.AreEqual("existing-token", client.Token.AccessToken);
+            Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+        }
+
+
+        [TestMethod]
+        public async Task PatronAccountGetAsync_InvalidStaffAuthentication_AfterExpiredExistingTokenClearsTokenAndDoesNotCache()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson(string.Empty, string.Empty, DateTime.Now.AddHours(1)));
+            var client = CreateProtectedClient(handler);
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "existing-token",
+                AccessSecret = "existing-secret",
+                ExpirationDate = DateTime.Now.AddHours(-1)
+            };
+
+            var response = await client.PatronAccountGetAsync("ABC123");
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.IsNull(client.Token);
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_ExpiredProtectedToken_DoesNotUseSecretForProtectedMethodSigning()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "expired-token",
+                AccessSecret = "expired-secret",
+                ExpirationDate = DateTime.Now.AddHours(-1)
+            };
+            var request = new PapiRestRequest(HttpMethod.Get, "/protected/v1/1033/100/1/expired-token/search/patrons/Boolean");
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            var date = formatted.Headers["PolarisDate"].ToString();
+            var uri = client.BuildRequestUri(formatted).AbsoluteUri;
+            Assert.AreEqual($"PWS access-id:{ComputePapiHash("GET", uri, date, string.Empty, "access-key")}", formatted.Headers["Authorization"]);
+            Assert.AreNotEqual($"PWS access-id:{ComputePapiHash("GET", uri, date, "expired-secret", "access-key")}", formatted.Headers["Authorization"]);
+            Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
+            Assert.IsNull(client.Token);
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_ExpiredProtectedToken_DoesNotUseSecretOrHeaderForPublicStaffOverrideSigning()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "expired-token",
+                AccessSecret = "expired-secret",
+                ExpirationDate = DateTime.Now.AddHours(-1)
+            };
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/patron/ABC");
+            request.Headers["X-PAPI-AccessToken"] = "stale-token";
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            var date = formatted.Headers["PolarisDate"].ToString();
+            var uri = client.BuildRequestUri(formatted).AbsoluteUri;
+            var authorization = formatted.Headers["Authorization"];
+            Assert.AreEqual($"PWS access-id:{ComputePapiHash("GET", uri, date, string.Empty, "access-key")}", authorization);
+            Assert.AreNotEqual($"PWS access-id:{ComputePapiHash("GET", uri, date, "expired-secret", "access-key")}", authorization);
+            Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
+            Assert.IsNull(client.Token);
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_PublicStaffOverrideWithMissingTokenValues_DoesNotAddAccessTokenHeader()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = " ",
+                AccessSecret = "manual-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            };
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/patron/ABC"));
+
+            Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
         }
 
         [TestMethod]
@@ -390,6 +497,13 @@ namespace Clc.Polaris.Api.Tests
                 $"\"AccessSecret\":\"{accessSecret}\"," +
                 $"\"AuthExpDate\":\"{expirationDate:O}\"" +
                 "}";
+        }
+
+        private static string ComputePapiHash(string httpMethod, string uri, string date, string password, string accessKey)
+        {
+            var hashString = httpMethod + uri + date + password;
+            var computedHash = HMACSHA1.HashData(Encoding.UTF8.GetBytes(accessKey), Encoding.UTF8.GetBytes(hashString));
+            return Convert.ToBase64String(computedHash);
         }
 
         private sealed class CapturingHttpMessageHandler : HttpMessageHandler

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -437,6 +437,64 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsFalse(handler.Requests[1].RequestUri!.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
         }
 
+
+        [TestMethod]
+        public async Task ProtectedTokenPathRequest_WithExpiredToken_AcquiresProtectedTokenBeforePlaceholderReplacement()
+        {
+            var handler = new ProtectedTokenCancellationHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = $"expired-placeholder-{Guid.NewGuid():N}",
+                Password = "secret"
+            };
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "expired-token",
+                AccessSecret = "expired-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(-1)
+            };
+
+            var response = await client.PatronSearchAsync("name=Smith", orgId: 9);
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(2, handler.Requests.Count);
+            StringAssert.Contains(handler.Requests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
+            StringAssert.Contains(handler.Requests[1].RequestUri!.AbsolutePath, "/protected/v1/1033/100/9/protected-token/search/patrons/Boolean");
+            Assert.IsFalse(handler.Requests[1].RequestUri!.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
+            Assert.AreEqual("protected-token", client.Token!.AccessToken);
+        }
+
+        [TestMethod]
+        public async Task ProtectedTokenPathRequest_WhenAuthenticationCannotProvideValidToken_ThrowsPlaceholderExceptionBeforeProtectedRequest()
+        {
+            var handler = new FailingStaffAuthenticationHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = $"failed-placeholder-{Guid.NewGuid():N}",
+                Password = "secret"
+            };
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "expired-token",
+                AccessSecret = "expired-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(-1)
+            };
+
+            var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => client.PatronSearchAsync("name=Smith", orgId: 9));
+
+            Assert.AreEqual("A valid protected access token is required to replace ProtectedToken.Placeholder in the request path.", exception.Message);
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.IsNull(client.Token);
+        }
+
         [TestMethod]
         public async Task ProtectedTokenPathRequest_UsesCachedProtectedTokenForPlaceholderReplacement()
         {
@@ -886,6 +944,30 @@ namespace Clc.Polaris.Api.Tests
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+                });
+            }
+        }
+
+        private sealed class FailingStaffAuthenticationHttpMessageHandler : HttpMessageHandler
+        {
+            public int AuthenticationRequestCount { get; private set; }
+            public int ProtectedRequestCount { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (request.RequestUri!.AbsolutePath.Contains("/authenticator/staff", StringComparison.Ordinal))
+                {
+                    AuthenticationRequestCount++;
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{}", Encoding.UTF8, "application/json")
+                    });
+                }
+
+                ProtectedRequestCount++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
                 });
             }
         }


### PR DESCRIPTION
### Motivation

- Expired or missing protected tokens must never be reused for request signing, protected-token placeholder replacement, or public-method staff override headers to avoid producing stale or invalid requests.  
- This is a clean redo of PR 78 on the `upgrade-to-restclient-3alpha` base that re-implements the change minimally without the previous revert history.

### Description

- Change `Token` getter so it clears `_token` and returns `null` when `_token` is `null`, has no `ExpirationDate`, or is expired according to `IsProtectedTokenMissingOrExpired`, while keeping the setter unchanged.  
- In `PreformatRestRequest` snapshot `Token` locally, remove any existing `X-PAPI-AccessToken` header up front, only add `X-PAPI-AccessToken` for public staff override when both `AccessSecret` and `AccessToken` are non-empty, and only use a protected `AccessSecret` for protected-method signing when non-empty.  
- In `ReplaceProtectedTokenPlaceholderInPath` snapshot the token/access-token locally and throw the existing `InvalidOperationException` when no valid non-empty protected access token is available, using the local value for replacement.  
- In protected-token acquisition (`EnsureProtectedTokenAsync` / `AuthenticateAndLoadProtectedTokenAsync`) treat a non-null `Token` (post-clear) as the fast path, load only non-expired cached tokens, and ensure failed, null, or invalid staff-auth responses do not restore or cache an expired token.

### Testing

- Ran the focused token tests: `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter FullyQualifiedName~PapiClientTokenTests` — Result: Passed: 21, Failed: 0, Skipped: 0, Total: 21.  
- Ran the characterization tests: `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter FullyQualifiedName~RestClientMigrationCharacterizationTests` — Result: Passed: 40, Failed: 0, Skipped: 0, Total: 40.  
- Ran the whole test project: `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj` — Result: Partial success; 90 tests passed and 69 tests failed because many unrelated `PapiClientTests` could not instantiate due to a missing `appsettings.Test.json` configuration file in the test environment, so the full-suite failure is an environment/configuration limitation and unrelated to these changes.

Files modified: `src/polaris-api-csharp/PapiClient.cs`, `src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs`, and `src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs`.

This PR is intentionally minimal, preserves public API shape and existing exception messages, and avoids repeated `Token` property reads within single logical operations as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b9f32522c8323bf28c2d88c8af5c5)