### PR TITLE
Fix request-model nullability for required PAPI fields

### DIFF
--- a/src/polaris-api-csharp/Methods/HoldRequestReply.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestReply.cs
@@ -12,6 +12,16 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<HoldRequestReplyResult>> HoldRequestReplyAsync(HoldRequestCreateResult holdCreateResult, int requestingOrgId, HoldRequestReplyAnswer answer, HoldRequestReplyState state, CancellationToken cancellationToken = default)
         {
+            if (string.IsNullOrEmpty(holdCreateResult.TxnGroupQualifier))
+            {
+                throw new InvalidOperationException("Hold request reply requires TxnGroupQualifier from the hold request create result.");
+            }
+
+            if (string.IsNullOrEmpty(holdCreateResult.TxnQualifier))
+            {
+                throw new InvalidOperationException("Hold request reply requires TxnQualifier from the hold request create result.");
+            }
+
             var url = $"/public/v1/1033/100/1/holdrequest/{holdCreateResult.RequestGuid}";
             var body = new HoldRequestReplyData
             {

--- a/src/polaris-api-csharp/Models/CreatePatronBlocksRequest.cs
+++ b/src/polaris-api-csharp/Models/CreatePatronBlocksRequest.cs
@@ -9,7 +9,7 @@ namespace Clc.Polaris.Api.Models
     public class CreatePatronBlocksRequest
     {
         public int BlockTypeId { get; set; }
-        public string? BlockValue { get; set; }
+        public string BlockValue { get; set; } = string.Empty;
 
         public CreatePatronBlocksRequest()
         {

--- a/src/polaris-api-csharp/Models/HoldRequestReplyData.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestReplyData.cs
@@ -8,8 +8,8 @@ namespace Clc.Polaris.Api.Models
 {
     public class HoldRequestReplyData
     {
-        public string? TxnGroupQualifier { get; set; }
-        public string? TxnQualifier { get; set; }
+        public string TxnGroupQualifier { get; set; } = string.Empty;
+        public string TxnQualifier { get; set; } = string.Empty;
         public int RequestingOrgID { get; set; }
         public int Answer { get; set; }
         public int State { get; set; }

--- a/src/polaris-api-csharp/Models/ItemUpdateBarcodeData.cs
+++ b/src/polaris-api-csharp/Models/ItemUpdateBarcodeData.cs
@@ -7,6 +7,6 @@ namespace Clc.Polaris.Api.Models
     public class ItemUpdateBarcodeData
     {
         public int TransactionBranchId { get; set; }
-        public string? ItemBarcode { get; set; }
+        public string ItemBarcode { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/NotificationUpdateParams.cs
+++ b/src/polaris-api-csharp/Models/NotificationUpdateParams.cs
@@ -47,7 +47,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// How the message was delivered. In the currently implementation this is the patron's phone number.
 		/// </summary>
-		public string? DeliveryString { get; set; }
+		public string DeliveryString { get; set; } = string.Empty;
 
         /// <summary>
         /// Any additional data/notes.

--- a/src/polaris-api-csharp/Models/PatronAccountCreateCreditData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountCreateCreditData.cs
@@ -8,6 +8,6 @@ namespace Clc.Polaris.Api.Models
     {
         public double TxnAmount { get; set; }
         public PaymentMethod PaymentMethodId { get; set; }
-        public string? FreeTextNote { get; set; }
+        public string FreeTextNote { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAccountCreateTitleListData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountCreateTitleListData.cs
@@ -6,6 +6,6 @@ namespace Clc.Polaris.Api.Models
 {
     public class PatronAccountCreateTitleListData
     {
-        public string? RecordStoreName { get; set; }
+        public string RecordStoreName { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAccountPayData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountPayData.cs
@@ -10,6 +10,6 @@ namespace Clc.Polaris.Api.Models
     {
         public double TxnAmount { get; set; }
         public PaymentMethod PaymentMethodId { get; set; }
-        public string? FreeTextNote { get; set; }
+        public string FreeTextNote { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/PatronRegistrationParams.cs
+++ b/src/polaris-api-csharp/Models/PatronRegistrationParams.cs
@@ -73,12 +73,12 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// First name
         /// </summary>
-		public string? NameFirst { get; set; }
+		public string NameFirst { get; set; } = string.Empty;
 
         /// <summary>
         /// Last name
         /// </summary>
-		public string? NameLast { get; set; }
+		public string NameLast { get; set; } = string.Empty;
 
         /// <summary>
         /// Middle name

--- a/src/polaris-api-csharp/Models/PolarisUser.cs
+++ b/src/polaris-api-csharp/Models/PolarisUser.cs
@@ -14,17 +14,17 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Domain
         /// </summary>
-        public string? Domain { get; set; }
+        public string Domain { get; set; } = string.Empty;
 
         /// <summary>
         /// Username
         /// </summary>
-        public string? Username { get; set; }
+        public string Username { get; set; } = string.Empty;
 
         /// <summary>
         /// Password
         /// </summary>
-        public string? Password { get; set; }
+        public string Password { get; set; } = string.Empty;
 
         public PolarisUser()
         {


### PR DESCRIPTION
### Motivation
- Restore correct nullability for request-body models so fields marked `Required = Yes` in the PAPI docs are non-nullable and serializer-friendly.
- Avoid weakening API contracts by leaving required request properties nullable, while keeping response DTO nullability where PAPI may omit/return nil values.

### Description
- Converted required request-body string properties to non-nullable and initialized them with `= string.Empty` in the following request models: `PolarisUser`, `CreatePatronBlocksRequest`, `ItemUpdateBarcodeData`, `PatronAccountCreateCreditData`, `PatronAccountPayData`, `PatronAccountCreateTitleListData`, `NotificationUpdateParams`, and `PatronRegistrationParams`.
- Restored required hold-reply fields in `HoldRequestReplyData` to non-nullable and added validation in `Methods/HoldRequestReply.cs` that checks `HoldRequestCreateResult.TxnGroupQualifier` and `TxnQualifier` and throws an `InvalidOperationException` if they are missing before constructing the reply body.
- Preserved response DTO nullability and optional request fields as nullable where the PAPI docs indicate they may be absent, and kept `Nullable` enabled in `src/polaris-api-csharp/Clc.Polaris.Api.csproj` without adding broad nullable suppressions.

### Testing
- Ran `dotnet build src/polaris-api-csharp.sln` which completed successfully with `0 Warning(s)` and `0 Error(s)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c3ea2668883239fce096f3127aa4b)