### PR TITLE
Enable nullable reference types in API project

### DIFF
--- a/src/polaris-api-csharp/Clc.Polaris.Api.csproj
+++ b/src/polaris-api-csharp/Clc.Polaris.Api.csproj
@@ -2,6 +2,9 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<!-- API response/request DTOs are populated by serializers; keep existing constructors/public surface while enabling NRT. -->
+		<NoWarn>$(NoWarn);CS8618</NoWarn>
 		<RootNamespace>Clc.Polaris</RootNamespace>
 		<PackageId>Clc.Polaris.Api</PackageId>
 		<Authors>Central Library Consortium, Michael Fields</Authors>

--- a/src/polaris-api-csharp/Configuration/PapiSettings.cs
+++ b/src/polaris-api-csharp/Configuration/PapiSettings.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api.Configuration
         public int OrganizationId { get; set; } = 1;
         public int UserId { get; set; } = 1;
         public int WorkstationId { get; set; } = 1;
-        public PolarisUser PolarisOverrideAccount { get; set; }
+        public PolarisUser? PolarisOverrideAccount { get; set; }
     }
     public interface IPapiSettings
     {
@@ -25,6 +25,6 @@ namespace Clc.Polaris.Api.Configuration
         int OrganizationId { get; set; }
         int UserId { get; set; }
         int WorkstationId { get; set; }
-        PolarisUser PolarisOverrideAccount { get; set; }
+        PolarisUser? PolarisOverrideAccount { get; set; }
     }
 }

--- a/src/polaris-api-csharp/IPapiClient.cs
+++ b/src/polaris-api-csharp/IPapiClient.cs
@@ -32,7 +32,7 @@ namespace Clc.Polaris.Api
         /// <summary>
         /// The staff credentials used for protected methods and public method overrides
         /// </summary>
-        PolarisUser StaffOverrideAccount { get; set; }
+        PolarisUser? StaffOverrideAccount { get; set; }
 
         Task<IRestResponse<PapiResponseCommon>> ApiKeyValidateAsync(CancellationToken cancellationToken = default);
         Task<IRestResponse<ApiResult>> ApiVersionGetAsync(CancellationToken cancellationToken = default);
@@ -51,8 +51,8 @@ namespace Clc.Polaris.Api
         Task<IRestResponse<HoldRequestActivationResult>> HoldRequestReactivateAsync(string barcode, string password, int requestId, DateTime activationDate, int? userId = null, CancellationToken cancellationToken = default);
         Task<IRestResponse<HoldRequestReplyResult>> HoldRequestReplyAsync(HoldRequestCreateResult holdCreateResult, int requestingOrgId, HoldRequestReplyAnswer answer, HoldRequestReplyState state, CancellationToken cancellationToken = default);
         Task<IRestResponse<HoldRequestActivationResult>> HoldRequestSuspendAsync(string barcode, int requestId, DateTime activationDate, string password = "", int? userId = null, CancellationToken cancellationToken = default);
-        Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAsync(string barcode, int itemId, string password = "", ItemRenewOptions renewOptions = null, CancellationToken cancellationToken = default);
-        Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAllForPatronAsync(string barcode, string password = "", ItemRenewOptions renewOptions = null, CancellationToken cancellationToken = default);
+        Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAsync(string barcode, int itemId, string password = "", ItemRenewOptions? renewOptions = null, CancellationToken cancellationToken = default);
+        Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAllForPatronAsync(string barcode, string password = "", ItemRenewOptions? renewOptions = null, CancellationToken cancellationToken = default);
         Task<IRestResponse<ItemStatusesGetResult>> ItemStatusesGetAsync(int? branchId = null, CancellationToken cancellationToken = default);
         Task<IRestResponse<PapiResponseCommon>> ItemUpdateBarcodeAsync(string newBarcode, int? itemRecordId = null, int? transactionBranchId = null, string oldBarcode = "", CancellationToken cancellationToken = default);
         Task<IRestResponse<LimitFiltersGetResult>> LimitFiltersGetAsync(int? branchId = null, CancellationToken cancellationToken = default);
