### PR TITLE
Remove global TLS override from PapiClient

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -3,7 +3,6 @@ using Clc.Polaris.Api.Configuration;
 using Clc.Polaris.Api.Models;
 using Clc.Rest;
 using System;
-using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
@@ -56,10 +55,12 @@ namespace Clc.Polaris.Api
             set { _token = value; }
         }
 
+        /// <summary>
+        /// Initializes a new PAPI client. Configure TLS behavior on the injected <see cref="HttpClient"/>
+        /// by supplying an <see cref="HttpClientHandler"/> with the desired settings.
+        /// </summary>
         public PapiClient(HttpClient client, IPapiSettings settings) : base(null, client)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-
             if (settings != null)
             {
                 AccessID = settings.AccessId;


### PR DESCRIPTION
### Motivation
- The library set `ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12` in the `PapiClient` constructor which forces a process-wide TLS configuration that is inappropriate for a net8.0 library. 
- TLS policy should be controlled by the caller via an injected `HttpClient`/`HttpClientHandler` to avoid affecting other code in the process.

### Description
- Remove the process-global `ServicePointManager.SecurityProtocol` assignment from the `PapiClient(HttpClient, IPapiSettings)` constructor. 
- Add an XML doc comment on the constructor explaining that TLS behavior must be configured on the injected `HttpClient` (for example by providing a configured `HttpClientHandler`).
- Remove the now-unused `using System.Net;` import and keep the rest of constructor initialization unchanged.

### Testing
- Searched the repository for `ServicePointManager.SecurityProtocol`, `ServicePointManager`, and `SecurityProtocol` with `rg` and found no remaining references. 
- Built the solution with `dotnet build src/polaris-api-csharp.sln --no-restore` which succeeded. 
- Ran `dotnet test src/polaris-api-csharp.sln` where the build completed but test execution failed due to a missing `appsettings.Test.json` in the test output path (environment-specific test configuration), not because of the code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b93752bfc8323ade12fae8cefd130)