### PR TITLE
Invalidate expired ProtectedToken and prevent stale token reuse

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -52,7 +52,16 @@ namespace Clc.Polaris.Api
         /// </summary>
         public ProtectedToken Token
         {
-            get { return _token; }
+            get
+            {
+                if (IsProtectedTokenMissingOrExpired(_token))
+                {
+                    _token = null;
+                    return null;
+                }
+
+                return _token;
+            }
             set { _token = value; }
         }
 
@@ -89,19 +98,20 @@ namespace Clc.Polaris.Api
             {
                 papiRequest.Headers.Remove("X-PAPI-AccessToken");
 
-                if (papiRequest.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(password) && !papiRequest.BlockStaffOverride)
+                var token = Token;
+                var accessSecret = token?.AccessSecret;
+                var accessToken = token?.AccessToken;
+
+                if (papiRequest.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(password) && !papiRequest.BlockStaffOverride &&
+                    !string.IsNullOrWhiteSpace(accessSecret) && !string.IsNullOrWhiteSpace(accessToken))
                 {
-                    var token = Token;
-                    if (token != null)
-                    {
-                        password = token.AccessSecret;
-                        papiRequest.Headers["X-PAPI-AccessToken"] = token.AccessToken;
-                    }
+                    password = accessSecret;
+                    papiRequest.Headers["X-PAPI-AccessToken"] = accessToken;
                 }
 
-                if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password) && Token != null)
+                if (papiRequest.IsProtectedMethod && string.IsNullOrWhiteSpace(password) && !string.IsNullOrWhiteSpace(accessSecret))
                 {
-                    password = Token.AccessSecret;
+                    password = accessSecret;
                 }
 
                 var date = DateTime.Now.ToUniversalTime().ToString("R");
@@ -164,9 +174,10 @@ namespace Clc.Polaris.Api
 
         private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
         {
-            if (StaffOverrideAccount == null || !IsProtectedTokenMissingOrExpired(_token))
+            var token = Token;
+            if (StaffOverrideAccount == null || token != null)
             {
-                return _token;
+                return token;
             }
 
             var cacheKey = BuildProtectedTokenCacheKey();
@@ -184,7 +195,8 @@ namespace Clc.Polaris.Api
             await cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                if (!IsProtectedTokenMissingOrExpired(_token) || TryLoadProtectedTokenFromCache(cacheKey))
+                token = Token;
+                if (token != null || TryLoadProtectedTokenFromCache(cacheKey))
                 {
                     return _token;
                 }
@@ -233,7 +245,7 @@ namespace Clc.Polaris.Api
 
         private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenAsync(string cacheKey, CancellationToken cancellationToken)
         {
-            var currentToken = _token;
+            var currentToken = Token;
             var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
             if (response?.Response == null || !response.Response.IsSuccessStatusCode || IsProtectedTokenMissingOrExpired(response.Data))
             {

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -79,7 +79,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
-        public void Token_WhenExistingTokenIsExpiredAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsExistingTokenWithoutCacheLookupOrAuthenticating()
+        public void Token_WhenExistingTokenIsExpiredAndStaffOverrideAccountExistsAndCacheHasValidToken_ReturnsNullAndClearsTokenWithoutCacheLookupOrAuthenticating()
         {
             var handler = new CapturingHttpMessageHandler();
             var client = CreateClient(handler);
@@ -101,13 +101,13 @@ namespace Clc.Polaris.Api.Tests
 
             var token = client.Token;
 
-            Assert.IsNotNull(token);
-            Assert.AreEqual("expired-token", token.AccessToken);
+            Assert.IsNull(token);
+            Assert.IsNull(client.Token);
             Assert.AreEqual(0, handler.RequestCount);
         }
 
         [TestMethod]
-        public void Token_WhenExistingTokenIsExpiredAndNoStaffOverrideAccount_ReturnsExistingTokenWithoutAuthenticating()
+        public void Token_WhenExistingTokenIsExpiredAndNoStaffOverrideAccount_ReturnsNullAndClearsTokenWithoutAuthenticating()
         {
             var handler = new CapturingHttpMessageHandler();
             var client = CreateClient(handler);
@@ -120,8 +120,26 @@ namespace Clc.Polaris.Api.Tests
 
             var token = client.Token;
 
-            Assert.IsNotNull(token);
-            Assert.AreEqual("expired-token", token.AccessToken);
+            Assert.IsNull(token);
+            Assert.IsNull(client.Token);
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public void Token_WhenExistingTokenHasNoExpiration_ReturnsNullAndClearsTokenWithoutAuthenticating()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "missing-expiration-token",
+                AccessSecret = "missing-expiration-secret"
+            };
+
+            var token = client.Token;
+
+            Assert.IsNull(token);
+            Assert.IsNull(client.Token);
             Assert.AreEqual(0, handler.RequestCount);
         }
 
@@ -270,7 +288,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
-        public async Task PatronAccountGetAsync_FailedStaffAuthentication_DoesNotOverwriteExistingToken()
+        public async Task PatronAccountGetAsync_FailedStaffAuthentication_AfterExpiredExistingTokenClearsToken()
         {
             var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
             var client = CreateProtectedClient(handler);
@@ -285,13 +303,12 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.IsNotNull(client.Token);
-            Assert.AreEqual("existing-token", client.Token.AccessToken);
+            Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
         }
 
         [TestMethod]
-        public async Task PatronAccountGetAsync_NullDataStaffAuthentication_DoesNotOverwriteExistingToken()
+        public async Task PatronAccountGetAsync_NullDataStaffAuthentication_AfterExpiredExistingTokenClearsToken()
         {
             var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, "{}");
             var client = CreateProtectedClient(handler);
@@ -306,8 +323,7 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.IsNotNull(client.Token);
-            Assert.AreEqual("existing-token", client.Token.AccessToken);
+            Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
         }
 

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -129,6 +129,31 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
         }
 