@@ -113,6 +113,6 @@ namespace Clc.Polaris.Api
         Task<IRestResponse<Sync_BibsByIdGetResult>> Synch_BibsByIdGetAsync(int[] bibIds, bool includeItems = false, CancellationToken cancellationToken = default);
         Task<IRestResponse<Sync_BibsByIdGetResult>> Synch_BibsByIdGetAsync(int bibId, bool includeItems = false, CancellationToken cancellationToken = default);
         Task<IRestResponse<PapiResponseCommon>> UpdatePickupBranchIDAsync(string barcode, int requestId, int pickupBranchId, string password = "", int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default);
-        Task<IRestResponse<PapiResponseCommon>> UpdatePatronNotesDataAsync(string barcode, string nonBlockingNote = null, string blockingNote = null, UpdateNoteMode updateMode = UpdateNoteMode.Prepend, int? workstationId = null, CancellationToken cancellationToken = default);
+        Task<IRestResponse<PapiResponseCommon>> UpdatePatronNotesDataAsync(string barcode, string? nonBlockingNote = null, string? blockingNote = null, UpdateNoteMode updateMode = UpdateNoteMode.Prepend, int? workstationId = null, CancellationToken cancellationToken = default);
     }
 }

--- a/src/polaris-api-csharp/Methods/ItemRenew.cs
+++ b/src/polaris-api-csharp/Methods/ItemRenew.cs
@@ -9,13 +9,13 @@ namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-        public async Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAsync(string barcode, int itemId, string password = "", ItemRenewOptions renewOptions = null, CancellationToken cancellationToken = default)
+        public async Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAsync(string barcode, int itemId, string password = "", ItemRenewOptions? renewOptions = null, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/itemsout/{itemId}";
             var request = PapiRestRequest.Put(url, body: renewOptions ?? new ItemRenewOptions(), password: password);
             return await ExecutePapiAsync<ItemRenewResultWrapper>(request, cancellationToken).ConfigureAwait(false);
         }
-        public Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAllForPatronAsync(string barcode, string password = "", ItemRenewOptions renewOptions = null, CancellationToken cancellationToken = default)
+        public Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAllForPatronAsync(string barcode, string password = "", ItemRenewOptions? renewOptions = null, CancellationToken cancellationToken = default)
             => ItemRenewAsync(barcode, 0, password, renewOptions, cancellationToken);
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
+++ b/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
@@ -16,10 +16,10 @@ namespace Clc.Polaris.Api
         public Task<IRestResponse<PapiResponseCommon>> PatronReadingHistoryClearAsync(string barcode, IEnumerable<int> ids, CancellationToken cancellationToken = default)
             => PatronReadingHistoryClearAsync(barcode, null, ids, cancellationToken);
 
