### PR TITLE
Enable nullable reference types in Clc.Polaris.Api and annotate API surface

### DIFF
--- a/src/polaris-api-csharp/Clc.Polaris.Api.csproj
+++ b/src/polaris-api-csharp/Clc.Polaris.Api.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>Clc.Polaris</RootNamespace>
+		<Nullable>enable</Nullable>
 		<PackageId>Clc.Polaris.Api</PackageId>
 		<Authors>Central Library Consortium, Michael Fields</Authors>
 		<Description>A helper library that assists in the consumption of the Polaris ILS API</Description>

--- a/src/polaris-api-csharp/Configuration/PapiSettings.cs
+++ b/src/polaris-api-csharp/Configuration/PapiSettings.cs
@@ -9,13 +9,13 @@ namespace Clc.Polaris.Api.Configuration
     {
         public const string SECTION_NAME = "PapiSettings";
 
-        public string AccessId { get; set; }
-        public string AccessKey { get; set; }
-        public string Hostname { get; set; }
+        public string AccessId { get; set; } = string.Empty;
+        public string AccessKey { get; set; } = string.Empty;
+        public string Hostname { get; set; } = string.Empty;
         public int OrganizationId { get; set; } = 1;
         public int UserId { get; set; } = 1;
         public int WorkstationId { get; set; } = 1;
-        public PolarisUser PolarisOverrideAccount { get; set; }
+        public PolarisUser? PolarisOverrideAccount { get; set; }
     }
     public interface IPapiSettings
     {
@@ -25,6 +25,6 @@ namespace Clc.Polaris.Api.Configuration
         int OrganizationId { get; set; }
         int UserId { get; set; }
         int WorkstationId { get; set; }
-        PolarisUser PolarisOverrideAccount { get; set; }
+        PolarisUser? PolarisOverrideAccount { get; set; }
     }
 }

--- a/src/polaris-api-csharp/IPapiClient.cs
+++ b/src/polaris-api-csharp/IPapiClient.cs
@@ -32,7 +32,7 @@ namespace Clc.Polaris.Api
         /// <summary>
         /// The staff credentials used for protected methods and public method overrides
         /// </summary>
-        PolarisUser StaffOverrideAccount { get; set; }
+        PolarisUser? StaffOverrideAccount { get; set; }
 
         Task<IRestResponse<PapiResponseCommon>> ApiKeyValidateAsync(CancellationToken cancellationToken = default);
         Task<IRestResponse<ApiResult>> ApiVersionGetAsync(CancellationToken cancellationToken = default);
@@ -51,8 +51,8 @@ namespace Clc.Polaris.Api
         Task<IRestResponse<HoldRequestActivationResult>> HoldRequestReactivateAsync(string barcode, string password, int requestId, DateTime activationDate, int? userId = null, CancellationToken cancellationToken = default);
         Task<IRestResponse<HoldRequestReplyResult>> HoldRequestReplyAsync(HoldRequestCreateResult holdCreateResult, int requestingOrgId, HoldRequestReplyAnswer answer, HoldRequestReplyState state, CancellationToken cancellationToken = default);
         Task<IRestResponse<HoldRequestActivationResult>> HoldRequestSuspendAsync(string barcode, int requestId, DateTime activationDate, string password = "", int? userId = null, CancellationToken cancellationToken = default);
-        Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAsync(string barcode, int itemId, string password = "", ItemRenewOptions renewOptions = null, CancellationToken cancellationToken = default);
-        Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAllForPatronAsync(string barcode, string password = "", ItemRenewOptions renewOptions = null, CancellationToken cancellationToken = default);
+        Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAsync(string barcode, int itemId, string password = "", ItemRenewOptions? renewOptions = null, CancellationToken cancellationToken = default);
+        Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAllForPatronAsync(string barcode, string password = "", ItemRenewOptions? renewOptions = null, CancellationToken cancellationToken = default);
         Task<IRestResponse<ItemStatusesGetResult>> ItemStatusesGetAsync(int? branchId = null, CancellationToken cancellationToken = default);
         Task<IRestResponse<PapiResponseCommon>> ItemUpdateBarcodeAsync(string newBarcode, int? itemRecordId = null, int? transactionBranchId = null, string oldBarcode = "", CancellationToken cancellationToken = default);
         Task<IRestResponse<LimitFiltersGetResult>> LimitFiltersGetAsync(int? branchId = null, CancellationToken cancellationToken = default);
@@ -113,6 +113,6 @@ namespace Clc.Polaris.Api
         Task<IRestResponse<Sync_BibsByIdGetResult>> Synch_BibsByIdGetAsync(int[] bibIds, bool includeItems = false, CancellationToken cancellationToken = default);
         Task<IRestResponse<Sync_BibsByIdGetResult>> Synch_BibsByIdGetAsync(int bibId, bool includeItems = false, CancellationToken cancellationToken = default);
         Task<IRestResponse<PapiResponseCommon>> UpdatePickupBranchIDAsync(string barcode, int requestId, int pickupBranchId, string password = "", int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default);
-        Task<IRestResponse<PapiResponseCommon>> UpdatePatronNotesDataAsync(string barcode, string nonBlockingNote = null, string blockingNote = null, UpdateNoteMode updateMode = UpdateNoteMode.Prepend, int? workstationId = null, CancellationToken cancellationToken = default);
+        Task<IRestResponse<PapiResponseCommon>> UpdatePatronNotesDataAsync(string barcode, string? nonBlockingNote = null, string? blockingNote = null, UpdateNoteMode updateMode = UpdateNoteMode.Prepend, int? workstationId = null, CancellationToken cancellationToken = default);
     }
 }

--- a/src/polaris-api-csharp/Methods/ItemRenew.cs
+++ b/src/polaris-api-csharp/Methods/ItemRenew.cs
@@ -1,4 +1,4 @@
-
+﻿
 using Clc.Rest;
 using Clc.Polaris.Api.Models;
 using System.Net;
@@ -9,13 +9,13 @@ namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-        public async Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAsync(string barcode, int itemId, string password = "", ItemRenewOptions renewOptions = null, CancellationToken cancellationToken = default)
+        public async Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAsync(string barcode, int itemId, string password = "", ItemRenewOptions? renewOptions = null, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/itemsout/{itemId}";
             var request = PapiRestRequest.Put(url, body: renewOptions ?? new ItemRenewOptions(), password: password);
             return await ExecutePapiAsync<ItemRenewResultWrapper>(request, cancellationToken).ConfigureAwait(false);
         }
-        public Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAllForPatronAsync(string barcode, string password = "", ItemRenewOptions renewOptions = null, CancellationToken cancellationToken = default)
+        public Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAllForPatronAsync(string barcode, string password = "", ItemRenewOptions? renewOptions = null, CancellationToken cancellationToken = default)
             => ItemRenewAsync(barcode, 0, password, renewOptions, cancellationToken);
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
+++ b/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -16,10 +16,10 @@ namespace Clc.Polaris.Api
         public Task<IRestResponse<PapiResponseCommon>> PatronReadingHistoryClearAsync(string barcode, IEnumerable<int> ids, CancellationToken cancellationToken = default)
             => PatronReadingHistoryClearAsync(barcode, null, ids, cancellationToken);
 
