### PR TITLE
Correct required request model nullability

### DIFF
--- a/src/polaris-api-csharp/Methods/HoldRequestReply.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestReply.cs
@@ -12,17 +12,9 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<HoldRequestReplyResult>> HoldRequestReplyAsync(HoldRequestCreateResult holdCreateResult, int requestingOrgId, HoldRequestReplyAnswer answer, HoldRequestReplyState state, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(holdCreateResult);
-
-            if (string.IsNullOrWhiteSpace(holdCreateResult.TxnGroupQualifier))
-            {
-                throw new InvalidOperationException("HoldRequestCreateResult is missing the TxnGroupQualifier required to reply to the hold request.");
-            }
-
-            if (string.IsNullOrWhiteSpace(holdCreateResult.TxnQualifier))
-            {
-                throw new InvalidOperationException("HoldRequestCreateResult is missing the TxnQualifier required to reply to the hold request.");
-            }
+            Require.Argument(holdCreateResult);
+            Require.Argument(holdCreateResult.TxnGroupQualifier);
+            Require.Argument(holdCreateResult.TxnQualifier);
 
             var url = $"/public/v1/1033/100/1/holdrequest/{holdCreateResult.RequestGuid}";
             var body = new HoldRequestReplyData

--- a/src/polaris-api-csharp/Methods/HoldRequestReply.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestReply.cs
@@ -12,6 +12,18 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<HoldRequestReplyResult>> HoldRequestReplyAsync(HoldRequestCreateResult holdCreateResult, int requestingOrgId, HoldRequestReplyAnswer answer, HoldRequestReplyState state, CancellationToken cancellationToken = default)
         {
+            ArgumentNullException.ThrowIfNull(holdCreateResult);
+
+            if (string.IsNullOrWhiteSpace(holdCreateResult.TxnGroupQualifier))
+            {
+                throw new InvalidOperationException("HoldRequestCreateResult is missing the TxnGroupQualifier required to reply to the hold request.");
+            }
+
+            if (string.IsNullOrWhiteSpace(holdCreateResult.TxnQualifier))
+            {
+                throw new InvalidOperationException("HoldRequestCreateResult is missing the TxnQualifier required to reply to the hold request.");
+            }
+
             var url = $"/public/v1/1033/100/1/holdrequest/{holdCreateResult.RequestGuid}";
             var body = new HoldRequestReplyData
             {

--- a/src/polaris-api-csharp/Models/CreatePatronBlocksRequest.cs
+++ b/src/polaris-api-csharp/Models/CreatePatronBlocksRequest.cs
@@ -9,7 +9,7 @@ namespace Clc.Polaris.Api.Models
     public class CreatePatronBlocksRequest
     {
         public int BlockTypeId { get; set; }
-        public string? BlockValue { get; set; }
+        public string BlockValue { get; set; } = string.Empty;
 
         public CreatePatronBlocksRequest()
         {

--- a/src/polaris-api-csharp/Models/HoldRequestReplyData.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestReplyData.cs
@@ -8,8 +8,8 @@ namespace Clc.Polaris.Api.Models
 {
     public class HoldRequestReplyData
     {
-        public string? TxnGroupQualifier { get; set; }
-        public string? TxnQualifier { get; set; }
+        public string TxnGroupQualifier { get; set; } = string.Empty;
+        public string TxnQualifier { get; set; } = string.Empty;
         public int RequestingOrgID { get; set; }
         public int Answer { get; set; }
         public int State { get; set; }

--- a/src/polaris-api-csharp/Models/ItemUpdateBarcodeData.cs
+++ b/src/polaris-api-csharp/Models/ItemUpdateBarcodeData.cs
@@ -7,6 +7,6 @@ namespace Clc.Polaris.Api.Models
     public class ItemUpdateBarcodeData
     {
         public int TransactionBranchId { get; set; }
-        public string? ItemBarcode { get; set; }
+        public string ItemBarcode { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/NotificationUpdateParams.cs
+++ b/src/polaris-api-csharp/Models/NotificationUpdateParams.cs
@@ -47,7 +47,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// How the message was delivered. In the currently implementation this is the patron's phone number.
 		/// </summary>
-		public string? DeliveryString { get; set; }
+		public string DeliveryString { get; set; } = string.Empty;
 
         /// <summary>
         /// Any additional data/notes.

--- a/src/polaris-api-csharp/Models/PatronAccountCreateCreditData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountCreateCreditData.cs
@@ -8,6 +8,6 @@ namespace Clc.Polaris.Api.Models
     {
         public double TxnAmount { get; set; }
         public PaymentMethod PaymentMethodId { get; set; }
-        public string? FreeTextNote { get; set; }
+        public string FreeTextNote { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAccountCreateTitleListData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountCreateTitleListData.cs
@@ -6,6 +6,6 @@ namespace Clc.Polaris.Api.Models
 {
     public class PatronAccountCreateTitleListData
     {
-        public string? RecordStoreName { get; set; }
+        public string RecordStoreName { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAccountPayData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountPayData.cs
@@ -10,6 +10,6 @@ namespace Clc.Polaris.Api.Models
     {
         public double TxnAmount { get; set; }
         public PaymentMethod PaymentMethodId { get; set; }
-        public string? FreeTextNote { get; set; }
+        public string FreeTextNote { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/PatronRegistrationParams.cs
+++ b/src/polaris-api-csharp/Models/PatronRegistrationParams.cs
@@ -73,12 +73,12 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// First name
         /// </summary>
-		public string? NameFirst { get; set; }
+		public string NameFirst { get; set; } = string.Empty;
 
         /// <summary>
         /// Last name
         /// </summary>
-		public string? NameLast { get; set; }
+		public string NameLast { get; set; } = string.Empty;
 
         /// <summary>
         /// Middle name

--- a/src/polaris-api-csharp/Models/PolarisUser.cs
+++ b/src/polaris-api-csharp/Models/PolarisUser.cs
@@ -14,17 +14,17 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Domain
         /// </summary>
-        public string? Domain { get; set; }
+        public string Domain { get; set; } = string.Empty;
 
         /// <summary>
         /// Username
         /// </summary>
-        public string? Username { get; set; }
+        public string Username { get; set; } = string.Empty;
 
         /// <summary>
         /// Password
         /// </summary>
-        public string? Password { get; set; }
+        public string Password { get; set; } = string.Empty;
 
         public PolarisUser()
         {

--- a/src/polaris-api-csharp/Validation/Require.cs
+++ b/src/polaris-api-csharp/Validation/Require.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace Clc.Polaris.Api.Validation
 {
@@ -14,13 +12,20 @@ namespace Clc.Polaris.Api.Validation
         /// <summary>
         /// Verify argument is provided
         /// </summary>
-        /// <param name="name"></param>
         /// <param name="value"></param>
-        public static void Argument(string name, object? value)
+        /// <param name="name"></param>
+        public static void Argument(
+            [NotNull] object? value,
+            [CallerArgumentExpression(nameof(value))] string? name = null)
         {
             if (value == null)
             {
                 throw new ArgumentNullException(name);
+            }
+
+            if (value is string stringValue && string.IsNullOrWhiteSpace(stringValue))
+            {
+                throw new ArgumentException("Value cannot be empty or whitespace.", name);
             }
         }
     }

--- a/src/polaris-api-csharpTests/Validation/RequireTests.cs
+++ b/src/polaris-api-csharpTests/Validation/RequireTests.cs
@@ -1,6 +1,6 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Clc.Polaris.Api.Validation;
 using System;
+using Clc.Polaris.Api.Validation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Clc.Polaris.Api.Validation.Tests
 {
@@ -8,31 +8,59 @@ namespace Clc.Polaris.Api.Validation.Tests
     public class RequireTests
     {
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void Argument_NullValue_ThrowsArgumentNullException()
+        public void Argument_NullObject_ThrowsArgumentNullException()
         {
-            // Arrange
-            string argumentName = "testArgument";
             object? nullValue = null;
 
-            // Act
-            Require.Argument(argumentName, nullValue);
+            var exception = Assert.ThrowsException<ArgumentNullException>(() => Require.Argument(nullValue));
 
-            // Assert is handled by ExpectedException
+            Assert.AreEqual(nameof(nullValue), exception.ParamName);
         }
 
         [TestMethod]
-        public void Argument_NotNullValue_DoesNotThrow()
+        public void Argument_NonNullObject_DoesNotThrow()
         {
-            // Arrange
-            string argumentName = "testArgument";
             object notNullValue = new object();
 
-            // Act
-            Require.Argument(argumentName, notNullValue);
+            Require.Argument(notNullValue);
+        }
 
-            // Assert
-            // No exception should be thrown
+        [TestMethod]
+        public void Argument_NullString_ThrowsArgumentNullException()
+        {
+            string? nullString = null;
+
+            var exception = Assert.ThrowsException<ArgumentNullException>(() => Require.Argument(nullString));
+
+            Assert.AreEqual(nameof(nullString), exception.ParamName);
+        }
+
+        [TestMethod]
+        public void Argument_EmptyString_ThrowsArgumentException()
+        {
+            string emptyString = string.Empty;
+
+            var exception = Assert.ThrowsException<ArgumentException>(() => Require.Argument(emptyString));
+
+            Assert.AreEqual(nameof(emptyString), exception.ParamName);
+        }
+
+        [TestMethod]
+        public void Argument_WhitespaceString_ThrowsArgumentException()
+        {
+            string whitespaceString = "   ";
+
+            var exception = Assert.ThrowsException<ArgumentException>(() => Require.Argument(whitespaceString));
+
+            Assert.AreEqual(nameof(whitespaceString), exception.ParamName);
+        }
+
+        [TestMethod]
+        public void Argument_NonEmptyString_DoesNotThrow()
+        {
+            string nonEmptyString = "value";
+
+            Require.Argument(nonEmptyString);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Align request-body model nullability with the PAPI documentation so required fields are non-nullable and serializer-friendly.
- Preserve nullable response DTOs and optional request fields while avoiding broad nullable suppressions.
- Centralize required-argument validation instead of using one-off checks in individual client methods.

### Description
- Restored required request properties to non-nullable strings with `= string.Empty` defaults in request models: `PolarisUser` (`Domain`, `Username`, `Password`), `CreatePatronBlocksRequest.BlockValue`, `ItemUpdateBarcodeData.ItemBarcode`, `PatronAccountCreateCreditData.FreeTextNote`, `PatronAccountPayData.FreeTextNote`, `PatronAccountCreateTitleListData.RecordStoreName`, and `PatronRegistrationParams.NameFirst`/`NameLast`.
- Made `NotificationUpdateParams.DeliveryString` non-nullable (`= string.Empty`) while keeping `Details` and `ItemBarcode` nullable per docs.
- Made `HoldRequestReplyData.TxnGroupQualifier` and `TxnQualifier` non-nullable, and updated `HoldRequestReplyAsync` to validate the hold-create result and required qualifiers before constructing the reply request.
- Modernized `Require.Argument` to a single `CallerArgumentExpression`-based helper that rejects null values and empty/whitespace strings.
- Added/updated tests for `Require.Argument`, including null object, non-null object, null string, empty string, whitespace string, non-empty string, and inferred parameter names.
- Kept nullable reference types enabled and avoided project-wide nullable or `CS8618` suppressions.

### Testing
- `dotnet build src/polaris-api-csharp.sln` completed successfully with 0 warnings and 0 errors.
- `dotnet test src/polaris-api-csharp.sln --no-build` could not run the full test suite because the local test configuration file `appsettings.Test.json` is not present in the test output directory, causing tests to fail during initialization. This appears to be an environment/test-config issue rather than a nullability regression.