-        public async Task<IRestResponse<PapiResponseCommon>> PatronReadingHistoryClearAsync(string barcode, string password, IEnumerable<int> ids, CancellationToken cancellationToken = default)
+        public async Task<IRestResponse<PapiResponseCommon>> PatronReadingHistoryClearAsync(string barcode, string? password, IEnumerable<int> ids, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/readinghistory";
-            var request = PapiRestRequest.Delete(url, password: password);
+            var request = PapiRestRequest.Delete(url, password: password ?? string.Empty);
             if (ids.Any()) { request.QueryParameters.Add("ids", string.Join(",", ids)); }
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
@@ -13,7 +13,7 @@ namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-        public async Task<IRestResponse<PapiResponseCommon>> UpdatePatronNotesDataAsync(string barcode, string nonBlockingNote = null, string blockingNote = null, UpdateNoteMode updateMode = UpdateNoteMode.Prepend, int? workstationId = null, CancellationToken cancellationToken = default)
+        public async Task<IRestResponse<PapiResponseCommon>> UpdatePatronNotesDataAsync(string barcode, string? nonBlockingNote = null, string? blockingNote = null, UpdateNoteMode updateMode = UpdateNoteMode.Prepend, int? workstationId = null, CancellationToken cancellationToken = default)
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/notes";
             var body = new UpdatePatronNotesData();

--- a/src/polaris-api-csharp/Models/BibGetResult.cs
+++ b/src/polaris-api-csharp/Models/BibGetResult.cs
@@ -28,7 +28,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// ISBN of the record.
         /// </summary>
-        public string ISBN => GetBibResultRow(6).FirstOrDefault();
+        public string? ISBN => GetBibResultRow(6).FirstOrDefault();
 
         /// <summary>
         /// Number of items associated with this record system-wide.
@@ -70,7 +70,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Format of the record.
         /// </summary>
-        public string Format => GetBibResultRow(17).FirstOrDefault();
+        public string? Format => GetBibResultRow(17).FirstOrDefault();
 
         /// <summary>
         /// Author of the record.
@@ -100,17 +100,17 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// LCCN of the record.
         /// </summary>
-        public string LCCN => GetBibResultRow(23).FirstOrDefault();
+        public string? LCCN => GetBibResultRow(23).FirstOrDefault();
 
         /// <summary>
         /// ISSN of the record.
         /// </summary>
-        public string ISSN => GetBibResultRow(24).FirstOrDefault();
+        public string? ISSN => GetBibResultRow(24).FirstOrDefault();
 
         /// <summary>
         /// Other number of the record.
         /// </summary>
-        public string OtherNumber => GetBibResultRow(25).FirstOrDefault();
+        public string? OtherNumber => GetBibResultRow(25).FirstOrDefault();
 
         /// <summary>
         /// Genre of the title.
@@ -140,22 +140,22 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Uniform title of the record.
         /// </summary>
-        public string UniformTitle => GetBibResultRow(34).FirstOrDefault();
+        public string? UniformTitle => GetBibResultRow(34).FirstOrDefault();
 
         /// <summary>
         /// Title of the record.
         /// </summary>
-        public string Title => GetBibResultRow(35).FirstOrDefault();
+        public string? Title => GetBibResultRow(35).FirstOrDefault();
 
         /// <summary>
         /// Volume of the record.
         /// </summary>
-        public string Volume => GetBibResultRow(36).FirstOrDefault();
+        public string? Volume => GetBibResultRow(36).FirstOrDefault();
 
         /// <summary>
         /// Frequency of the record.
         /// </summary>
-        public string Frequency => GetBibResultRow(37).FirstOrDefault();
+        public string? Frequency => GetBibResultRow(37).FirstOrDefault();
 
         /// <summary>
         /// Former title of the record.
@@ -191,7 +191,7 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Medium of the record.
         /// </summary>
-        public string Medium => GetBibResultRow(46).FirstOrDefault();
+        public string? Medium => GetBibResultRow(46).FirstOrDefault();
 
         private int? GetBibResultRowInt(int id)
         {

--- a/src/polaris-api-csharp/Models/GetBarcodeAndPatronIDResult.cs
+++ b/src/polaris-api-csharp/Models/GetBarcodeAndPatronIDResult.cs
@@ -13,11 +13,11 @@ namespace Clc.Polaris.Api.Models
 		/// </summary>
 		public List<BarcodeAndPatronIDRow> BarcodeAndPatronIDRows { get; set; }
 
-        public string Barcode => BarcodeAndPatronIDRows.FirstOrDefault()?.Barcode;
+        public string? Barcode => BarcodeAndPatronIDRows.FirstOrDefault()?.Barcode;
 
         public override string ToString()
         {
-            return Barcode;
+            return Barcode ?? string.Empty;
         }
     }
 

--- a/src/polaris-api-csharp/Models/PapiRestRequest.cs
+++ b/src/polaris-api-csharp/Models/PapiRestRequest.cs
@@ -10,24 +10,24 @@ namespace Clc.Polaris.Api.Models
         public bool AuthRequired { get; set; } = true;
         public bool JsonSerializerIgnoreNulls { get; set; } = true;
         public bool BlockStaffOverride = false;
-        public string HashString { get; set; }
+        public string? HashString { get; set; }
 
         public bool IsPublicMethod => Path.StartsWith("/public", StringComparison.OrdinalIgnoreCase);
         public bool IsProtectedMethod => Path.StartsWith("/protected", StringComparison.OrdinalIgnoreCase);
 
-        public static PapiRestRequest Get(string path, string password = "", object body = null) =>
+        public static PapiRestRequest Get(string path, string password = "", object? body = null) =>
             new PapiRestRequest(HttpMethod.Get, path, password, body);
 
-        public static PapiRestRequest Delete(string path, string password = "", object body = null) =>
+        public static PapiRestRequest Delete(string path, string password = "", object? body = null) =>
             new PapiRestRequest(HttpMethod.Delete, path, password, body);
 
-        public static PapiRestRequest Post(string path, object body = null, string password = "") =>
+        public static PapiRestRequest Post(string path, object? body = null, string password = "") =>
             new PapiRestRequest(HttpMethod.Post, path, password, body);
 
-        public static PapiRestRequest Put(string path, object body = null, string password = "") =>
+        public static PapiRestRequest Put(string path, object? body = null, string password = "") =>
             new PapiRestRequest(HttpMethod.Put, path, password, body);
 
-        public static PapiRestRequest Create(HttpMethod method, string path, object body = null, string password = "") =>
+        public static PapiRestRequest Create(HttpMethod method, string path, object? body = null, string password = "") =>
             new PapiRestRequest(method, path, password, body);
 
         public PapiRestRequest()
@@ -35,7 +35,7 @@ namespace Clc.Polaris.Api.Models
 
         }
 