+
+        [TestMethod]
+        public void PreformatRestRequest_ProtectedGet_DoesNotUseExpiredProtectedTokenSecretForHash()
+        {
+            var client = CreateClient();
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "expired-protected-token",
+                AccessSecret = "expired-protected-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(-1)
+            };
+            var request = new PapiRestRequest(HttpMethod.Get, "/protected/v1/1033/100/1/expired-protected-token/search/patrons/Boolean");
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            var date = formatted.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/protected/v1/1033/100/1/expired-protected-token/search/patrons/Boolean";
+            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
+            var staleHash = ComputePapiHash("GET", expectedUri, date, "expired-protected-secret", "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
+            Assert.AreNotEqual($"PWS access-id:{staleHash}", formatted.Headers["Authorization"]);
+            Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
+            Assert.IsNull(client.Token);
+        }
+
         [TestMethod]
         public void PreformatRestRequest_PublicAuthenticatedGetWithQueryParameters_HashesEffectiveOutgoingUrl()
         {
@@ -200,6 +225,55 @@ namespace Clc.Polaris.Api.Tests
             var date = formatted.Headers["PolarisDate"];
             var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate";
             var expectedHash = ComputePapiHash("GET", expectedUri, date, "staff-secret", "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
+        }
+
+
+        [TestMethod]
+        public void PreformatRestRequest_PublicStaffOverride_DoesNotUseExpiredProtectedTokenOrAddStaleAccessTokenHeader()
+        {
+            var client = CreateClient();
+            client.AllowStaffOverrideRequests = true;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "expired-staff-token",
+                AccessSecret = "expired-staff-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(-1)
+            };
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/apikeyvalidate");
+            request.Headers["X-PAPI-AccessToken"] = "stale-header-token";
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
+            var date = formatted.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate";
+            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
+            var staleHash = ComputePapiHash("GET", expectedUri, date, "expired-staff-secret", "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
+            Assert.AreNotEqual($"PWS access-id:{staleHash}", formatted.Headers["Authorization"]);
+            Assert.IsNull(client.Token);
+        }
+
+        [TestMethod]
+        public void PreformatRestRequest_PublicStaffOverride_DoesNotAddAccessTokenHeaderWhenTokenValuesAreBlank()
+        {
+            var client = CreateClient();
+            client.AllowStaffOverrideRequests = true;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = " ",
+                AccessSecret = "staff-secret",
+                ExpirationDate = DateTime.UtcNow.AddHours(1)
+            };
+            var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/apikeyvalidate");
+
+            var formatted = (PapiRestRequest)client.PreformatRestRequest(request);
+
+            Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
+            var date = formatted.Headers["PolarisDate"];
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate";
+            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
             Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
         }
 