-        public async Task<IRestResponse<PapiResponseCommon>> PatronReadingHistoryClearAsync(string barcode, string password, IEnumerable<int> ids, CancellationToken cancellationToken = default)
+        public async Task<IRestResponse<PapiResponseCommon>> PatronReadingHistoryClearAsync(string barcode, string? password, IEnumerable<int> ids, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/readinghistory";
-            var request = PapiRestRequest.Delete(url, password: password);
+            var request = PapiRestRequest.Delete(url, password: password ?? string.Empty);
             if (ids.Any()) { request.QueryParameters.Add("ids", string.Join(",", ids)); }
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
@@ -1,4 +1,4 @@
-using Clc.Polaris.Api.Models;
+﻿using Clc.Polaris.Api.Models;
 using Clc.Polaris.Models;
 using Clc.Rest;
 using System;
@@ -13,7 +13,7 @@ namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-        public async Task<IRestResponse<PapiResponseCommon>> UpdatePatronNotesDataAsync(string barcode, string nonBlockingNote = null, string blockingNote = null, UpdateNoteMode updateMode = UpdateNoteMode.Prepend, int? workstationId = null, CancellationToken cancellationToken = default)
+        public async Task<IRestResponse<PapiResponseCommon>> UpdatePatronNotesDataAsync(string barcode, string? nonBlockingNote = null, string? blockingNote = null, UpdateNoteMode updateMode = UpdateNoteMode.Prepend, int? workstationId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/notes";
             var body = new UpdatePatronNotesData();

--- a/src/polaris-api-csharp/Models/ApiResult.cs
+++ b/src/polaris-api-csharp/Models/ApiResult.cs
@@ -8,8 +8,8 @@ namespace Clc.Polaris.Api.Models
 {
     public class ApiResult : PapiResponseCommon
     {
-        public string Version { get; set; }
+        public string? Version { get; set; }
 
-        public override string ToString() => Version;
+        public override string ToString() => Version ?? string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/BibGetResult.cs
+++ b/src/polaris-api-csharp/Models/BibGetResult.cs
@@ -11,7 +11,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// List of rows containing raw bibliographic record information.
         /// </summary>
-        public List<BibGetRow> BibGetRows { get; set; }
+        public List<BibGetRow> BibGetRows { get; set; } = new List<BibGetRow>();
 
         /// <summary>
         /// Publisher(s) of the record.
@@ -28,7 +28,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// ISBN of the record.
         /// </summary>
-        public string ISBN => GetBibResultRow(6).FirstOrDefault();
+        public string ISBN => GetBibResultRow(6).FirstOrDefault() ?? string.Empty;
 
         /// <summary>
         /// Number of items associated with this record system-wide.
@@ -70,7 +70,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Format of the record.
         /// </summary>
-        public string Format => GetBibResultRow(17).FirstOrDefault();
+        public string Format => GetBibResultRow(17).FirstOrDefault() ?? string.Empty;
 
         /// <summary>
         /// Author of the record.
@@ -100,17 +100,17 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// LCCN of the record.
         /// </summary>
-        public string LCCN => GetBibResultRow(23).FirstOrDefault();
+        public string LCCN => GetBibResultRow(23).FirstOrDefault() ?? string.Empty;
 
         /// <summary>
         /// ISSN of the record.
         /// </summary>
-        public string ISSN => GetBibResultRow(24).FirstOrDefault();
+        public string ISSN => GetBibResultRow(24).FirstOrDefault() ?? string.Empty;
 
         /// <summary>
         /// Other number of the record.
         /// </summary>
-        public string OtherNumber => GetBibResultRow(25).FirstOrDefault();
+        public string OtherNumber => GetBibResultRow(25).FirstOrDefault() ?? string.Empty;
 
         /// <summary>
         /// Genre of the title.
@@ -140,22 +140,22 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Uniform title of the record.
         /// </summary>
-        public string UniformTitle => GetBibResultRow(34).FirstOrDefault();
+        public string UniformTitle => GetBibResultRow(34).FirstOrDefault() ?? string.Empty;
 
         /// <summary>
         /// Title of the record.
         /// </summary>
-        public string Title => GetBibResultRow(35).FirstOrDefault();
+        public string Title => GetBibResultRow(35).FirstOrDefault() ?? string.Empty;
 
         /// <summary>
         /// Volume of the record.
         /// </summary>
-        public string Volume => GetBibResultRow(36).FirstOrDefault();
+        public string Volume => GetBibResultRow(36).FirstOrDefault() ?? string.Empty;
 
         /// <summary>
         /// Frequency of the record.
         /// </summary>
-        public string Frequency => GetBibResultRow(37).FirstOrDefault();
+        public string Frequency => GetBibResultRow(37).FirstOrDefault() ?? string.Empty;
 
         /// <summary>
         /// Former title of the record.
@@ -191,7 +191,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Medium of the record.
         /// </summary>
-        public string Medium => GetBibResultRow(46).FirstOrDefault();
+        public string Medium => GetBibResultRow(46).FirstOrDefault() ?? string.Empty;
 
         private int? GetBibResultRowInt(int id)
         {
@@ -202,7 +202,7 @@ namespace Clc.Polaris.Api.Models
 
         private List<string> GetBibResultRow(int id)
         {
-            return BibGetRows.Where(b => b.ElementID == id).Select(b => b.Value).ToList();
+            return BibGetRows.Where(b => b.ElementID == id).Select(b => b.Value ?? string.Empty).ToList();
         }
     }
 
@@ -225,12 +225,12 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// The label associated with this element.
         /// </summary>
-        public string Label { get; set; }
+        public string? Label { get; set; }
 
         /// <summary>
         /// The value of the element.
         /// </summary>
-        public string Value { get; set; }
+        public string? Value { get; set; }
 
         public override string ToString()
         {

--- a/src/polaris-api-csharp/Models/BibHoldingsGetResult.cs
+++ b/src/polaris-api-csharp/Models/BibHoldingsGetResult.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api.Models
         /// Container for bib holding rows
         /// </summary>
         [XmlElement(ElementName = "BibHoldingsGetRows")]
-        public List<BibHoldingsGetRow> BibHoldingsGetRows { get; set; }
+        public List<BibHoldingsGetRow> BibHoldingsGetRows { get; set; } = new List<BibHoldingsGetRow>();
     }
 
     /// <summary>
@@ -28,138 +28,138 @@ namespace Clc.Polaris.Api.Models
         /// Item's assigned branch ID
         /// </summary>
         [XmlElement(ElementName = "LocationID")]
-        public string LocationID { get; set; }
+        public string? LocationID { get; set; }
 
         /// <summary>
         /// Item's assigned branch name
         /// </summary>
         [XmlElement(ElementName = "LocationName")]
-        public string LocationName { get; set; }
+        public string? LocationName { get; set; }
 
         /// <summary>
         /// CollectionID
         /// </summary>
         [XmlElement(ElementName = "CollectionID")]
-        public string CollectionID { get; set; }
+        public string? CollectionID { get; set; }
 
         /// <summary>
         /// Collection name
         /// </summary>
         [XmlElement(ElementName = "CollectionName")]
-        public string CollectionName { get; set; }
+        public string? CollectionName { get; set; }
 
         /// <summary>
         /// Barcode
         /// </summary>
         [XmlElement(ElementName = "Barcode")]
-        public string Barcode { get; set; }
+        public string? Barcode { get; set; }
 
         /// <summary>
         /// Public note
         /// </summary>
         [XmlElement(ElementName = "PublicNote")]
-        public string PublicNote { get; set; }
+        public string? PublicNote { get; set; }
 
         /// <summary>
         /// Call number
         /// </summary>
         [XmlElement(ElementName = "CallNumber")]
-        public string CallNumber { get; set; }
+        public string? CallNumber { get; set; }
 
         /// <summary>
         /// Designation
         /// </summary>
         [XmlElement(ElementName = "Designation")]
-        public string Designation { get; set; }
+        public string? Designation { get; set; }
 
         /// <summary>
         /// Shelf location
         /// </summary>
         [XmlElement(ElementName = "ShelfLocation")]
-        public string ShelfLocation { get; set; }
+        public string? ShelfLocation { get; set; }
 
         /// <summary>
         /// Circulation status
         /// </summary>
         [XmlElement(ElementName = "CircStatus")]
-        public string CircStatus { get; set; }
+        public string? CircStatus { get; set; }
 
         /// <summary>
         /// Last circulation date
         /// </summary>
         [XmlElement(ElementName = "LastCircDate")]
-        public string LastCircDate { get; set; }
+        public string? LastCircDate { get; set; }
 
         /// <summary>
         /// Material type
         /// </summary>
         [XmlElement(ElementName = "MaterialType")]
-        public string MaterialType { get; set; }
+        public string? MaterialType { get; set; }
 
         /// <summary>
         /// Textual holdings note
         /// </summary>
         [XmlElement(ElementName = "TextualHoldingsNote")]
-        public string TextualHoldingsNote { get; set; }
+        public string? TextualHoldingsNote { get; set; }
 
         /// <summary>
         /// Retention statement
         /// </summary>
         [XmlElement(ElementName = "RetentionStatement")]
-        public string RetentionStatement { get; set; }
+        public string? RetentionStatement { get; set; }
 
         /// <summary>
         /// Holdings statement
         /// </summary>
         [XmlElement(ElementName = "HoldingsStatement")]
-        public string HoldingsStatement { get; set; }
+        public string? HoldingsStatement { get; set; }
 
         /// <summary>
         /// Holdings note
         /// </summary>
         [XmlElement(ElementName = "HoldingsNote")]
-        public string HoldingsNote { get; set; }
+        public string? HoldingsNote { get; set; }
 
         /// <summary>
         /// Total items at the assigned location
         /// </summary>
         [XmlElement(ElementName = "ItemsTotal")]
-        public string ItemsTotal { get; set; }
+        public string? ItemsTotal { get; set; }
 
         /// <summary>
         /// Items available for checkouts
         /// </summary>
         [XmlElement(ElementName = "ItemsIn")]
-        public string ItemsIn { get; set; }
+        public string? ItemsIn { get; set; }
 
         /// <summary>
         /// Holdable
         /// </summary>
         [XmlElement(ElementName = "Holdable")]
-        public string Holdable { get; set; }
+        public string? Holdable { get; set; }
 
         /// <summary>
         /// Volume number
         /// </summary>
         [XmlElement(ElementName = "VolumeNumber")]
-        public string VolumeNumber { get; set; }
+        public string? VolumeNumber { get; set; }
 
         /// <summary>
         /// Due date
         /// </summary>
         [XmlElement(ElementName = "DueDate")]
-        public string DueDate { get; set; }
+        public string? DueDate { get; set; }
 
         /// <summary>
         /// Is this material type chargeable
         /// </summary>
         [XmlElement(ElementName = "IsMaterialTypeChargeable")]
-        public string IsMaterialTypeChargeable { get; set; }
+        public string? IsMaterialTypeChargeable { get; set; }
 
         /// <summary>
         /// Is this an electronic item
         /// </summary>
         [XmlElement(ElementName = "IsElectronicItem")]
-        public string IsElectronicItem { get; set; }
+        public string? IsElectronicItem { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/BibSearchOptions.cs
+++ b/src/polaris-api-csharp/Models/BibSearchOptions.cs
@@ -14,7 +14,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Search term
         /// </summary>
-        public string Term { get; set; }
+        public string? Term { get; set; }
 
         /// <summary>
         /// Search type, keyword or boolean
@@ -34,7 +34,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Limit by filter you want to apply
         /// </summary>
-        public string Limit { get; set; }
+        public string? Limit { get; set; }
 
         /// <summary>
         /// Branch to search

--- a/src/polaris-api-csharp/Models/BibSearchResult.cs
+++ b/src/polaris-api-csharp/Models/BibSearchResult.cs
@@ -10,7 +10,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// List of words used to perform the search.
 		/// </summary>
-		public string WordList { get; set; }
+		public string? WordList { get; set; }
 
 		/// <summary>
 		/// Total number of records that match the search criteria.
@@ -20,7 +20,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// A row that contains bibliographic record information of the search results.
 		/// </summary>
-		public List<BibSearchRow> BibSearchRows { get; set; }
+		public List<BibSearchRow> BibSearchRows { get; set; } = new List<BibSearchRow>();
 	}
 
 	/// <summary>
@@ -41,57 +41,57 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// Author of this record.
 		/// </summary>
-		public string Author { get; set; }
+		public string? Author { get; set; }
 
 		/// <summary>
 		/// Title of this record.
 		/// </summary>
-		public string Title { get; set; }
+		public string? Title { get; set; }
 
 		/// <summary>
 		/// Publisher of this record.
 		/// </summary>
-		public string Publisher { get; set; }
+		public string? Publisher { get; set; }
 
 		/// <summary>
 		/// Edition of this record.
 		/// </summary>
-		public string Edition { get; set; }
+		public string? Edition { get; set; }
 
 		/// <summary>
 		/// Publication date of this record.
 		/// </summary>
-		public string PublicationDate { get; set; }
+		public string? PublicationDate { get; set; }
 
 		/// <summary>
 		/// ISBN of this record.
 		/// </summary>
-		public string ISBN { get; set; }
+		public string? ISBN { get; set; }
 
 		/// <summary>
 		/// Description of this record.
 		/// </summary>
-		public string Description { get; set; }
+		public string? Description { get; set; }
 
 		/// <summary>
 		/// Web link of this record.
 		/// </summary>
-		public string WebLink { get; set; }
+		public string? WebLink { get; set; }
 
 		/// <summary>
 		/// GUESS: If this record is a work of fiction.
 		/// </summary>
-		public string Fiction { get; set; }
+		public string? Fiction { get; set; }
 
 		/// <summary>
 		/// Type of material of this record.
 		/// </summary>
-		public string TypeOfMaterial { get; set; }
+		public string? TypeOfMaterial { get; set; }
 
 		/// <summary>
 		/// Call number of this record.
 		/// </summary>
-		public string CallNumber { get; set; }
+		public string? CallNumber { get; set; }
 
 		/// <summary>
 		/// GUESS: Number of reserves of courses.
@@ -126,87 +126,87 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// Key word in context.
 		/// </summary>
-		public string KWIC { get; set; }
+		public string? KWIC { get; set; }
 
 		/// <summary>
 		/// Retention statement of this record.
 		/// </summary>
-		public string RetentionStatement { get; set; }
+		public string? RetentionStatement { get; set; }
 
 		/// <summary>
 		/// Holdings statement of this record.
 		/// </summary>
-		public string HoldingsStatement { get; set; }
+		public string? HoldingsStatement { get; set; }
 
 		/// <summary>
 		/// Holdings note of this record.
 		/// </summary>
-		public string HoldingsNote { get; set; }
+		public string? HoldingsNote { get; set; }
 
 		/// <summary>
 		/// Summary of this record.
 		/// </summary>
-		public string Summary { get; set; }
+		public string? Summary { get; set; }
 
 		/// <summary>
 		/// GUESS: OCLC number of this record.
 		/// </summary>
-		public string OCLC { get; set; }
+		public string? OCLC { get; set; }
 
 		/// <summary>
 		/// UPC number of this record.
 		/// </summary>
-		public string UPC { get; set; }
+		public string? UPC { get; set; }
 
 		/// <summary>
 		/// Target audience of this record.
 		/// </summary>
-		public string TargetAudience { get; set; }
+		public string? TargetAudience { get; set; }
 
 		/// <summary>
 		/// Medium of this record.
 		/// </summary>
-		public string Medium { get; set; }
+		public string? Medium { get; set; }
 
 		/// <summary>
 		/// Thumbnail link for this record.
 		/// </summary>
-		public string ThumbnailLink { get; set; }
+		public string? ThumbnailLink { get; set; }
 
 		/// <summary>
 		/// Vernacular title of this record.
 		/// </summary>
-		public string VernacularTitle { get; set; }
+		public string? VernacularTitle { get; set; }
 
 		/// <summary>
 		/// Vernacular author of this record.
 		/// </summary>
-		public string VernacularAuthor { get; set; }
+		public string? VernacularAuthor { get; set; }
 
 		/// <summary>
 		/// Vernacular publisher of this record.
 		/// </summary>
-		public string VernacularPublisher { get; set; }
+		public string? VernacularPublisher { get; set; }
 
 		/// <summary>
 		/// Local control number of this record.
 		/// </summary>
-		public string LocalControlNumber { get; set; }
+		public string? LocalControlNumber { get; set; }
 
 		/// <summary>
 		/// Series of this record.
 		/// </summary>
-		public string Series { get; set; }
+		public string? Series { get; set; }
 
 		/// <summary>
 		/// Series suggested query for this record.
 		/// </summary>
-		public string SeriesSuggestedQuery { get; set; }
+		public string? SeriesSuggestedQuery { get; set; }
 
 		/// <summary>
 		/// Vernacular series of this record.
 		/// </summary>
-		public string VernacularSeries { get; set; }
+		public string? VernacularSeries { get; set; }
 
         public override string ToString()
         {

--- a/src/polaris-api-csharp/Models/CollectionsGetResult.cs
+++ b/src/polaris-api-csharp/Models/CollectionsGetResult.cs
@@ -8,14 +8,14 @@ namespace Clc.Polaris.Api.Models
 {
     public class CollectionsGetResult : PapiResponseCommon
     {
-        public List<CollectionsRow> CollectionsRows { get; set; }
+        public List<CollectionsRow> CollectionsRows { get; set; } = new List<CollectionsRow>();
     }
 
     public class CollectionsRow
     {
         public int ID { get; set; }
-        public string Name { get; set; }
-        public string Abbreviation { get; set; }
+        public string? Name { get; set; }
+        public string? Abbreviation { get; set; }
 
         public override string ToString() => $"{ID} - {Abbreviation} - {Name}";
     }

--- a/src/polaris-api-csharp/Models/CreatePatronBlocksRequest.cs
+++ b/src/polaris-api-csharp/Models/CreatePatronBlocksRequest.cs
@@ -9,7 +9,7 @@ namespace Clc.Polaris.Api.Models
     public class CreatePatronBlocksRequest
     {
         public int BlockTypeId { get; set; }
-        public string BlockValue { get; set; }
+        public string? BlockValue { get; set; }
 
         public CreatePatronBlocksRequest()
         {

--- a/src/polaris-api-csharp/Models/DatesClosedGetResult.cs
+++ b/src/polaris-api-csharp/Models/DatesClosedGetResult.cs
@@ -8,7 +8,7 @@ namespace Clc.Polaris.Api.Models
 {
     public class DatesClosedGetResult
     {
-        public List<DatesClosedRow> DatesClosedRows { get; set; }
+        public List<DatesClosedRow> DatesClosedRows { get; set; } = new List<DatesClosedRow>();
 
         public override string ToString()
         {

--- a/src/polaris-api-csharp/Models/GetBarcodeAndPatronIDResult.cs
+++ b/src/polaris-api-csharp/Models/GetBarcodeAndPatronIDResult.cs
@@ -11,13 +11,13 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// A collection of rows containing a PatronID and barcode.
 		/// </summary>
-		public List<BarcodeAndPatronIDRow> BarcodeAndPatronIDRows { get; set; }
+		public List<BarcodeAndPatronIDRow> BarcodeAndPatronIDRows { get; set; } = new List<BarcodeAndPatronIDRow>();
 
-        public string Barcode => BarcodeAndPatronIDRows.FirstOrDefault()?.Barcode;
+        public string Barcode => BarcodeAndPatronIDRows.FirstOrDefault()?.Barcode ?? string.Empty;
 
         public override string ToString()
         {
-            return Barcode;
+            return Barcode ?? string.Empty;
         }
     }
 
@@ -34,11 +34,11 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// The patron's barcode
 		/// </summary>
-		public string Barcode { get; set; }
+		public string? Barcode { get; set; }
 
 		public override string ToString()
 		{
-			return Barcode;
+			return Barcode ?? string.Empty;
 		}
 	}
 }

--- a/src/polaris-api-csharp/Models/HoldRequestActivationResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestActivationResult.cs
@@ -11,7 +11,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// Information about activated holds.
 		/// </summary>
-		public List<HoldActivationRow> HoldActivationRows { get; set; }
+		public List<HoldActivationRow> HoldActivationRows { get; set; } = new List<HoldActivationRow>();
 	}
 
 	/// <summary>
@@ -43,6 +43,6 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// The error message if not sucessful.
 		/// </summary>
-		public string ErrorMessage { get; set; }
+		public string? ErrorMessage { get; set; }
 	}
 }

--- a/src/polaris-api-csharp/Models/HoldRequestCancelResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestCancelResult.cs
@@ -10,7 +10,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// Information about cancelled holds.
 		/// </summary>
-		public List<HoldRequestCancelRow> HoldRequestCancelRows { get; set; }
+		public List<HoldRequestCancelRow> HoldRequestCancelRows { get; set; } = new List<HoldRequestCancelRow>();
 	}
 
 	/// <summary>
@@ -31,6 +31,6 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// The error message returned by the Polaris API.
 		/// </summary>
-		public string ErrorMessage { get; set; }
+		public string? ErrorMessage { get; set; }
 	}
 }

--- a/src/polaris-api-csharp/Models/HoldRequestCreateParams.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestCreateParams.cs
@@ -20,17 +20,17 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// The barcode of the item for a title level hold.
 		/// </summary>
-		public string ItemBarcode { get; set; }
+		public string? ItemBarcode { get; set; }
 
 		/// <summary>
 		/// Volume of the hold request.
 		/// </summary>
-		public string VolumeNumber { get; set; }
+		public string? VolumeNumber { get; set; }
 
 		/// <summary>
 		/// Serial designation of the hold request.
 		/// </summary>
-		public string Designation { get; set; }
+		public string? Designation { get; set; }
 
 		/// <summary>
 		/// OrganizationID of the hold pickup location.
@@ -45,7 +45,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// Notes created by patron.
 		/// </summary>
-		public string PatronNotes { get; set; }
+		public string? PatronNotes { get; set; }
 
 		/// <summary>
 		/// The date this hold request will become active.

--- a/src/polaris-api-csharp/Models/HoldRequestCreateResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestCreateResult.cs
@@ -15,12 +15,12 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// TxnGroupQualifier of the hold request.
 		/// </summary>
-		public string TxnGroupQualifier { get; set; }
+		public string? TxnGroupQualifier { get; set; }
 
 		/// <summary>
 		/// TxnQualifier of the hold request.
 		/// </summary>
-		public string TxnQualifier { get; set; }
+		public string? TxnQualifier { get; set; }
 
 		/// <summary>
 		/// Status type of the hold request.
@@ -35,7 +35,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// Display text.
 		/// </summary>
-		public string Message { get; set; }
+		public string? Message { get; set; }
 
 		/// <summary>
 		/// Position of this hold in the queue.

--- a/src/polaris-api-csharp/Models/HoldRequestGetListResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestGetListResult.cs
@@ -11,61 +11,61 @@ namespace Clc.Polaris.Api.Models
         public int RecordCount { get; set; }
         public DateTime PickListCreateTime { get; set; }
         public DateTime PickListExpirationTime { get; set; }
-        public Requestpicklistrow[] RequestPicklistRows { get; set; }
+        public Requestpicklistrow[] RequestPicklistRows { get; set; } = Array.Empty<Requestpicklistrow>();
     }
 
     public class Requestpicklistrow
     {
         public int SysHoldRequestID { get; set; }
         public int SysHoldStatusID { get; set; }
-        public string HoldStatus { get; set; }
+        public string? HoldStatus { get; set; }
         public int PickupBranchID { get; set; }
-        public string PickupBranch { get; set; }
+        public string? PickupBranch { get; set; }
         public DateTime ActivationDate { get; set; }
         public DateTime ExpirationDate { get; set; }
         public DateTime StatusDate { get; set; }
         public int BibliographicRecordID { get; set; }
         public int ConstituentBibRecordID { get; set; }
-        public string BrowseAuthor { get; set; }
-        public string BrowseTitle { get; set; }
+        public string? BrowseAuthor { get; set; }
+        public string? BrowseTitle { get; set; }
         public int PrimaryMARCTOMID { get; set; }
-        public string MarcTypeOfMaterial { get; set; }
+        public string? MarcTypeOfMaterial { get; set; }
         public bool ItemLevelHold { get; set; }
         public bool BorrowByMail { get; set; }
         public int PatronID { get; set; }
-        public string PatronBarcode { get; set; }
+        public string? PatronBarcode { get; set; }
         public int PatronBranchID { get; set; }
-        public string PatronBranch { get; set; }
-        public string PatronFullName { get; set; }
+        public string? PatronBranch { get; set; }
+        public string? PatronFullName { get; set; }
         public int PatronCodeID { get; set; }
-        public string PatronCode { get; set; }
-        public string EmailAddress { get; set; }
-        public string AltEmailAddress { get; set; }
-        public string PhoneVoice1 { get; set; }
-        public string SMSAddress { get; set; }
+        public string? PatronCode { get; set; }
+        public string? EmailAddress { get; set; }
+        public string? AltEmailAddress { get; set; }
+        public string? PhoneVoice1 { get; set; }
+        public string? SMSAddress { get; set; }
         public int ItemRecordID { get; set; }
-        public string ItemBarcode { get; set; }
+        public string? ItemBarcode { get; set; }
         public int ItemBranchID { get; set; }
-        public string ItemBranch { get; set; }
-        public string CallNumber { get; set; }
-        public string CopyNumber { get; set; }
-        public string VolumeNumber { get; set; }
-        public string Pages { get; set; }
+        public string? ItemBranch { get; set; }
+        public string? CallNumber { get; set; }
+        public string? CopyNumber { get; set; }
+        public string? VolumeNumber { get; set; }
+        public string? Pages { get; set; }
         public int AssignedCollectionID { get; set; }
-        public string CollectionName { get; set; }
+        public string? CollectionName { get; set; }
         public int MaterialTypeID { get; set; }
-        public string MaterialType { get; set; }
+        public string? MaterialType { get; set; }
         public int ShelfLocationID { get; set; }
-        public object ShelfLocation { get; set; }
+        public object? ShelfLocation { get; set; }
         public int PublicationYear { get; set; }
-        public string Publisher { get; set; }
-        public string Designation { get; set; }
-        public string Edition { get; set; }
-        public string StaffDisplayNotes { get; set; }
-        public string NonPublicNotes { get; set; }
-        public string PACDisplayNotes { get; set; }
-        public string SortTitle { get; set; }
-        public string SortAuthor { get; set; }
+        public string? Publisher { get; set; }
+        public string? Designation { get; set; }
+        public string? Edition { get; set; }
+        public string? StaffDisplayNotes { get; set; }
+        public string? NonPublicNotes { get; set; }
+        public string? PACDisplayNotes { get; set; }
+        public string? SortTitle { get; set; }
+        public string? SortAuthor { get; set; }
 
         public override string ToString() => $"{ItemRecordID} - {ItemBarcode} - {BrowseTitle} - {PatronFullName}";
     }

--- a/src/polaris-api-csharp/Models/HoldRequestReplyData.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestReplyData.cs
@@ -8,8 +8,8 @@ namespace Clc.Polaris.Api.Models
 {
     public class HoldRequestReplyData
     {
-        public string TxnGroupQualifier { get; set; }
-        public string TxnQualifier { get; set; }
+        public string? TxnGroupQualifier { get; set; }
+        public string? TxnQualifier { get; set; }
         public int RequestingOrgID { get; set; }
         public int Answer { get; set; }
         public int State { get; set; }

--- a/src/polaris-api-csharp/Models/HoldRequestReplyResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestReplyResult.cs
@@ -8,12 +8,12 @@
         /// <summary>
         /// Txn group qualifier.
         /// </summary>
-        public string TxnGroupQualifier { get; set; }
+        public string? TxnGroupQualifier { get; set; }
 
         /// <summary>
         /// Txn qualifier.
         /// </summary>
-        public string TxnQualifier { get; set; }
+        public string? TxnQualifier { get; set; }
 
         /// <summary>
         /// The org ID of the branch processing the request.

--- a/src/polaris-api-csharp/Models/ItemRenewResultWrapper.cs
+++ b/src/polaris-api-csharp/Models/ItemRenewResultWrapper.cs
@@ -5,7 +5,7 @@ namespace Clc.Polaris.Api.Models
 {
     public class ItemRenewResultWrapper : PapiResponseCommon
     {
-        public ItemRenewResultBody ItemRenewResult { get; set; }
+        public ItemRenewResultBody? ItemRenewResult { get; set; }
     }
     /// <summary>
     /// Lists of items that could and couldn't be renewed.
@@ -15,12 +15,12 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// A list of items that could not be renewed.
 		/// </summary>
-		public List<ItemRenewBlockRow> BlockRows { get; set; }// = new List<ItemRenewBlockRow>();
+		public List<ItemRenewBlockRow> BlockRows { get; set; } = new List<ItemRenewBlockRow>();// = new List<ItemRenewBlockRow>();
 
         /// <summary>
         /// A list of successfully renewed items.
         /// </summary>
-        public List<ItemRenewDueDateRow> DueDateRows { get; set; }// = new List<ItemRenewDueDateRow>();
+        public List<ItemRenewDueDateRow> DueDateRows { get; set; } = new List<ItemRenewDueDateRow>();// = new List<ItemRenewDueDateRow>();
 	}
 
     /// <summary>
@@ -48,7 +48,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Description of the error.
         /// </summary>
-        public string ErrorDesc { get; set; }
+        public string? ErrorDesc { get; set; }
 
         /// <summary>
         /// ID of the item record.

--- a/src/polaris-api-csharp/Models/ItemStatusesGetResult.cs
+++ b/src/polaris-api-csharp/Models/ItemStatusesGetResult.cs
@@ -6,14 +6,14 @@ namespace Clc.Polaris.Api.Models
 {
     public class ItemStatusesGetResult : PapiResponseCommon
     {
-        public ItemStatusRow[] ItemStatusesRows { get; set; }
+        public ItemStatusRow[] ItemStatusesRows { get; set; } = Array.Empty<ItemStatusRow>();
     }
 
     public class ItemStatusRow
     {
         public int ItemStatusId { get; set; }
-        public string Description { get; set; }
-        public string Name { get; set; }
-        public string BannerText { get; set; }
+        public string? Description { get; set; }
+        public string? Name { get; set; }
+        public string? BannerText { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/ItemUpdateBarcodeData.cs
+++ b/src/polaris-api-csharp/Models/ItemUpdateBarcodeData.cs
@@ -7,6 +7,6 @@ namespace Clc.Polaris.Api.Models
     public class ItemUpdateBarcodeData
     {
         public int TransactionBranchId { get; set; }
-        public string ItemBarcode { get; set; }
+        public string? ItemBarcode { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/ItemsOutActionResult.cs
+++ b/src/polaris-api-csharp/Models/ItemsOutActionResult.cs
@@ -10,6 +10,6 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// The result of the item renewal.
 		/// </summary>
-		public ItemRenewResultWrapper ItemRenewResult { get; set; }
+		public ItemRenewResultWrapper? ItemRenewResult { get; set; }
 	}
 }

--- a/src/polaris-api-csharp/Models/LimitFiltersGetResult.cs
+++ b/src/polaris-api-csharp/Models/LimitFiltersGetResult.cs
@@ -6,13 +6,13 @@ namespace Clc.Polaris.Api.Models
 {
     public class LimitFiltersGetResult : PapiResponseCommon
     {
-        public LimitFiltersRow[] LimitFiltersRows { get; set; }
+        public LimitFiltersRow[] LimitFiltersRows { get; set; } = Array.Empty<LimitFiltersRow>();
     }
 
     public class LimitFiltersRow
     {
-        public string Description { get; set; }
-        public string CCLFilter { get; set; }
+        public string? Description { get; set; }
+        public string? CCLFilter { get; set; }
         public int DisplayOrder { get; set; }
 
         public override string ToString()

--- a/src/polaris-api-csharp/Models/MARCTypeOfMaterialsGetResult.cs
+++ b/src/polaris-api-csharp/Models/MARCTypeOfMaterialsGetResult.cs
@@ -6,14 +6,14 @@ namespace Clc.Polaris.Api.Models
 {
     public class MARCTypeOfMaterialsGetResult : PapiResponseCommon
     {
-        public MARCTypeOfMaterialsRow[] MARCTypeOfMaterialsRows { get; set; }
+        public MARCTypeOfMaterialsRow[] MARCTypeOfMaterialsRows { get; set; } = Array.Empty<MARCTypeOfMaterialsRow>();
     }
 
     public class MARCTypeOfMaterialsRow
     {
         public int MARCTypeOfMaterialId { get; set; }
-        public string SearchCode { get; set; }
-        public string Description { get; set; }
+        public string? SearchCode { get; set; }
+        public string? Description { get; set; }
 
         public override string ToString() => $"{MARCTypeOfMaterialId} - {SearchCode} - {Description}";
     }

--- a/src/polaris-api-csharp/Models/MaterialTypesGetResult.cs
+++ b/src/polaris-api-csharp/Models/MaterialTypesGetResult.cs
@@ -6,12 +6,12 @@ namespace Clc.Polaris.Api.Models
 {
     public class MaterialTypesGetResult : PapiResponseCommon
     {
-        public MaterialTypesRow[] MaterialTypesRows { get; set; }
+        public MaterialTypesRow[] MaterialTypesRows { get; set; } = Array.Empty<MaterialTypesRow>();
     }
 
     public class MaterialTypesRow
     {
         public int MaterialTypeId { get; set; }
-        public string Description { get; set; }
+        public string? Description { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/NotificationUpdateParams.cs
+++ b/src/polaris-api-csharp/Models/NotificationUpdateParams.cs
@@ -47,12 +47,12 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// How the message was delivered. In the currently implementation this is the patron's phone number.
 		/// </summary>
-		public string DeliveryString { get; set; }
+		public string? DeliveryString { get; set; }
 
         /// <summary>
         /// Any additional data/notes.
         /// </summary>
-        public string Details { get; set; }
+        public string? Details { get; set; }
 
         /// <summary>
         /// The ID of the patron.
@@ -64,6 +64,6 @@ namespace Clc.Polaris.Api.Models
         /// </summary>
         public int? ItemRecordId { get; set; }
 
-        public string ItemBarcode { get; set; }
+        public string? ItemBarcode { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/OrganizationsGetResult.cs
+++ b/src/polaris-api-csharp/Models/OrganizationsGetResult.cs
@@ -13,7 +13,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// List of organization data
         /// </summary>
-		public List<OrganizationsGetRow> OrganizationsGetRows { get; set; }
+		public List<OrganizationsGetRow> OrganizationsGetRows { get; set; } = new List<OrganizationsGetRow>();
 	}
 
     /// <summary>
@@ -39,17 +39,17 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Name
         /// </summary>
-		public string Name { get; set; }
+		public string? Name { get; set; }
 
         /// <summary>
         /// Abbreviation
         /// </summary>
-		public string Abbreviation { get; set; }
+		public string? Abbreviation { get; set; }
 
         /// <summary>
         /// Display name
         /// </summary>
-		public string DisplayName { get; set; }
+		public string? DisplayName { get; set; }
 
         public override string ToString()
         {

--- a/src/polaris-api-csharp/Models/PapiResponseCommon.cs
+++ b/src/polaris-api-csharp/Models/PapiResponseCommon.cs
@@ -20,7 +20,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Error message, if any
         /// </summary>
-        public string ErrorMessage { get; set; }
+        public string? ErrorMessage { get; set; }
 
         public override string ToString()
         {

--- a/src/polaris-api-csharp/Models/PapiRestRequest.cs
+++ b/src/polaris-api-csharp/Models/PapiRestRequest.cs
@@ -1,4 +1,4 @@
-using Clc.Rest.Models;
+﻿using Clc.Rest.Models;
 using System;
 using System.Net.Http;
 
@@ -10,24 +10,24 @@ namespace Clc.Polaris.Api.Models
         public bool AuthRequired { get; set; } = true;
         public bool JsonSerializerIgnoreNulls { get; set; } = true;
         public bool BlockStaffOverride = false;
-        public string HashString { get; set; }
+        public string? HashString { get; set; }
 
         public bool IsPublicMethod => Path.StartsWith("/public", StringComparison.OrdinalIgnoreCase);
         public bool IsProtectedMethod => Path.StartsWith("/protected", StringComparison.OrdinalIgnoreCase);
 
-        public static PapiRestRequest Get(string path, string password = "", object body = null) =>
+        public static PapiRestRequest Get(string path, string password = "", object? body = null) =>
             new PapiRestRequest(HttpMethod.Get, path, password, body);
 
-        public static PapiRestRequest Delete(string path, string password = "", object body = null) =>
+        public static PapiRestRequest Delete(string path, string password = "", object? body = null) =>
             new PapiRestRequest(HttpMethod.Delete, path, password, body);
 
-        public static PapiRestRequest Post(string path, object body = null, string password = "") =>
+        public static PapiRestRequest Post(string path, object? body = null, string password = "") =>
             new PapiRestRequest(HttpMethod.Post, path, password, body);
 
-        public static PapiRestRequest Put(string path, object body = null, string password = "") =>
+        public static PapiRestRequest Put(string path, object? body = null, string password = "") =>
             new PapiRestRequest(HttpMethod.Put, path, password, body);
 
-        public static PapiRestRequest Create(HttpMethod method, string path, object body = null, string password = "") =>
+        public static PapiRestRequest Create(HttpMethod method, string path, object? body = null, string password = "") =>
             new PapiRestRequest(method, path, password, body);
 
         public PapiRestRequest()
@@ -35,7 +35,7 @@ namespace Clc.Polaris.Api.Models
 
         }
 
-        public PapiRestRequest(HttpMethod method, string url, string password = "", object body = null) : base()
+        public PapiRestRequest(HttpMethod method, string url, string password = "", object? body = null) : base()
         {
             Method = method;
             Path = url;
@@ -43,7 +43,7 @@ namespace Clc.Polaris.Api.Models
             Body = body;
         }
 
-        public PapiRestRequest(string url, string password = "", object body = null) : this(HttpMethod.Get, url, password, body)
+        public PapiRestRequest(string url, string password = "", object? body = null) : this(HttpMethod.Get, url, password, body)
         {
         }
 

--- a/src/polaris-api-csharp/Models/PatronAccountCreateCreditData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountCreateCreditData.cs
@@ -8,6 +8,6 @@ namespace Clc.Polaris.Api.Models
     {
         public double TxnAmount { get; set; }
         public PaymentMethod PaymentMethodId { get; set; }
-        public string FreeTextNote { get; set; }
+        public string? FreeTextNote { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAccountCreateTitleListData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountCreateTitleListData.cs
@@ -6,6 +6,6 @@ namespace Clc.Polaris.Api.Models
 {
     public class PatronAccountCreateTitleListData
     {
-        public string RecordStoreName { get; set; }
+        public string? RecordStoreName { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAccountDepositCreditData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountDepositCreditData.cs
@@ -7,6 +7,6 @@ namespace Clc.Polaris.Api.Models
     public class PatronAccountDepositCreditData
     {
         public double TxnAmount { get; set; }
-        public string FreeTextNote { get; set; }
+        public string? FreeTextNote { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAccountGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountGetResult.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Rows of patron fine and fee information
         /// </summary>
-        public List<PatronAccountGetRow> PatronAccountGetRows { get; set; }
+        public List<PatronAccountGetRow> PatronAccountGetRows { get; set; } = new List<PatronAccountGetRow>();
     }
 
     /// <summary>
@@ -42,7 +42,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Associated branch
         /// </summary>
-        public string BranchName { get; set; }
+        public string? BranchName { get; set; }
 
         /// <summary>
         /// Transaction type id
@@ -52,12 +52,12 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Transaction type description
         /// </summary>
-        public string TransactionTypeDescription { get; set; }
+        public string? TransactionTypeDescription { get; set; }
 
         /// <summary>
         /// Fee description
         /// </summary>
-        public string FeeDescription { get; set; }
+        public string? FeeDescription { get; set; }
 
         /// <summary>
         /// Transaction amount
@@ -72,7 +72,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Free text note
         /// </summary>
-        public string FreeTextNote { get; set; }
+        public string? FreeTextNote { get; set; }
 
         /// <summary>
         /// Item ID
@@ -82,7 +82,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Item barcode
         /// </summary>
-        public string Barcode { get; set; }
+        public string? Barcode { get; set; }
 
         /// <summary>
         /// Item bibiographic record ID
@@ -97,22 +97,22 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Material type description
         /// </summary>
-        public string FormatDescription { get; set; }
+        public string? FormatDescription { get; set; }
 
         /// <summary>
         /// Title
         /// </summary>
-        public string Title { get; set; }
+        public string? Title { get; set; }
 
         /// <summary>
         /// Author
         /// </summary>
-        public string Author { get; set; }
+        public string? Author { get; set; }
 
         /// <summary>
         /// Call number
         /// </summary>
-        public string CallNumber { get; set; }
+        public string? CallNumber { get; set; }
 
         /// <summary>
         /// Checkout date

--- a/src/polaris-api-csharp/Models/PatronAccountGetTitleListsResult.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountGetTitleListsResult.cs
@@ -8,14 +8,14 @@ namespace Clc.Polaris.Api.Models
 {
     public class PatronAccountGetTitleListsResult : PapiResponseCommon
     {
-        public List<PatronAccountTitleListsRow> PatronAccountTitleListsRows { get; set; }
+        public List<PatronAccountTitleListsRow> PatronAccountTitleListsRows { get; set; } = new List<PatronAccountTitleListsRow>();
 
         public override string ToString() => string.Join("\r\n", PatronAccountTitleListsRows);
     }
 
     public class PatronAccountTitleListsRow
     {
-        public string RecordStoreName { get; set; }
+        public string? RecordStoreName { get; set; }
         public bool Sorted { get; set; }
         public int Count { get; set; }
         public int RecordStoreId { get; set; }

--- a/src/polaris-api-csharp/Models/PatronAccountPayData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountPayData.cs
@@ -10,6 +10,6 @@ namespace Clc.Polaris.Api.Models
     {
         public double TxnAmount { get; set; }
         public PaymentMethod PaymentMethodId { get; set; }
-        public string FreeTextNote { get; set; }
+        public string? FreeTextNote { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAccountRefundCreditData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountRefundCreditData.cs
@@ -7,6 +7,6 @@ namespace Clc.Polaris.Api.Models
     public class PatronAccountRefundCreditData
     {
         public double TxnAmount { get; set; }
-        public string FreeTextNote { get; set; }
+        public string? FreeTextNote { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAuthenicationResult.cs
+++ b/src/polaris-api-csharp/Models/PatronAuthenicationResult.cs
@@ -8,8 +8,8 @@ namespace Clc.Polaris.Api.Models
 {
     public class PatronAuthenticationResult : PapiResponseCommon
     {
-        public string AccessToken { get; set; }
-        public string AccessSecret { get; set; }
+        public string? AccessToken { get; set; }
+        public string? AccessSecret { get; set; }
         public int PatronID { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAuthenticationToken.cs
+++ b/src/polaris-api-csharp/Models/PatronAuthenticationToken.cs
@@ -8,8 +8,8 @@ namespace Clc.Polaris.Api.Models
 {
     public class PatronAuthenticationToken
     {
-        public string Barcode { get; set; }
-        public string Token { get; set; }
+        public string? Barcode { get; set; }
+        public string? Token { get; set; }
         public DateTime Expiration { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/PatronBasicDataGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronBasicDataGetResult.cs
@@ -12,11 +12,11 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Patron information for the supplied patron.
         /// </summary>
-        public PatronData PatronBasicData { get; set; }
+        public PatronData? PatronBasicData { get; set; }
 
         public override string ToString()
         {
-            if (PatronBasicData?.PatronID == 0) return base.ToString();
+            if (PatronBasicData == null || PatronBasicData.PatronID == 0) return base.ToString();
             return $"{PatronBasicData.PatronID} - {PatronBasicData.Barcode} - {PatronBasicData.NameFirst} {PatronBasicData.NameLast}";
         }
     }
@@ -27,12 +27,12 @@ namespace Clc.Polaris.Api.Models
     public class PatronData
     {
         public int PatronID { get; set; }
-        public string Barcode { get; set; }
-        public string NameFirst { get; set; }
-        public string NameLast { get; set; }
-        public string NameMiddle { get; set; }
-        public string PhoneNumber { get; set; }
-        public string EmailAddress { get; set; }
+        public string? Barcode { get; set; }
+        public string? NameFirst { get; set; }
+        public string? NameLast { get; set; }
+        public string? NameMiddle { get; set; }
+        public string? PhoneNumber { get; set; }
+        public string? EmailAddress { get; set; }
         public int ItemsOutCount { get; set; }
         public int ItemsOverdueCount { get; set; }
         public int ItemsOutLostCount { get; set; }
@@ -44,16 +44,16 @@ namespace Clc.Polaris.Api.Models
         public double ChargeBalance { get; set; }
         public double CreditBalance { get; set; }
         public double DepositBalance { get; set; }
-        public string NameTitle { get; set; }
-        public string NameSuffix { get; set; }
-        public string PhoneNumber2 { get; set; }
-        public string PhoneNumber3 { get; set; }
+        public string? NameTitle { get; set; }
+        public string? NameSuffix { get; set; }
+        public string? PhoneNumber2 { get; set; }
+        public string? PhoneNumber3 { get; set; }
         public int Phone1CarrierID { get; set; }
         public int Phone2CarrierID { get; set; }
         public int Phone3CarrierID { get; set; }
-        public string CellPhone { get; set; }
+        public string? CellPhone { get; set; }
         public int CellPhoneCarrierID { get; set; }
-        public string AltEmailAddress { get; set; }
+        public string? AltEmailAddress { get; set; }
         public DateTime? BirthDate { get; set; }
         public DateTime? RegistrationDate { get; set; }
         public DateTime? LastActivityDate { get; set; }
@@ -69,26 +69,26 @@ namespace Clc.Polaris.Api.Models
         public int EReceiptOptionID { get; set; }
         public int TxtPhoneNumber { get; set; }
         public int EmailFormatID { get; set; }
-        public string LegalNameFirst { get; set; }
-        public string LegalNameLast { get; set; }
-        public string LegalNameMiddle { get; set; }
+        public string? LegalNameFirst { get; set; }
+        public string? LegalNameLast { get; set; }
+        public string? LegalNameMiddle { get; set; }
         public bool UseLegalNameOnNotices { get; set; }
-        public string LegalFullName { get; set; }
-        public List<PatronAddress> PatronAddresses { get; set; }
+        public string? LegalFullName { get; set; }
+        public List<PatronAddress> PatronAddresses { get; set; } = new List<PatronAddress>();
         public DateTime ExpirationDate { get; set; }
         public int RequestPickupBranchID { get; set; }
-        public string User1 { get; set; }
-        public string User2 { get; set; }
-        public string User3 { get; set; }
-        public string User4 { get; set; }
-        public string User5 { get; set; }
+        public string? User1 { get; set; }
+        public string? User2 { get; set; }
+        public string? User3 { get; set; }
+        public string? User4 { get; set; }
+        public string? User5 { get; set; }
         public int LanguageID { get; set; }
-        public string FormerID { get; set; }
+        public string? FormerID { get; set; }
         public int StatisticalClassID { get; set; }
         public PatronNotes? PatronNotes { get; set; }
-        public PatronSystemBlock[] PatronSystemBlocks { get; set; }
+        public PatronSystemBlock[] PatronSystemBlocks { get; set; } = Array.Empty<PatronSystemBlock>();
 
-        string fixpn(string pn) => new string(pn.Where(c => char.IsDigit(c)).ToArray());
+        string fixpn(string? pn) => new string((pn ?? string.Empty).Where(c => char.IsDigit(c)).ToArray());
 
         public string TxtDeliveryPhoneNumber => TxtPhoneNumber == 1 ? fixpn(PhoneNumber) : TxtPhoneNumber == 2 ? fixpn(PhoneNumber2) : TxtPhoneNumber == 3 ? fixpn(PhoneNumber3) : "";
 
@@ -104,7 +104,7 @@ namespace Clc.Polaris.Api.Models
                         var street = !string.IsNullOrWhiteSpace(address.StreetTwo) ? $"{address.StreetOne} {address.StreetTwo}" : address.StreetOne;
                         return $"{street} {address.City}, {address.State} {address.PostalCode}";
                     case 2:
-                        return EmailAddress;
+                        return EmailAddress ?? string.Empty;
                     case 3:
                         return fixpn(PhoneNumber);
                     case 4:
@@ -123,7 +123,7 @@ namespace Clc.Polaris.Api.Models
     public class PatronSystemBlock
     {
         public int BlockID { get; set; }
-        public string BlockDescription { get; set; }
+        public string? BlockDescription { get; set; }
 
         public override string ToString() => $"{BlockID} | {BlockDescription}";
     }

--- a/src/polaris-api-csharp/Models/PatronCirculateBlocksResult.cs
+++ b/src/polaris-api-csharp/Models/PatronCirculateBlocksResult.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Patron's barcode
         /// </summary>
-        public string Barcode { get; set; }
+        public string? Barcode { get; set; }
 
         /// <summary>
         /// Valid patron
@@ -40,12 +40,12 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// The patron's barcode
         /// </summary>
-        public string PatronBarcode { get; set; }
+        public string? PatronBarcode { get; set; }
 
         /// <summary>
         /// Assigned branch name
         /// </summary>
-        public string AssignedBranchName { get; set; }
+        public string? AssignedBranchName { get; set; }
 
         /// <summary>
         /// Account expiration date
@@ -60,9 +60,9 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// List of blocks on the patron's account
         /// </summary>
-        ////public Blocks Blocks { get; set; }
+        ////public Blocks? Blocks { get; set; }
 
-        public List<Block> Blocks { get; set; }
+        public List<Block> Blocks { get; set; } = new List<Block>();
 
         /// <summary>
         /// Can the patron check out items
@@ -72,22 +72,22 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Email address
         /// </summary>
-        public string EmailAddress { get; set; }
+        public string? EmailAddress { get; set; }
 
         /// <summary>
         /// First name
         /// </summary>
-        public string NameFirst { get; set; }
+        public string? NameFirst { get; set; }
 
         /// <summary>
         /// Last name
         /// </summary>
-        public string NameLast { get; set; }
+        public string? NameLast { get; set; }
 
         /// <summary>
         /// Middle name
         /// </summary>
-        public string NameMiddle { get; set; }
+        public string? NameMiddle { get; set; }
     }
 
     /// <summary>
@@ -103,11 +103,11 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Patron name
         /// </summary>
-        public string PatronName { get; set; }
+        public string? PatronName { get; set; }
 
         /// <summary>
         /// Block description
         /// </summary>
-        public string BlockDescription { get; set; }
+        public string? BlockDescription { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/PatronCodesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronCodesGetResult.cs
@@ -8,18 +8,18 @@ namespace Clc.Polaris.Api.Models
 {
     public class PatronCodesGetResult : PapiResponseCommon
     {
-        public List<PatronCodeRow> PatronCodesRows { get; set; }
+        public List<PatronCodeRow> PatronCodesRows { get; set; } = new List<PatronCodeRow>();
 
         public override string ToString()
         {
-            return string.Join("\r\n", PatronCodesRows?.OrderBy(pc => pc.Description));
+            return string.Join("\r\n", PatronCodesRows.OrderBy(pc => pc.Description));
         }
     }
 
     public class PatronCodeRow
     {
         public int PatronCodeID { get; set; }
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         public override string ToString()
         {

--- a/src/polaris-api-csharp/Models/PatronHoldRequestsGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronHoldRequestsGetResult.cs
@@ -11,7 +11,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// A list of rows containing information about a hold.
 		/// </summary>
-		public List<PatronHoldRequestsGetRow> PatronHoldRequestsGetRows { get; set; }
+		public List<PatronHoldRequestsGetRow> PatronHoldRequestsGetRows { get; set; } = new List<PatronHoldRequestsGetRow>();
 	}
 
 	/// <summary>
@@ -37,22 +37,22 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// The status description of the hold.
 		/// </summary>
-		public string StatusDescription { get; set; }
+		public string? StatusDescription { get; set; }
 
 		/// <summary>
 		/// Title of the item on hold.
 		/// </summary>
-		public string Title { get; set; }
+		public string? Title { get; set; }
 
 		/// <summary>
 		/// Author of the item on hold.
 		/// </summary>
-		public string Author { get; set; }
+		public string? Author { get; set; }
 
 		/// <summary>
 		/// Call number of the item on hold.
 		/// </summary>
-		public string CallNumber { get; set; }
+		public string? CallNumber { get; set; }
 
 		/// <summary>
 		/// Format ID of the item on hold.
@@ -62,7 +62,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// Format description of the item on hold.
 		/// </summary>
-		public string FormatDescription { get; set; }
+		public string? FormatDescription { get; set; }
 
 		/// <summary>
 		/// ID of the branch the hold will be picked up at.
@@ -72,7 +72,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// Name of the branch the hold will be picked up at.
 		/// </summary>
-		public string PickupBranchName { get; set; }
+		public string? PickupBranchName { get; set; }
 
 		/// <summary>
 		/// Date the item can be picked up by.
@@ -102,7 +102,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// Name used to identify a group of titles that can satisfy this hold request
 		/// </summary>
-		public string GroupName { get; set; }
+		public string? GroupName { get; set; }
 
 		/// <summary>
 		/// Is the hold an item level hold.

--- a/src/polaris-api-csharp/Models/PatronIllRequestsGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronIllRequestsGetResult.cs
@@ -9,7 +9,7 @@ namespace Clc.Polaris.Api.Models
     
     public class PatronILLRequestsGetResult : PapiResponseCommon
     {
-        public List<PatronILLRequestsGetRow> PatronILLRequestsGetRows { get; set; }
+        public List<PatronILLRequestsGetRow> PatronILLRequestsGetRows { get; set; } = new List<PatronILLRequestsGetRow>();
     }
 
     public class PatronILLRequestsGetRow
@@ -20,20 +20,20 @@ namespace Clc.Polaris.Api.Models
         public int ItemRecordID { get; set; }
         public int BibRecordID { get; set; }
         public int PickupBranchID { get; set; }
-        public string Author { get; set; }
-        public string Title { get; set; }
-        public string Format { get; set; }
+        public string? Author { get; set; }
+        public string? Title { get; set; }
+        public string? Format { get; set; }
         public DateTime CreationDate { get; set; }
         public DateTime ActivationDate { get; set; }
-        public string Status { get; set; }
-        public string Item { get; set; }
+        public string? Status { get; set; }
+        public string? Item { get; set; }
         public DateTime NeedByDate { get; set; }
-        public string PickupBranch { get; set; }
+        public string? PickupBranch { get; set; }
         public int FormatID { get; set; }
         public DateTime LastStatusTransitionDate { get; set; }
-        public string OpacNotes { get; set; }
-        public string CallNumber { get; set; }
-        public string VolumeAndIssue { get; set; }
+        public string? OpacNotes { get; set; }
+        public string? CallNumber { get; set; }
+        public string? VolumeAndIssue { get; set; }
         public DateTime? PickupByDate { get; set; }
     }    
 }

--- a/src/polaris-api-csharp/Models/PatronItemsOutGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronItemsOutGetResult.cs
@@ -11,7 +11,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// A list of rows containing information about the items the patron has out.
 		/// </summary>
-		public List<PatronItemsOutGetRow> PatronItemsOutGetRows { get; set; }
+		public List<PatronItemsOutGetRow> PatronItemsOutGetRows { get; set; } = new List<PatronItemsOutGetRow>();
 	}
 
 	/// <summary>
@@ -27,7 +27,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// The item's barcode.
 		/// </summary>
-		public string Barcode { get; set; }
+		public string? Barcode { get; set; }
 
 		/// <summary>
 		/// The ID of the bibliographic record this item is assigned to.
@@ -42,22 +42,22 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// The description of this item's format.
 		/// </summary>
-		public string FormatDescription { get; set; }
+		public string? FormatDescription { get; set; }
 
 		/// <summary>
 		/// The title of the item.
 		/// </summary>
-		public string Title { get; set; }
+		public string? Title { get; set; }
 
 		/// <summary>
 		/// The author of the item.
 		/// </summary>
-		public string Author { get; set; }
+		public string? Author { get; set; }
 
 		/// <summary>
 		/// The call number of the item.
 		/// </summary>
-		public string CallNumber { get; set; }
+		public string? CallNumber { get; set; }
 
 		/// <summary>
 		/// The date this itemw as checked out.
@@ -87,7 +87,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// The name of the branch this item is assigned to.
 		/// </summary>
-		public string AssignedBranchName { get; set; }
+		public string? AssignedBranchName { get; set; }
 
 		/// <summary>
 		/// The ID of the branch this item was checked out from.
@@ -97,7 +97,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// The name of the branch this item was checked out from.
 		/// </summary>
-		public string LoaningBranchName { get; set; }
+		public string? LoaningBranchName { get; set; }
 
         public override string ToString()
         {

--- a/src/polaris-api-csharp/Models/PatronMessagesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronMessagesGetResult.cs
@@ -7,16 +7,16 @@ namespace Clc.Polaris.Api.Models
 
     public class PatronMessagesGetResult : PapiResponseCommon
     {
-        public Patronmessagesgetrow[] PatronMessagesGetRows { get; set; }
+        public Patronmessagesgetrow[] PatronMessagesGetRows { get; set; } = Array.Empty<Patronmessagesgetrow>();
     }
 
     public class Patronmessagesgetrow
     {
         public int Type { get; set; }
         public int ID { get; set; }
-        public string OrgName { get; set; }
+        public string? OrgName { get; set; }
         public DateTime Date { get; set; }
-        public string Value { get; set; }
+        public string? Value { get; set; }
         public bool IsRead { get; set; }
 
         public override string ToString() => $"{Date} - {OrgName} - {Value} - {IsRead}";

--- a/src/polaris-api-csharp/Models/PatronPreferencesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronPreferencesGetResult.cs
@@ -6,18 +6,18 @@ namespace Clc.Polaris.Api.Models
 {
     public class PatronPreferencesGetResult : PapiResponseCommon
     {
-        public Patronpreferences PatronPreferences { get; set; }
+        public Patronpreferences? PatronPreferences { get; set; }
     }
 
     public class Patronpreferences
     {
         public int PatronID { get; set; }
-        public string Barcode { get; set; }
+        public string? Barcode { get; set; }
         public bool ReadingListEnabled { get; set; }
         public int DeliveryMethodID { get; set; }
-        public string DeliveryMethodDescription { get; set; }
+        public string? DeliveryMethodDescription { get; set; }
         public int DeliveryEmailFormatID { get; set; }
-        public string DeliveryEmailFormatDescription { get; set; }
+        public string? DeliveryEmailFormatDescription { get; set; }
     }
 
 }

--- a/src/polaris-api-csharp/Models/PatronReadingHistoryGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronReadingHistoryGetResult.cs
@@ -7,7 +7,7 @@ namespace Clc.Polaris.Api.Models
 {
     public class PatronReadingHistoryGetResult : PapiResponseCommon
     {
-        public PatronReadingHistoryGetRow[] PatronReadingHistoryGetRows { get; set; }
+        public PatronReadingHistoryGetRow[] PatronReadingHistoryGetRows { get; set; } = Array.Empty<PatronReadingHistoryGetRow>();
 
         public override string ToString() => string.Join("\r\n", (IEnumerable<PatronReadingHistoryGetRow>)PatronReadingHistoryGetRows);
     }
@@ -15,16 +15,16 @@ namespace Clc.Polaris.Api.Models
     public class PatronReadingHistoryGetRow
     {
         public int ItemID { get; set; }
-        public string Barcode { get; set; }
+        public string? Barcode { get; set; }
         public int BibID { get; set; }
         public int FormatID { get; set; }
-        public string FormatDescription { get; set; }
-        public string Title { get; set; }
-        public string Author { get; set; }
-        public string CallNumber { get; set; }
+        public string? FormatDescription { get; set; }
+        public string? Title { get; set; }
+        public string? Author { get; set; }
+        public string? CallNumber { get; set; }
         public DateTime CheckOutDate { get; set; }
         public int LoaningBranchID { get; set; }
-        public string LoaningBranchName { get; set; }
+        public string? LoaningBranchName { get; set; }
         public int PatronReadingHistoryID { get; set; }
 
         public override string ToString() => $"{Barcode} - {Title} - {FormatDescription} - {CheckOutDate.ToShortDateString()}";

--- a/src/polaris-api-csharp/Models/PatronRegistrationCreateResult.cs
+++ b/src/polaris-api-csharp/Models/PatronRegistrationCreateResult.cs
@@ -13,7 +13,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Patron's barcode
         /// </summary>
-		public string Barcode { get; set; }
+		public string? Barcode { get; set; }
 
         /// <summary>
         /// Patron ID

--- a/src/polaris-api-csharp/Models/PatronRegistrationDataV2.cs
+++ b/src/polaris-api-csharp/Models/PatronRegistrationDataV2.cs
@@ -14,19 +14,19 @@ namespace Clc.Polaris.Models
         public bool? ReadingListFlag { get; set; }             // "No" in table – optional
         public int? EmailFormat { get; set; }                 // 1=Plain,2=HTML
         public int? DeliveryOptionID { get; set; }
-        public string EmailAddress { get; set; }
-        public string AltEmailAddress { get; set; }
+        public string? EmailAddress { get; set; }
+        public string? AltEmailAddress { get; set; }
         public bool? EnableSMS { get; set; }
-        public string PhoneVoice1 { get; set; }
-        public string PhoneVoice2 { get; set; }
-        public string PhoneVoice3 { get; set; }
+        public string? PhoneVoice1 { get; set; }
+        public string? PhoneVoice2 { get; set; }
+        public string? PhoneVoice3 { get; set; }
         public int? Phone1CarrierID { get; set; }
         public int? Phone2CarrierID { get; set; }
         public int? Phone3CarrierID { get; set; }
         public int? TxtPhoneNumber { get; set; }
         public int? EReceiptOptionID { get; set; }
-        public string Password { get; set; }
-        public string Password2 { get; set; }
+        public string? Password { get; set; }
+        public string? Password2 { get; set; }
         public int? PatronCode { get; set; }
         public DateTime? ExpirationDate { get; set; }
         public DateTime? AddrCheckDate { get; set; }
@@ -34,24 +34,24 @@ namespace Clc.Polaris.Models
         public bool? ExcludeFromPatronRecExpiration { get; set; }
         public bool? ExcludeFromInactivePatron { get; set; }
         public int? RequestPickupBranchID { get; set; }
-        public string User1 { get; set; }
-        public string User2 { get; set; }
-        public string User3 { get; set; }
-        public string User4 { get; set; }
-        public string User5 { get; set; }
+        public string? User1 { get; set; }
+        public string? User2 { get; set; }
+        public string? User3 { get; set; }
+        public string? User4 { get; set; }
+        public string? User5 { get; set; }
         public int? LanguageID { get; set; }
-        public string FormerID { get; set; }
-        public string NameFirst { get; set; }
-        public string NameLast { get; set; }
-        public string NameMiddle { get; set; }
-        public string LegalNameFirst { get; set; }
-        public string LegalNameLast { get; set; }
-        public string LegalNameMiddle { get; set; }
+        public string? FormerID { get; set; }
+        public string? NameFirst { get; set; }
+        public string? NameLast { get; set; }
+        public string? NameMiddle { get; set; }
+        public string? LegalNameFirst { get; set; }
+        public string? LegalNameLast { get; set; }
+        public string? LegalNameMiddle { get; set; }
         public bool? UseLegalNameOnNotices { get; set; }
         public DateTime? Birthdate { get; set; }
         public int? GenderID { get; set; }
-        public string UserName { get; set; }
-        public string Barcode { get; set; }
+        public string? UserName { get; set; }
+        public string? Barcode { get; set; }
         public int PatronBranchID { get; set; }
         public int? StatisticalClassID { get; set; }
         public bool? UseSingleName { get; set; }
@@ -60,16 +60,16 @@ namespace Clc.Polaris.Models
 
         public class PatronRegistrationAddressData
         {
-            public string FreeTextLabel { get; set; }
-            public string StreetOne { get; set; }
-            public string StreetTwo { get; set; }
-            public string StreetThree { get; set; }
-            public string City { get; set; }
-            public string State { get; set; }
-            public string County { get; set; }
-            public string PostalCode { get; set; }
-            public string ZipPlusFour { get; set; }
-            public string Country { get; set; }
+            public string? FreeTextLabel { get; set; }
+            public string? StreetOne { get; set; }
+            public string? StreetTwo { get; set; }
+            public string? StreetThree { get; set; }
+            public string? City { get; set; }
+            public string? State { get; set; }
+            public string? County { get; set; }
+            public string? PostalCode { get; set; }
+            public string? ZipPlusFour { get; set; }
+            public string? Country { get; set; }
             public int? CountryID { get; set; }
             public int? AddressTypeID { get; set; }
         }

--- a/src/polaris-api-csharp/Models/PatronRegistrationParams.cs
+++ b/src/polaris-api-csharp/Models/PatronRegistrationParams.cs
@@ -33,7 +33,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// ZIP code
         /// </summary>
-		public string PostalCode { get; set; }
+		public string? PostalCode { get; set; }
 
         /// <summary>
         /// ZIP+4
@@ -43,17 +43,17 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// City
         /// </summary>
-		public string City { get; set; }
+		public string? City { get; set; }
 
         /// <summary>
         /// State
         /// </summary>
-		public string State { get; set; }
+		public string? State { get; set; }
 
         /// <summary>
         /// County
         /// </summary>
-		public string County { get; set; }
+		public string? County { get; set; }
 
         /// <summary>
         /// Country ID
@@ -63,57 +63,57 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Street one
         /// </summary>
-		public string StreetOne { get; set; }
+		public string? StreetOne { get; set; }
 
         /// <summary>
         /// Street two
         /// </summary>
-		public string StreetTwo { get; set; }
+		public string? StreetTwo { get; set; }
 
         /// <summary>
         /// First name
         /// </summary>
-		public string NameFirst { get; set; }
+		public string? NameFirst { get; set; }
 
         /// <summary>
         /// Last name
         /// </summary>
-		public string NameLast { get; set; }
+		public string? NameLast { get; set; }
 
         /// <summary>
         /// Middle name
         /// </summary>
-		public string NameMiddle { get; set; }
+		public string? NameMiddle { get; set; }
 
         /// <summary>
         /// User defined field 1
         /// </summary>
-		public string User1 { get; set; }
+		public string? User1 { get; set; }
 
         /// <summary>
         /// User defined field 2
         /// </summary>
-		public string User2 { get; set; }
+		public string? User2 { get; set; }
 
         /// <summary>
         /// User defined field 3
         /// </summary>
-		public string User3 { get; set; }
+		public string? User3 { get; set; }
 
         /// <summary>
         /// User defined field 4
         /// </summary>
-		public string User4 { get; set; }
+		public string? User4 { get; set; }
 
         /// <summary>
         /// User defined field 5
         /// </summary>
-		public string User5 { get; set; }
+		public string? User5 { get; set; }
 
         /// <summary>
         /// Gender
         /// </summary>
-		public string Gender { get; set; }
+		public string? Gender { get; set; }
 
         /// <summary>
         /// Date of birth
@@ -123,17 +123,17 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Phone 1
         /// </summary>
-		public string PhoneVoice1 { get; set; }
+		public string? PhoneVoice1 { get; set; }
 
         /// <summary>
         /// Phone 2
         /// </summary>
-		public string PhoneVoice2 { get; set; }
+		public string? PhoneVoice2 { get; set; }
 
         /// <summary>
         /// Email address
         /// </summary>
-		public string EmailAddress { get; set; }
+		public string? EmailAddress { get; set; }
 
         /// <summary>
         /// Language ID
@@ -151,27 +151,27 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Username
         /// </summary>
-		public string Username { get; set; }
+		public string? Username { get; set; }
 
         /// <summary>
         /// PIN/Password
         /// </summary>
-		public string Password { get; set; }
+		public string? Password { get; set; }
 
         /// <summary>
         /// Password confirmation
         /// </summary>
-		public string Password2 { get; set; }
+		public string? Password2 { get; set; }
 
         /// <summary>
         /// Alternate email address
         /// </summary>
-		public string AltEmailAddress { get; set; }
+		public string? AltEmailAddress { get; set; }
 
         /// <summary>
         /// Phone 3
         /// </summary>
-		public string PhoneVoice3 { get; set; }
+		public string? PhoneVoice3 { get; set; }
 
         /// <summary>
         /// PHone 1 mobile carrier id
@@ -201,7 +201,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Barcode
         /// </summary>
-		public string Barcode { get; set; }
+		public string? Barcode { get; set; }
 
         /// <summary>
         /// eReceipt option ID
@@ -225,9 +225,9 @@ namespace Clc.Polaris.Api.Models
         /// </summary>
         public DateTime? AddrCheckDate { get; set; }
 
-        public string LegalNameFirst { get; set; }
-        public string LegalNameMiddle { get; set; }
-        public string LegalNameLast { get; set; }
+        public string? LegalNameFirst { get; set; }
+        public string? LegalNameMiddle { get; set; }
+        public string? LegalNameLast { get; set; }
         public bool UseLegalNameOnNotices { get; set; }
 
         public PatronRegistrationParams()

--- a/src/polaris-api-csharp/Models/PatronRenewBlocksResult.cs
+++ b/src/polaris-api-csharp/Models/PatronRenewBlocksResult.cs
@@ -6,14 +6,14 @@ namespace Clc.Polaris.Api.Models
 {
     public class PatronRenewBlocksResult : PapiResponseCommon
     {
-        public PatronRenewBlock[] Blocks { get; set; }
+        public PatronRenewBlock[] Blocks { get; set; } = Array.Empty<PatronRenewBlock>();
         public bool CanPatronRenew { get; set; }
     }
 
     public class PatronRenewBlock
     {
         public int PatronId { get; set; }
-        public string PatronName { get; set; }
-        public string BlockDescription { get; set; }
+        public string? PatronName { get; set; }
+        public string? BlockDescription { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/PatronSavedSearchesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronSavedSearchesGetResult.cs
@@ -6,18 +6,18 @@ namespace Clc.Polaris.Api.Models
 {
     public class PatronSavedSearchesGetResult : PapiResponseCommon
     {
-        public Patronsavedsearchesgetrow[] PatronSavedSearchesGetRows { get; set; }
+        public Patronsavedsearchesgetrow[] PatronSavedSearchesGetRows { get; set; } = Array.Empty<Patronsavedsearchesgetrow>();
     }
 
     public class Patronsavedsearchesgetrow
     {
         public int SDISearchID { get; set; }
-        public string SDIName { get; set; }
-        public string SearchCriteria { get; set; }
-        public string SearchPeriod { get; set; }
+        public string? SDIName { get; set; }
+        public string? SearchCriteria { get; set; }
+        public string? SearchPeriod { get; set; }
         public DateTime LastRunDate { get; set; }
         public bool NotifyOnNoResults { get; set; }
-        public string EmailResultsTo { get; set; }
+        public string? EmailResultsTo { get; set; }
         public int ResultsCount { get; set; }
 
         public override string ToString() => $"{SearchPeriod} - {SDIName} - {SearchCriteria} - {LastRunDate.ToShortDateString()}";

--- a/src/polaris-api-csharp/Models/PatronSearchResult.cs
+++ b/src/polaris-api-csharp/Models/PatronSearchResult.cs
@@ -13,7 +13,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// List of keywords
         /// </summary>
-		public string WordList { get; set; }
+		public string? WordList { get; set; }
 
         /// <summary>
         /// Total records found
@@ -23,7 +23,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Patron search results
         /// </summary>
-		public List<PatronSearchRow> PatronSearchRows { get; set; }
+		public List<PatronSearchRow> PatronSearchRows { get; set; } = new List<PatronSearchRow>();
 	}
 
     /// <summary>
@@ -39,7 +39,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Patron barcode
         /// </summary>
-		public string Barcode { get; set; }
+		public string? Barcode { get; set; }
 
         /// <summary>
         /// Patron registered branch
@@ -49,7 +49,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Patron first and last name
         /// </summary>
-		public string PatronFirstLastName { get; set; }
+		public string? PatronFirstLastName { get; set; }
 
         public override string ToString() => $"{PatronID} | {Barcode} | {OrganizationID} | {PatronFirstLastName}";
     }

--- a/src/polaris-api-csharp/Models/PatronTitleListGetTitlesResult.cs
+++ b/src/polaris-api-csharp/Models/PatronTitleListGetTitlesResult.cs
@@ -8,8 +8,8 @@ namespace Clc.Polaris.Api.Models
     public class PatronTitleListGetTitlesResult
     {
         public int PAPIErrorCode { get; set; }
-        public object ErrorMessage { get; set; }
-        public PatronTitleListTitleRow[] PatronTitleListTitleRows { get; set; }
+        public object? ErrorMessage { get; set; }
+        public PatronTitleListTitleRow[] PatronTitleListTitleRows { get; set; } = Array.Empty<PatronTitleListTitleRow>();
 
         public override string ToString() => string.Join("\r\n", (IEnumerable<PatronTitleListTitleRow>)PatronTitleListTitleRows);
     }
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api.Models
     {
         public int Position { get; set; }
         public int RecordID { get; set; }
-        public string Name { get; set; }
+        public string? Name { get; set; }
         public int LocalControlNumber { get; set; }
 
         public override string ToString() => $"{Position} - {RecordID} - {Name}";

--- a/src/polaris-api-csharp/Models/PatronUpdateParams.cs
+++ b/src/polaris-api-csharp/Models/PatronUpdateParams.cs
@@ -35,19 +35,19 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// The patron's email address.
         /// </summary>
-        public string EmailAddress { get; set; }
+        public string? EmailAddress { get; set; }
 
         /// <summary>
 		/// The patron's alternate email address.
 		/// </summary>
-		public string AltEmailAddress { get; set; }
+		public string? AltEmailAddress { get; set; }
 
         /// <summary>
         /// The patron's phone number.
         /// </summary>
-        public string PhoneVoice1 { get; set; }
-        public string PhoneVoice2 { get; set; }
-        public string PhoneVoice3 { get; set; }
+        public string? PhoneVoice1 { get; set; }
+        public string? PhoneVoice2 { get; set; }
+        public string? PhoneVoice3 { get; set; }
 
         public int? Phone1CarrierID { get; set; }
         public int? Phone2CarrierID { get; set; }
@@ -63,7 +63,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// The patron's new Password/PIN
         /// </summary>
-        public string NewPassword { get; set; }
+        public string? NewPassword { get; set; }
 
         public DateTime? AddrCheckDate { get; set; }
         public DateTime? ExpirationDate { get; set; }
@@ -74,28 +74,28 @@ namespace Clc.Polaris.Api.Models
         public int? EReceiptOptionID { get; set; }
 
 
-        public List<PatronAddress> PatronAddresses { get; set; }
+        public List<PatronAddress> PatronAddresses { get; set; } = new List<PatronAddress>();
 
         /// <summary>
         /// User-defined field
         /// </summary>
-        public string User1 { get; set; }
+        public string? User1 { get; set; }
         /// <summary>
         /// User-defined field
         /// </summary>
-        public string User2 { get; set; }
+        public string? User2 { get; set; }
         /// <summary>
         /// User-defined field
         /// </summary>
-        public string User3 { get; set; }
+        public string? User3 { get; set; }
         /// <summary>
         /// User-defined field
         /// </summary>
-        public string User4 { get; set; }
+        public string? User4 { get; set; }
         /// <summary>
         /// User-defined field
         /// </summary>
-        public string User5 { get; set; }
+        public string? User5 { get; set; }
 
         public int? RequestPickupBranchID { get; set; }
         public int? PatronCode { get; set; }

--- a/src/polaris-api-csharp/Models/PatronValidateResult.cs
+++ b/src/polaris-api-csharp/Models/PatronValidateResult.cs
@@ -10,7 +10,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// The patron's barcode.
 		/// </summary>
-		public string Barcode { get; set; }
+		public string? Barcode { get; set; }
 
 		/// <summary>
 		/// Indicates valid patron.
@@ -35,7 +35,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// The name of the patron's assigned branch.
 		/// </summary>
-		public string AssignedBranchName { get; set; }
+		public string? AssignedBranchName { get; set; }
 
 		/// <summary>
 		/// The date this patron's registration expires.

--- a/src/polaris-api-csharp/Models/PickupBranchesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PickupBranchesGetResult.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api.Models
 
     public class PickupBranchesGetResult : PapiResponseCommon
     {
-        public List<PickupBranchesRow> PickupBranchesRows { get; set; }
+        public List<PickupBranchesRow> PickupBranchesRows { get; set; } = new List<PickupBranchesRow>();
 
         public List<int> PickupBranches => PickupBranchesRows.Select(b => b.ID).ToList();
     }

--- a/src/polaris-api-csharp/Models/PolarisUser.cs
+++ b/src/polaris-api-csharp/Models/PolarisUser.cs
@@ -14,17 +14,17 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Domain
         /// </summary>
-        public string Domain { get; set; }
+        public string? Domain { get; set; }
 
         /// <summary>
         /// Username
         /// </summary>
-        public string Username { get; set; }
+        public string? Username { get; set; }
 
         /// <summary>
         /// Password
         /// </summary>
-        public string Password { get; set; }
+        public string? Password { get; set; }
 
         public PolarisUser()
         {

--- a/src/polaris-api-csharp/Models/ProtectedToken.cs
+++ b/src/polaris-api-csharp/Models/ProtectedToken.cs
@@ -20,12 +20,12 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Access token
         /// </summary>
-        public string AccessToken { get; set; }
+        public string? AccessToken { get; set; }
 
         /// <summary>
         /// Access secret
         /// </summary>
-        public string AccessSecret { get; set; }
+        public string? AccessSecret { get; set; }
 
         /// <summary>
         /// Token expiration date

--- a/src/polaris-api-csharp/Models/RecordSetRecordsGetResult.cs
+++ b/src/polaris-api-csharp/Models/RecordSetRecordsGetResult.cs
@@ -8,7 +8,7 @@ namespace Clc.Polaris.Api.Models
 {
     public partial class RecordSetRecordsGetResult : PapiResponseCommon
     {
-        public List<RecordSetRecordsGetRow> RecordSetRecordsGetRows { get; set; }
+        public List<RecordSetRecordsGetRow> RecordSetRecordsGetRows { get; set; } = new List<RecordSetRecordsGetRow>();
 
         public IEnumerable<int> Ids { get { return RecordSetRecordsGetRows.Select(r => r.RecordID); } }
 

--- a/src/polaris-api-csharp/Models/RemoteStorageItemsGetResult.cs
+++ b/src/polaris-api-csharp/Models/RemoteStorageItemsGetResult.cs
@@ -7,27 +7,27 @@ namespace Clc.Polaris.Api.Models
     public class RemoteStorageItemsGetResult
     {
         public int PAPIErrorCode { get; set; }
-        public string ErrorMessage { get; set; }
+        public string? ErrorMessage { get; set; }
         public int RecordCount { get; set; }
         public int RowCount { get; set; }
-        public RemoteStorageItemsGetRow[] RemoteStorageItemsGetRows { get; set; }
+        public RemoteStorageItemsGetRow[] RemoteStorageItemsGetRows { get; set; } = Array.Empty<RemoteStorageItemsGetRow>();
     }
 
     public class RemoteStorageItemsGetRow
     {
         public int ItemRecordID { get; set; }
         public int BibliographicRecordID { get; set; }
-        public string Barcode { get; set; }
-        public string BrowseTitle { get; set; }
-        public object BrowseAuthor { get; set; }
+        public string? Barcode { get; set; }
+        public string? BrowseTitle { get; set; }
+        public object? BrowseAuthor { get; set; }
         public int MaterialTypeID { get; set; }
-        public string MaterialType { get; set; }
+        public string? MaterialType { get; set; }
         public int CollectionID { get; set; }
-        public string Collection { get; set; }
+        public string? Collection { get; set; }
         public int ShelfLocationID { get; set; }
-        public string ShelfLocation { get; set; }
-        public string CallNumber { get; set; }
-        public object CopyNumber { get; set; }
-        public object VolumeNumber { get; set; }
+        public string? ShelfLocation { get; set; }
+        public string? CallNumber { get; set; }
+        public object? CopyNumber { get; set; }
+        public object? VolumeNumber { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/ShelfLocationsGetResult.cs
+++ b/src/polaris-api-csharp/Models/ShelfLocationsGetResult.cs
@@ -6,14 +6,14 @@ namespace Clc.Polaris.Api.Models
 {
     public class ShelfLocationsGetResult : PapiResponseCommon
     {
-        public Shelflocationsrow[] ShelfLocationsRows { get; set; }
+        public Shelflocationsrow[] ShelfLocationsRows { get; set; } = Array.Empty<Shelflocationsrow>();
     }
 
     public class Shelflocationsrow
     {
         public int ID { get; set; }
         public int OrganizationID { get; set; }
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         public override string ToString() => $"{ID} - {OrganizationID} - {Description}";
     }

--- a/src/polaris-api-csharp/Models/StringResult.cs
+++ b/src/polaris-api-csharp/Models/StringResult.cs
@@ -14,7 +14,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Value
         /// </summary>
-        public string Value { get; set; }
+        public string? Value { get; set; }
 
         /// <summary>
         /// Returns value
@@ -22,7 +22,7 @@ namespace Clc.Polaris.Api.Models
         /// <returns></returns>
         public override string ToString()
         {
-            return Value;
+            return Value ?? string.Empty;
         }
     }
 }

--- a/src/polaris-api-csharp/Models/Sync_BibsByIdGetResult.cs
+++ b/src/polaris-api-csharp/Models/Sync_BibsByIdGetResult.cs
@@ -9,14 +9,14 @@ namespace Clc.Polaris.Api.Models
     public class Sync_BibsByIdGetResult
     {
         public int PAPIErrorCode { get; set; }
-        public object ErrorMessage { get; set; }
-        public GetBibsByIdRow[] GetBibsByIDRows { get; set; }
+        public object? ErrorMessage { get; set; }
+        public GetBibsByIdRow[] GetBibsByIDRows { get; set; } = Array.Empty<GetBibsByIdRow>();
     }
 
     public class GetBibsByIdRow
     {
         public int BibliographicRecordID { get; set; }
-        public string BibliographicRecordXML { get; set; }
+        public string? BibliographicRecordXML { get; set; }
         public bool IsDisplayInPAC { get; set; }
         public DateTime CreationDate { get; set; }
         public DateTime? FirstAvailableDate { get; set; }

--- a/src/polaris-api-csharp/Models/UpdatePatronNotesData.cs
+++ b/src/polaris-api-csharp/Models/UpdatePatronNotesData.cs
@@ -6,9 +6,9 @@ namespace Clc.Polaris.Models
 {
     public class UpdatePatronNotesData
     {
-        public string BlockingNote { get; set; }
+        public string? BlockingNote { get; set; }
         public int? BlockingNoteMode { get; set; }
-        public string NonBlockingNote { get; set; }
+        public string? NonBlockingNote { get; set; }
         public int? NonBlockingNoteMode { get; set; }
     }
 }

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -17,17 +17,17 @@ namespace Clc.Polaris.Api
         /// <summary>
         /// Your PAPI Access ID
         /// </summary>
-        public string AccessID { get; set; }
+        public string AccessID { get; set; } = string.Empty;
 
         /// <summary>
         /// Your PAPI Access Key
         /// </summary>
-        public string AccessKey { get; set; }
+        public string AccessKey { get; set; } = string.Empty;
 
         /// <summary>
         /// The base URL of your PAPI service
         /// </summary>
-        public string Hostname { get; set; }
+        public string Hostname { get; set; } = string.Empty;
 
         public int UserId { get; set; } = 1;
         public int WorkstationId { get; set; } = 1;
@@ -38,18 +38,18 @@ namespace Clc.Polaris.Api
         /// <summary>
         /// The staff credentials used for protected methods and public method overrides
         /// </summary>
-        public PolarisUser StaffOverrideAccount { get; set; }
+        public PolarisUser? StaffOverrideAccount { get; set; }
 
         public bool UseProtectedTokenCache { get; set; } = true;
         private static ConcurrentDictionary<string, ProtectedToken> ProtectedTokenCache { get; set; } = new ConcurrentDictionary<string, ProtectedToken>();
         private static ConcurrentDictionary<string, SemaphoreSlim> ProtectedTokenCacheLocks { get; set; } = new ConcurrentDictionary<string, SemaphoreSlim>();
 
-        private ProtectedToken _token;
+        private ProtectedToken? _token;
 
         /// <summary>
         /// Used for protected methods and public method overrides
         /// </summary>
-        public ProtectedToken Token
+        public ProtectedToken? Token
         {
             get
             {
@@ -68,7 +68,7 @@ namespace Clc.Polaris.Api
         /// Initializes a new PAPI client. Configure TLS behavior on the injected <see cref="HttpClient"/>
         /// by supplying an <see cref="HttpClientHandler"/> with the desired settings.
         /// </summary>
-        public PapiClient(HttpClient client, IPapiSettings settings) : base(null, client)
+        public PapiClient(HttpClient? client, IPapiSettings? settings) : base(null, client)
         {
             if (settings != null)
             {
@@ -83,7 +83,7 @@ namespace Clc.Polaris.Api
         }
 
         public PapiClient() : this(null, null) { }
-        public PapiClient(IPapiSettings settings) : this(null, settings) { }
+        public PapiClient(IPapiSettings? settings) : this(null, settings) { }
 
         // map BaseUrl to Hostname
         public override string BaseUrl { get => Hostname; set => Hostname = value; }
@@ -91,7 +91,7 @@ namespace Clc.Polaris.Api
 
         public override RestRequest PreformatRestRequest(RestRequest request)
         {
-            var papiRequest = request is PapiRestRequest ? request as PapiRestRequest : new PapiRestRequest(request);
+            var papiRequest = request is PapiRestRequest existingRequest ? existingRequest : new PapiRestRequest(request);
 
             var password = papiRequest.Password;
 
@@ -178,13 +178,15 @@ namespace Clc.Polaris.Api
             request.Path = request.Path.Replace(ProtectedToken.Placeholder, accessToken, StringComparison.Ordinal);
         }
 
-        private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
+        private async Task<ProtectedToken?> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
         {
             var token = Token;
             if (StaffOverrideAccount == null || token != null)
             {
                 return token;
             }
+
+            var staffOverrideAccount = StaffOverrideAccount;
 
             var cacheKey = BuildProtectedTokenCacheKey();
             if (TryLoadProtectedTokenFromCache(cacheKey))
@@ -194,7 +196,7 @@ namespace Clc.Polaris.Api
 
             if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
             {
-                return await AuthenticateAndLoadProtectedTokenAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+                return await AuthenticateAndLoadProtectedTokenAsync(cacheKey, staffOverrideAccount, cancellationToken).ConfigureAwait(false);
             }
 
             var cacheLock = ProtectedTokenCacheLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
@@ -207,7 +209,7 @@ namespace Clc.Polaris.Api
                     return _token;
                 }
 
-                return await AuthenticateAndLoadProtectedTokenAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+                return await AuthenticateAndLoadProtectedTokenAsync(cacheKey, staffOverrideAccount, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -215,7 +217,7 @@ namespace Clc.Polaris.Api
             }
         }
 
-        private string BuildProtectedTokenCacheKey()
+        private string? BuildProtectedTokenCacheKey()
         {
             if (StaffOverrideAccount == null ||
                 string.IsNullOrWhiteSpace(Hostname) ||
@@ -228,12 +230,12 @@ namespace Clc.Polaris.Api
             return $"{Hostname}|{StaffOverrideAccount.Domain}|{StaffOverrideAccount.Username}";
         }
 
-        private static bool IsProtectedTokenMissingOrExpired(ProtectedToken token)
+        private static bool IsProtectedTokenMissingOrExpired(ProtectedToken? token)
         {
             return token == null || !token.ExpirationDate.HasValue || token.ExpirationDate <= DateTime.Now;
         }
 
-        private bool TryLoadProtectedTokenFromCache(string cacheKey)
+        private bool TryLoadProtectedTokenFromCache(string? cacheKey)
         {
             if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
             {
@@ -249,21 +251,22 @@ namespace Clc.Polaris.Api
             return false;
         }
 
-        private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenAsync(string cacheKey, CancellationToken cancellationToken)
+        private async Task<ProtectedToken?> AuthenticateAndLoadProtectedTokenAsync(string? cacheKey, PolarisUser staffOverrideAccount, CancellationToken cancellationToken)
         {
             var currentToken = Token;
-            var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
+            var response = await AuthenticateStaffUserAsync(staffOverrideAccount, cancellationToken).ConfigureAwait(false);
+            var responseData = response?.Data;
             if (response?.Response == null ||
                 !response.Response.IsSuccessStatusCode ||
-                IsProtectedTokenMissingOrExpired(response.Data) ||
-                string.IsNullOrWhiteSpace(response.Data.AccessToken) ||
-                string.IsNullOrWhiteSpace(response.Data.AccessSecret))
+                (responseData == null || IsProtectedTokenMissingOrExpired(responseData)) ||
+                string.IsNullOrWhiteSpace(responseData.AccessToken) ||
+                string.IsNullOrWhiteSpace(responseData.AccessSecret))
             {
                 _token = currentToken;
                 return _token;
             }
 
-            _token = response.Data;
+            _token = responseData;
 
             if (UseProtectedTokenCache && !string.IsNullOrWhiteSpace(cacheKey))
             {
@@ -276,7 +279,7 @@ namespace Clc.Polaris.Api
         private string GetPAPIHash(string httpMethod, string date, string uri, string password)
         {
             var hashString = httpMethod + uri + date + password;
-            using var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(AccessKey));
+            using var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(AccessKey ?? string.Empty));
             byte[] computedHash = hmac.ComputeHash(Encoding.UTF8.GetBytes(hashString));
             return Convert.ToBase64String(computedHash);
         }

--- a/src/polaris-api-csharp/Validation/Require.cs
+++ b/src/polaris-api-csharp/Validation/Require.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api.Validation
         /// </summary>
         /// <param name="name"></param>
         /// <param name="value"></param>
-        public static void Argument(string name, object value)
+        public static void Argument(string name, object? value)
         {
             if (value == null)
             {

--- a/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
@@ -66,7 +66,9 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod()]
         public async Task AuthenticateStaffUserTest()
         {
-            var response = await papi.AuthenticateStaffUserAsync(papi.StaffOverrideAccount);
+            var staffOverrideAccount = papi.StaffOverrideAccount;
+            Assert.IsNotNull(staffOverrideAccount);
+            var response = await papi.AuthenticateStaffUserAsync(staffOverrideAccount);
             Assert.AreEqual(response.Data.PAPIErrorCode, 0);
             Assert.IsFalse(string.IsNullOrWhiteSpace(response.Data.AccessSecret));
             Assert.IsFalse(string.IsNullOrWhiteSpace(response.Data.AccessToken));

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -235,7 +235,9 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.ProtectedRequestCount);
-            Assert.AreEqual("cached-token", client.Token.AccessToken);
+            var cachedClientToken = client.Token;
+            Assert.IsNotNull(cachedClientToken);
+            Assert.AreEqual("cached-token", cachedClientToken.AccessToken);
         }
 
         [TestMethod]
@@ -580,13 +582,13 @@ namespace Clc.Polaris.Api.Tests
             locks?.Clear();
         }
 
-        private static void SetCachedToken(string hostname, PolarisUser staffUser, ProtectedToken token)
+        private static void SetCachedToken(string hostname, PolarisUser? staffUser, ProtectedToken token)
         {
             var cache = GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache");
             cache?.TryAdd(BuildCacheKey(hostname, staffUser), token);
         }
 
-        private static bool TryGetCachedToken(string hostname, PolarisUser staffUser, out ProtectedToken? token)
+        private static bool TryGetCachedToken(string hostname, PolarisUser? staffUser, out ProtectedToken? token)
         {
             token = null;
             var cache = GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache");
@@ -599,9 +601,9 @@ namespace Clc.Polaris.Api.Tests
             return cacheProperty?.GetValue(null) as T;
         }
 
-        private static string BuildCacheKey(string hostname, PolarisUser staffUser)
+        private static string BuildCacheKey(string hostname, PolarisUser? staffUser)
         {
-            return $"{hostname}|{staffUser.Domain}|{staffUser.Username}";
+            return staffUser == null ? string.Empty : $"{hostname}|{staffUser.Domain}|{staffUser.Username}";
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Turn on C# nullable reference types for the main library to improve null-safety and make intent explicit by adding `<Nullable>enable</Nullable>` to the library project file.  
- Annotate high-confidence nullable fields/parameters (requests, tokens, DTOs, config) so the codebase is safer and the compiler can guide further fixes.  
- Preserve public surface where possible, making only necessary API changes to correctly represent nullable values (e.g. optional staff token, optional request parameters).  

### Description
- Enabled nullable reference types in `src/polaris-api-csharp/Clc.Polaris.Api.csproj`.  
- Annotated many model properties as nullable and initialized collection properties to empty collections to avoid CS8618 warnings (examples: `BibGetResult`, `BibSearchResult`, `Patron*` DTOs, `HoldRequest*` results).  
- Made request and helper types null-safe: `PapiRestRequest` optional `body`/`HashString` made nullable, `Get/Delete/Post/Put` overloads accept nullable `object? body`.  
- Updated client/config/token handling: `PapiClient` strings are initialized (`AccessID`, `AccessKey`, `Hostname`), `StaffOverrideAccount` and `ProtectedToken` are nullable, token cache and authentication methods were null-safe and adjusted accordingly.  
- Adjusted some public API signatures only where correctness required (examples in `IPapiClient`: nullable `StaffOverrideAccount`, `ItemRenewOptions?` and `UpdatePatronNotesDataAsync` string parameters now nullable).  
- Small test and helper updates to match nullable contracts: `Require.Argument` accepts `object?`, test helpers that manipulate the protected token cache were made nullable-aware, and a few test assertions were clarified.  

### Testing
- Built solution: `dotnet build src/polaris-api-csharp.sln --no-incremental -v:minimal` — build succeeded (final run showed 0 warnings).  
- Ran subset of tests (excluding tests which need local test configuration): `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build --filter "FullyQualifiedName!~Clc.Polaris.Api.Tests.PapiClientTests"` — passed (91 tests).  
- Ran full test run: `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-build` — many tests failed during test initialization because `appsettings.Test.json` is not present in the test output directory (external test config missing), not due to compile/runtime nullability failures.  
- Performed `git diff --check` and resolved issues; committed changes under message: "Enable nullable reference types in library".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c29061f088323ae583affbae02871)