-        public PapiRestRequest(HttpMethod method, string url, string password = "", object body = null) : base()
+        public PapiRestRequest(HttpMethod method, string url, string password = "", object? body = null) : base()
         {
             Method = method;
             Path = url;
@@ -43,7 +43,7 @@ namespace Clc.Polaris.Api.Models
             Body = body;
         }
 
-        public PapiRestRequest(string url, string password = "", object body = null) : this(HttpMethod.Get, url, password, body)
+        public PapiRestRequest(string url, string password = "", object? body = null) : this(HttpMethod.Get, url, password, body)
         {
         }
 

--- a/src/polaris-api-csharp/Models/PatronBasicDataGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronBasicDataGetResult.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api.Models
 
         public override string ToString()
         {
-            if (PatronBasicData?.PatronID == 0) return base.ToString();
+            if (PatronBasicData == null || PatronBasicData.PatronID == 0) return base.ToString();
             return $"{PatronBasicData.PatronID} - {PatronBasicData.Barcode} - {PatronBasicData.NameFirst} {PatronBasicData.NameLast}";
         }
     }
@@ -88,7 +88,7 @@ namespace Clc.Polaris.Api.Models
         public PatronNotes? PatronNotes { get; set; }
         public PatronSystemBlock[] PatronSystemBlocks { get; set; }
 
-        string fixpn(string pn) => new string(pn.Where(c => char.IsDigit(c)).ToArray());
+        string fixpn(string? pn) => new string((pn ?? string.Empty).Where(c => char.IsDigit(c)).ToArray());
 
         public string TxtDeliveryPhoneNumber => TxtPhoneNumber == 1 ? fixpn(PhoneNumber) : TxtPhoneNumber == 2 ? fixpn(PhoneNumber2) : TxtPhoneNumber == 3 ? fixpn(PhoneNumber3) : "";
 