@@ -435,6 +509,28 @@ namespace Clc.Polaris.Api.Tests
             StringAssert.Contains(handler.Requests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
             StringAssert.Contains(handler.Requests[1].RequestUri!.AbsolutePath, "/protected/v1/1033/100/9/protected-token/search/patrons/Boolean");
             Assert.IsFalse(handler.Requests[1].RequestUri!.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
+        }
+
+
+        [TestMethod]
+        public async Task ProtectedTokenPathRequest_WhenAuthenticationCannotProvideValidToken_ThrowsClearPlaceholderException()
+        {
+            var handler = new CapturingHttpMessageHandler("{}");
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = new PolarisUser
+            {
+                Domain = "main",
+                Username = $"invalid-placeholder-{Guid.NewGuid():N}",
+                Password = "secret"
+            };
+
+            var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith", orgId: 9));
+
+            Assert.AreEqual("A valid protected access token is required to replace ProtectedToken.Placeholder in the request path.", exception.Message);
+            Assert.IsNotNull(handler.LastRequest);
+            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
+            Assert.IsNull(client.Token);
         }
 
         [TestMethod]


### PR DESCRIPTION
### Motivation
- Expired or missing protected tokens must never be reused for request signing, placeholder replacement, or public-method staff override headers, and the previous messy revert history needed a clean, minimal re-implementation (clean redo of PR 78). 

### Description
- Update `PapiClient.Token` getter to clear and return `null` when `_token` is null, has no `ExpirationDate`, or is expired using `IsProtectedTokenMissingOrExpired`, while keeping the setter unchanged. 
- Snapshot `Token` once into a local variable in `PreformatRestRequest`, `ReplaceProtectedTokenPlaceholderInPath`, `EnsureProtectedTokenAsync`, and `AuthenticateAndLoadProtectedTokenAsync` to avoid repeated property reads and to use local `AccessToken`/`AccessSecret` values for decisions. 
- In `PreformatRestRequest` only add `X-PAPI-AccessToken` for public staff-override when both `AccessToken` and `AccessSecret` are non-empty, and avoid using expired secrets for protected-method signing. 
- In placeholder replacement, use a local snapshot of the access token and throw the existing `InvalidOperationException` when no valid non-empty access token is available. 
- Update protected-token preload/auth flow so a non-null `Token` is treated as the valid fast path, cache loading only returns non-expired cached tokens, and failed or invalid re-authentication after an expired token does not restore or cache the expired token. 

### Testing
- Ran the targeted unit suites: `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter PapiClientTokenTests` and observed "Passed!  - Failed:     0, Passed:    17, Skipped:     0, Total:    17". 
- Ran the characterization suite: `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter RestClientMigrationCharacterizationTests` and observed "Passed!  - Failed:     0, Passed:    42, Skipped:     0, Total:    42". 
- Ran both suites together: `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "PapiClientTokenTests|RestClientMigrationCharacterizationTests"` and observed "Passed!  - Failed:     0, Passed:    59, Skipped:     0, Total:    59". 
- Ran the full test project with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj` which surfaced unrelated environment configuration failures due to a missing `appsettings.Test.json` in the test output directory; the failures are environmental and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b9f32522c8323bf28c2d88c8af5c5)