### PR TITLE
Correct required request model nullability

### DIFF
--- a/src/polaris-api-csharp/Methods/HoldRequestReply.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestReply.cs
@@ -13,6 +13,16 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<HoldRequestReplyResult>> HoldRequestReplyAsync(HoldRequestCreateResult holdCreateResult, int requestingOrgId, HoldRequestReplyAnswer answer, HoldRequestReplyState state, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/holdrequest/{holdCreateResult.RequestGuid}";
+            if (string.IsNullOrEmpty(holdCreateResult.TxnGroupQualifier))
+            {
+                throw new InvalidOperationException("Hold request reply requires TxnGroupQualifier from the hold request create result.");
+            }
+
+            if (string.IsNullOrEmpty(holdCreateResult.TxnQualifier))
+            {
+                throw new InvalidOperationException("Hold request reply requires TxnQualifier from the hold request create result.");
+            }
+
             var body = new HoldRequestReplyData
             {
                 TxnGroupQualifier = holdCreateResult.TxnGroupQualifier,

--- a/src/polaris-api-csharp/Models/CreatePatronBlocksRequest.cs
+++ b/src/polaris-api-csharp/Models/CreatePatronBlocksRequest.cs
@@ -9,7 +9,7 @@ namespace Clc.Polaris.Api.Models
     public class CreatePatronBlocksRequest
     {
         public int BlockTypeId { get; set; }
-        public string? BlockValue { get; set; }
+        public string BlockValue { get; set; } = string.Empty;
 
         public CreatePatronBlocksRequest()
         {

--- a/src/polaris-api-csharp/Models/HoldRequestReplyData.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestReplyData.cs
@@ -8,8 +8,8 @@ namespace Clc.Polaris.Api.Models
 {
     public class HoldRequestReplyData
     {
-        public string? TxnGroupQualifier { get; set; }
-        public string? TxnQualifier { get; set; }
+        public string TxnGroupQualifier { get; set; } = string.Empty;
+        public string TxnQualifier { get; set; } = string.Empty;
         public int RequestingOrgID { get; set; }
         public int Answer { get; set; }
         public int State { get; set; }

--- a/src/polaris-api-csharp/Models/ItemUpdateBarcodeData.cs
+++ b/src/polaris-api-csharp/Models/ItemUpdateBarcodeData.cs
@@ -7,6 +7,6 @@ namespace Clc.Polaris.Api.Models
     public class ItemUpdateBarcodeData
     {
         public int TransactionBranchId { get; set; }
-        public string? ItemBarcode { get; set; }
+        public string ItemBarcode { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/NotificationUpdateParams.cs
+++ b/src/polaris-api-csharp/Models/NotificationUpdateParams.cs
@@ -47,7 +47,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// How the message was delivered. In the currently implementation this is the patron's phone number.
 		/// </summary>
-		public string? DeliveryString { get; set; }
+		public string DeliveryString { get; set; } = string.Empty;
 
         /// <summary>
         /// Any additional data/notes.

--- a/src/polaris-api-csharp/Models/PatronAccountCreateCreditData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountCreateCreditData.cs
@@ -8,6 +8,6 @@ namespace Clc.Polaris.Api.Models
     {
         public double TxnAmount { get; set; }
         public PaymentMethod PaymentMethodId { get; set; }
-        public string? FreeTextNote { get; set; }
+        public string FreeTextNote { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAccountCreateTitleListData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountCreateTitleListData.cs
@@ -6,6 +6,6 @@ namespace Clc.Polaris.Api.Models
 {
     public class PatronAccountCreateTitleListData
     {
-        public string? RecordStoreName { get; set; }
+        public string RecordStoreName { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAccountPayData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountPayData.cs
@@ -10,6 +10,6 @@ namespace Clc.Polaris.Api.Models
     {
         public double TxnAmount { get; set; }
         public PaymentMethod PaymentMethodId { get; set; }
-        public string? FreeTextNote { get; set; }
+        public string FreeTextNote { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/PatronRegistrationParams.cs
+++ b/src/polaris-api-csharp/Models/PatronRegistrationParams.cs
@@ -73,12 +73,12 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// First name
         /// </summary>
-		public string? NameFirst { get; set; }
+		public string NameFirst { get; set; } = string.Empty;
 
         /// <summary>
         /// Last name
         /// </summary>
-		public string? NameLast { get; set; }
+		public string NameLast { get; set; } = string.Empty;
 
         /// <summary>
         /// Middle name

--- a/src/polaris-api-csharp/Models/PolarisUser.cs
+++ b/src/polaris-api-csharp/Models/PolarisUser.cs
@@ -14,17 +14,17 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Domain
         /// </summary>
-        public string? Domain { get; set; }
+        public string Domain { get; set; } = string.Empty;
 
         /// <summary>
         /// Username
         /// </summary>
-        public string? Username { get; set; }
+        public string Username { get; set; } = string.Empty;
 
         /// <summary>
         /// Password
         /// </summary>
-        public string? Password { get; set; }
+        public string Password { get; set; } = string.Empty;
 
         public PolarisUser()
         {


### PR DESCRIPTION
### Motivation
- Nullable reference types are enabled and several request-body model properties were incorrectly made nullable in a prior change, breaking the documented required API contracts.
- Restore required request-field non-nullability per the PAPI docs so request models serialize cleanly and callers have clear contracts.
- Validate cases where required reply data originates from response DTOs that may be nullable to avoid constructing invalid request bodies.

### Description
- Restored required non-nullable request properties and initialized them with `= string.Empty` in request models including `PolarisUser.Domain`, `PolarisUser.Username`, `PolarisUser.Password`, `CreatePatronBlocksRequest.BlockValue`, `ItemUpdateBarcodeData.ItemBarcode`, `PatronAccountCreateCreditData.FreeTextNote`, `PatronAccountPayData.FreeTextNote`, `PatronAccountCreateTitleListData.RecordStoreName`, `NotificationUpdateParams.DeliveryString`, and `PatronRegistrationParams.NameFirst`/`NameLast`.
- Made `HoldRequestReplyData.TxnGroupQualifier` and `HoldRequestReplyData.TxnQualifier` non-nullable and added pre-checks in `Methods/HoldRequestReply.cs` that throw clear `InvalidOperationException`s when those qualifiers are missing on the `HoldRequestCreateResult` before constructing the reply body.
- Preserved optional request fields as nullable and left response DTO nullability unchanged unless clearly incorrect.
- Did not add any project-wide nullable suppressions and left `<Nullable>enable</Nullable>` in the project file intact.

### Testing
- Ran `dotnet build src/polaris-api-csharp.sln` which succeeded with the solution building and `0 Warning(s)` under nullable enabled.
- Ran `dotnet test src/polaris-api-csharp.sln --no-build` but test execution failed during setup because the test configuration file `appsettings.Test.json` was not present in the test output directory, preventing test initialization.
- Verified `git diff --check` and repository changes; updated models and the hold-reply call site and committed the corrections.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c3ea2668883239fce096f3127aa4b)