@@ -99,7 +99,7 @@ namespace Clc.Polaris.Api.Models
                 switch (DeliveryOptionID)
                 {
                     case 1:
-                        if (PatronAddresses.Count == 0) { return ""; }
+                        if (PatronAddresses == null || PatronAddresses.Count == 0) { return ""; }
                         var address = PatronAddresses[0];
                         var street = !string.IsNullOrWhiteSpace(address.StreetTwo) ? $"{address.StreetOne} {address.StreetTwo}" : address.StreetOne;
                         return $"{street} {address.City}, {address.State} {address.PostalCode}";

--- a/src/polaris-api-csharp/Models/PatronCodesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronCodesGetResult.cs
@@ -12,7 +12,7 @@ namespace Clc.Polaris.Api.Models
 
         public override string ToString()
         {
-            return string.Join("\r\n", PatronCodesRows?.OrderBy(pc => pc.Description));
+            return string.Join("\r\n", PatronCodesRows?.OrderBy(pc => pc.Description) ?? Enumerable.Empty<PatronCodeRow>());
         }
     }
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -17,17 +17,17 @@ namespace Clc.Polaris.Api
         /// <summary>
         /// Your PAPI Access ID
         /// </summary>
-        public string AccessID { get; set; }
+        public string AccessID { get; set; } = string.Empty;
 
         /// <summary>
         /// Your PAPI Access Key
         /// </summary>
-        public string AccessKey { get; set; }
+        public string AccessKey { get; set; } = string.Empty;
 
         /// <summary>
         /// The base URL of your PAPI service
         /// </summary>
-        public string Hostname { get; set; }
+        public string Hostname { get; set; } = string.Empty;
 
         public int UserId { get; set; } = 1;
         public int WorkstationId { get; set; } = 1;
@@ -38,18 +38,18 @@ namespace Clc.Polaris.Api
         /// <summary>
         /// The staff credentials used for protected methods and public method overrides
         /// </summary>
-        public PolarisUser StaffOverrideAccount { get; set; }
+        public PolarisUser? StaffOverrideAccount { get; set; }
 
         public bool UseProtectedTokenCache { get; set; } = true;
         private static ConcurrentDictionary<string, ProtectedToken> ProtectedTokenCache { get; set; } = new ConcurrentDictionary<string, ProtectedToken>();
         private static ConcurrentDictionary<string, SemaphoreSlim> ProtectedTokenCacheLocks { get; set; } = new ConcurrentDictionary<string, SemaphoreSlim>();
 
-        private ProtectedToken _token;
+        private ProtectedToken? _token;
 
         /// <summary>
         /// Used for protected methods and public method overrides
         /// </summary>
