### PR TITLE
Dispose HMACSHA1 in PAPI hash signing

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -254,7 +254,8 @@ namespace Clc.Polaris.Api
         private string GetPAPIHash(string httpMethod, string date, string uri, string password)
         {
             var hashString = httpMethod + uri + date + password;
-            byte[] computedHash = new HMACSHA1(Encoding.UTF8.GetBytes(AccessKey)).ComputeHash(Encoding.UTF8.GetBytes(hashString));
+            using var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(AccessKey));
+            byte[] computedHash = hmac.ComputeHash(Encoding.UTF8.GetBytes(hashString));
             return Convert.ToBase64String(computedHash);
         }
     }


### PR DESCRIPTION
### Motivation
- Ensure the `HMACSHA1` instance created in `GetPAPIHash` is disposed promptly to avoid leaving cryptographic objects undisposed.

### Description
- Replace direct `new HMACSHA1(...)` usage with `using var hmac = new HMACSHA1(...)` in `GetPAPIHash` inside `src/polaris-api-csharp/PapiClient.cs` so the signer is disposed after computing the hash.

### Testing
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter FullyQualifiedName~RestClientMigrationCharacterizationTests` and the filtered signing/authorization tests passed successfully.
- Ran `dotnet test src/polaris-api-csharp.sln` and the full test run failed due to a missing `appsettings.Test.json` file in this environment, not because of the change to `GetPAPIHash`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b9381bf5c832388201664ee0b8775)