### PR TITLE
Correct request model nullability

### DIFF
--- a/src/polaris-api-csharp/Methods/HoldRequestReply.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestReply.cs
@@ -13,10 +13,23 @@ namespace Clc.Polaris.Api
         public async Task<IRestResponse<HoldRequestReplyResult>> HoldRequestReplyAsync(HoldRequestCreateResult holdCreateResult, int requestingOrgId, HoldRequestReplyAnswer answer, HoldRequestReplyState state, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/1/holdrequest/{holdCreateResult.RequestGuid}";
+            var txnGroupQualifier = holdCreateResult.TxnGroupQualifier;
+            var txnQualifier = holdCreateResult.TxnQualifier;
+
+            if (string.IsNullOrEmpty(txnGroupQualifier))
+            {
+                throw new InvalidOperationException("HoldRequestCreateResult is missing the TxnGroupQualifier required to reply to the hold request.");
+            }
+
+            if (string.IsNullOrEmpty(txnQualifier))
+            {
+                throw new InvalidOperationException("HoldRequestCreateResult is missing the TxnQualifier required to reply to the hold request.");
+            }
+
             var body = new HoldRequestReplyData
             {
-                TxnGroupQualifier = holdCreateResult.TxnGroupQualifier,
-                TxnQualifier = holdCreateResult.TxnQualifier,
+                TxnGroupQualifier = txnGroupQualifier,
+                TxnQualifier = txnQualifier,
                 RequestingOrgID = requestingOrgId,
                 Answer = (int)answer,
                 State = (int)state

--- a/src/polaris-api-csharp/Models/CreatePatronBlocksRequest.cs
+++ b/src/polaris-api-csharp/Models/CreatePatronBlocksRequest.cs
@@ -9,7 +9,7 @@ namespace Clc.Polaris.Api.Models
     public class CreatePatronBlocksRequest
     {
         public int BlockTypeId { get; set; }
-        public string? BlockValue { get; set; }
+        public string BlockValue { get; set; } = string.Empty;
 
         public CreatePatronBlocksRequest()
         {

--- a/src/polaris-api-csharp/Models/HoldRequestReplyData.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestReplyData.cs
@@ -8,8 +8,8 @@ namespace Clc.Polaris.Api.Models
 {
     public class HoldRequestReplyData
     {
-        public string? TxnGroupQualifier { get; set; }
-        public string? TxnQualifier { get; set; }
+        public string TxnGroupQualifier { get; set; } = string.Empty;
+        public string TxnQualifier { get; set; } = string.Empty;
         public int RequestingOrgID { get; set; }
         public int Answer { get; set; }
         public int State { get; set; }

--- a/src/polaris-api-csharp/Models/ItemUpdateBarcodeData.cs
+++ b/src/polaris-api-csharp/Models/ItemUpdateBarcodeData.cs
@@ -7,6 +7,6 @@ namespace Clc.Polaris.Api.Models
     public class ItemUpdateBarcodeData
     {
         public int TransactionBranchId { get; set; }
-        public string? ItemBarcode { get; set; }
+        public string ItemBarcode { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/NotificationUpdateParams.cs
+++ b/src/polaris-api-csharp/Models/NotificationUpdateParams.cs
@@ -47,7 +47,7 @@ namespace Clc.Polaris.Api.Models
 		/// <summary>
 		/// How the message was delivered. In the currently implementation this is the patron's phone number.
 		/// </summary>
-		public string? DeliveryString { get; set; }
+		public string DeliveryString { get; set; } = string.Empty;
 
         /// <summary>
         /// Any additional data/notes.

--- a/src/polaris-api-csharp/Models/PatronAccountCreateCreditData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountCreateCreditData.cs
@@ -8,6 +8,6 @@ namespace Clc.Polaris.Api.Models
     {
         public double TxnAmount { get; set; }
         public PaymentMethod PaymentMethodId { get; set; }
-        public string? FreeTextNote { get; set; }
+        public string FreeTextNote { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAccountCreateTitleListData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountCreateTitleListData.cs
@@ -6,6 +6,6 @@ namespace Clc.Polaris.Api.Models
 {
     public class PatronAccountCreateTitleListData
     {
-        public string? RecordStoreName { get; set; }
+        public string RecordStoreName { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAccountPayData.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountPayData.cs
@@ -10,6 +10,6 @@ namespace Clc.Polaris.Api.Models
     {
         public double TxnAmount { get; set; }
         public PaymentMethod PaymentMethodId { get; set; }
-        public string? FreeTextNote { get; set; }
+        public string FreeTextNote { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/PatronRegistrationParams.cs
+++ b/src/polaris-api-csharp/Models/PatronRegistrationParams.cs
@@ -73,12 +73,12 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// First name
         /// </summary>
-		public string? NameFirst { get; set; }
+		public string NameFirst { get; set; } = string.Empty;
 
         /// <summary>
         /// Last name
         /// </summary>
-		public string? NameLast { get; set; }
+		public string NameLast { get; set; } = string.Empty;
 
         /// <summary>
         /// Middle name

--- a/src/polaris-api-csharp/Models/PolarisUser.cs
+++ b/src/polaris-api-csharp/Models/PolarisUser.cs
@@ -14,17 +14,17 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// Domain
         /// </summary>
-        public string? Domain { get; set; }
+        public string Domain { get; set; } = string.Empty;
 
         /// <summary>
         /// Username
         /// </summary>
-        public string? Username { get; set; }
+        public string Username { get; set; } = string.Empty;
 
         /// <summary>
         /// Password
         /// </summary>
-        public string? Password { get; set; }
+        public string Password { get; set; } = string.Empty;
 
         public PolarisUser()
         {


### PR DESCRIPTION
### Motivation
- Restore request-body nullability to match the PAPI documentation so required fields are non-nullable and serializer-friendly.
- Preserve optional request fields as nullable and keep response DTO nullability changes untouched unless clearly incorrect.
- Validate required hold-reply qualifiers at the call site to avoid constructing invalid request bodies when upstream data is missing.

### Description
- Converted several request-body string properties from nullable to non-nullable with `= string.Empty` defaults: `PolarisUser.Domain`, `PolarisUser.Username`, `PolarisUser.Password`, `CreatePatronBlocksRequest.BlockValue`, `ItemUpdateBarcodeData.ItemBarcode`, `PatronAccountCreateCreditData.FreeTextNote`, `PatronAccountPayData.FreeTextNote`, `PatronAccountCreateTitleListData.RecordStoreName`, `NotificationUpdateParams.DeliveryString`, and `PatronRegistrationParams.NameFirst`/`NameLast`.
- Made `HoldRequestReplyData.TxnGroupQualifier` and `TxnQualifier` non-nullable and added validation in `Methods/HoldRequestReply.cs` to throw a clear `InvalidOperationException` when the qualifiers are missing before building the reply body.
- Kept optional request fields nullable (e.g., hold-create optional fields, deposit/refund free-text notes, notification `Details`/`ItemBarcode`) and left response DTO nullability changes alone.
- Did not add project-wide nullable suppressions or a broad CS8618 suppression; `Clc.Polaris.Api.csproj` still has `<Nullable>enable</Nullable>`.

### Testing
- Ran `dotnet build src/polaris-api-csharp.sln`, which succeeded and produced the library artifacts with `0 Warning(s)` and `0 Error(s)`.
- Ran `dotnet test src/polaris-api-csharp.sln --no-build`; tests executed but were blocked by environment configuration (missing `appsettings.Test.json` in the test output directory), producing a test run with many failures (tests depend on the configuration file) — the failures are due to the missing test configuration, not the nullable fixes.
- Changes were committed on the current branch with the message `Correct request model nullability`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c3ea2668883239fce096f3127aa4b)