-        public ProtectedToken Token
+        public ProtectedToken? Token
         {
             get
             {
@@ -68,7 +68,7 @@ namespace Clc.Polaris.Api
         /// Initializes a new PAPI client. Configure TLS behavior on the injected <see cref="HttpClient"/>
         /// by supplying an <see cref="HttpClientHandler"/> with the desired settings.
         /// </summary>
-        public PapiClient(HttpClient client, IPapiSettings settings) : base(null, client)
+        public PapiClient(HttpClient? client, IPapiSettings? settings) : base(string.Empty, client)
         {
             if (settings != null)
             {
@@ -91,7 +91,7 @@ namespace Clc.Polaris.Api
 
         public override RestRequest PreformatRestRequest(RestRequest request)
         {
-            var papiRequest = request is PapiRestRequest ? request as PapiRestRequest : new PapiRestRequest(request);
+            var papiRequest = request is PapiRestRequest existingRequest ? existingRequest : new PapiRestRequest(request);
 
             var password = papiRequest.Password;
 
@@ -178,7 +178,7 @@ namespace Clc.Polaris.Api
             request.Path = request.Path.Replace(ProtectedToken.Placeholder, accessToken, StringComparison.Ordinal);
         }
 
-        private async Task<ProtectedToken> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
+        private async Task<ProtectedToken?> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
         {
             var token = Token;
             if (StaffOverrideAccount == null || token != null)
@@ -215,7 +215,7 @@ namespace Clc.Polaris.Api
             }
         }
 
-        private string BuildProtectedTokenCacheKey()
+        private string? BuildProtectedTokenCacheKey()
         {
             if (StaffOverrideAccount == null ||
                 string.IsNullOrWhiteSpace(Hostname) ||
@@ -228,12 +228,12 @@ namespace Clc.Polaris.Api
             return $"{Hostname}|{StaffOverrideAccount.Domain}|{StaffOverrideAccount.Username}";
         }
 
-        private static bool IsProtectedTokenMissingOrExpired(ProtectedToken token)
+        private static bool IsProtectedTokenMissingOrExpired(ProtectedToken? token)
         {
             return token == null || !token.ExpirationDate.HasValue || token.ExpirationDate <= DateTime.Now;
         }
 
-        private bool TryLoadProtectedTokenFromCache(string cacheKey)
+        private bool TryLoadProtectedTokenFromCache(string? cacheKey)
         {
             if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
             {
@@ -249,21 +249,29 @@ namespace Clc.Polaris.Api
             return false;
         }
 
-        private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenAsync(string cacheKey, CancellationToken cancellationToken)
+        private async Task<ProtectedToken?> AuthenticateAndLoadProtectedTokenAsync(string? cacheKey, CancellationToken cancellationToken)
         {
             var currentToken = Token;
-            var response = await AuthenticateStaffUserAsync(StaffOverrideAccount, cancellationToken).ConfigureAwait(false);
+            var staffOverrideAccount = StaffOverrideAccount;
+            if (staffOverrideAccount == null)
+            {
+                return currentToken;
+            }
+
+            var response = await AuthenticateStaffUserAsync(staffOverrideAccount, cancellationToken).ConfigureAwait(false);
+            var responseData = response?.Data;
             if (response?.Response == null ||
                 !response.Response.IsSuccessStatusCode ||
-                IsProtectedTokenMissingOrExpired(response.Data) ||
-                string.IsNullOrWhiteSpace(response.Data.AccessToken) ||
-                string.IsNullOrWhiteSpace(response.Data.AccessSecret))
+                responseData == null ||
+                IsProtectedTokenMissingOrExpired(responseData) ||
+                string.IsNullOrWhiteSpace(responseData.AccessToken) ||
+                string.IsNullOrWhiteSpace(responseData.AccessSecret))
             {
                 _token = currentToken;
                 return _token;
             }
 
-            _token = response.Data;
+            _token = responseData;
 
             if (UseProtectedTokenCache && !string.IsNullOrWhiteSpace(cacheKey))
             {

--- a/src/polaris-api-csharp/Validation/Require.cs
+++ b/src/polaris-api-csharp/Validation/Require.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api.Validation
         /// </summary>
         /// <param name="name"></param>
         /// <param name="value"></param>
-        public static void Argument(string name, object value)
+        public static void Argument(string name, object? value)
         {
             if (value == null)
             {

--- a/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
@@ -66,6 +66,7 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod()]
         public async Task AuthenticateStaffUserTest()
         {
+            Assert.IsNotNull(papi.StaffOverrideAccount);
             var response = await papi.AuthenticateStaffUserAsync(papi.StaffOverrideAccount);
             Assert.AreEqual(response.Data.PAPIErrorCode, 0);
             Assert.IsFalse(string.IsNullOrWhiteSpace(response.Data.AccessSecret));

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -224,6 +224,7 @@ namespace Clc.Polaris.Api.Tests
         {
             var handler = new ProtectedTokenHttpMessageHandler();
             var client = CreateProtectedClient(handler);
+            Assert.IsNotNull(client.StaffOverrideAccount);
             SetCachedToken(client.Hostname, client.StaffOverrideAccount, new ProtectedToken
             {
                 AccessToken = "cached-token",
@@ -235,6 +236,7 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.IsNotNull(client.Token);
             Assert.AreEqual("cached-token", client.Token.AccessToken);
         }
 
@@ -254,6 +256,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual(2, paths.Length);
             StringAssert.Contains(paths[0], "/protected/v1/1033/100/1/authenticator/staff");
             StringAssert.Contains(paths[1], "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
+            Assert.IsNotNull(client.StaffOverrideAccount);
             Assert.IsTrue(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out var cachedToken));
             Assert.IsNotNull(cachedToken);
             Assert.AreEqual("protected-token", cachedToken.AccessToken);
@@ -271,6 +274,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
+            Assert.IsNotNull(client.StaffOverrideAccount);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
         }
 
@@ -285,6 +289,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
+            Assert.IsNotNull(client.StaffOverrideAccount);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
         }
 
@@ -305,6 +310,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
+            Assert.IsNotNull(client.StaffOverrideAccount);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
         }
 
@@ -325,6 +331,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
+            Assert.IsNotNull(client.StaffOverrideAccount);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
         }
 
@@ -348,6 +355,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
+            Assert.IsNotNull(client.StaffOverrideAccount);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
         }
 


### PR DESCRIPTION
### Motivation
- Turn on C# nullable reference types for the main library so NRT analysis can catch definite issues while preserving existing DTO public surface used by serializers.
- Annotate obvious nullable parameters and properties where runtime data or serializers may produce nulls to improve code safety without changing external behavior.

### Description
- Enabled `<Nullable>enable</Nullable>` in `src/polaris-api-csharp/Clc.Polaris.Api.csproj` and added a `CS8618` suppression with a comment noting serializer-populated DTOs. (`Clc.Polaris.Api.csproj`)
- Added nullability annotations and sensible defaults to client state and settings including `PolarisUser? PolarisOverrideAccount`, `PolarisUser? StaffOverrideAccount`, `ProtectedToken? _token` / `ProtectedToken? Token`, and `string` properties initialized to `string.Empty` in `PapiClient`. (`PapiClient.cs`, `PapiSettings.cs`)
- Made request/body types and optional arguments nullable where appropriate (`object? body` in `PapiRestRequest`, `ItemRenewOptions? renewOptions`, `string? nonBlockingNote`, `string? blockingNote`, `string? password` in `PatronReadingHistoryClear`), and updated `PapiRestRequest` API factory methods accordingly. (`Models/PapiRestRequest.cs`, `IPapiClient.cs`, `Methods/*`)
- Made DTO convenience accessors and helper code null-safe (e.g. numerous `string` properties to `string?` in `BibGetResult`, `Barcode` to `string?` and `ToString()` safe-return in `GetBarcodeAndPatronIDResult`, null-coalescing and guards in `PatronBasicDataGetResult`, `PatronCodesGetResult`, and `Require.Argument`). (`Models/*`, `Validation/Require.cs`)
- Hardened protected-token acquisition flows to avoid passing null into test helpers by short-circuiting if `StaffOverrideAccount` is null and using local copies to avoid race conditions; updated a few tests to assert non-null guard values before use. (`PapiClient.cs`, `Methods/AuthenticateStaffUser.cs`, `src/...Tests/*`)

### Testing
- Ran `dotnet build src/polaris-api-csharp.sln --no-restore -v:minimal` and the solution builds successfully after changes (no blocking errors reported). 
- Attempted `dotnet test src/polaris-api-csharp.sln --no-build -v:minimal`; test execution fails in this environment because the test suite expects a configuration file `appsettings.Test.json` to be present in the test output directory, which is not available here, so multiple tests could not be exercised end-to-end.
- Verified NRT diagnostics were addressed for the high-confidence warnings targeted (converted many `string` members to nullable, adjusted method signatures and null checks) and suppressed `CS8618` for serializer-populated DTOs to avoid breaking existing public surface.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c29061f088323ae583affbae02871)