### PR TITLE
Make PAPI integration test config optional

### DIFF
--- a/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
@@ -20,32 +20,61 @@ namespace Clc.Polaris.Api.Tests
     [TestCategory("Integration")]
     public class PapiClientTests
     {
-        TestSettings Settings;
+        private const string MissingIntegrationConfigurationMessage = "Integration test configuration is missing. Provide appsettings.Test.json or environment variables to run integration tests.";
+
+        TestSettings Settings = null!;
 
         protected static IConfiguration InitConfiguration()
         {
             var config = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.Test.json")
+                .AddJsonFile("appsettings.Test.json", optional: true)
                 .AddEnvironmentVariables()
                 .Build();
 
             return config;
         }
 
-        IPapiClient papi;
+        IPapiClient papi = null!;
         int bibId = 478907;
 
-        public PapiClientTests()
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            InitializeIntegrationConfiguration();
+        }
+
+        private void InitializeIntegrationConfiguration()
         {
             var config = InitConfiguration();
+            var papiSettings = config.GetSection(PapiSettings.SECTION_NAME).Get<PapiSettings>();
+            var testSettings = config.Get<TestSettings>();
 
-            var papiSettings = config.GetSection(PapiSettings.SECTION_NAME).Get<PapiSettings>()
-                ?? throw new InvalidOperationException("Missing PapiSettings configuration.");
+            if (!HasRequiredPapiSettings(papiSettings) || !HasRequiredTestSettings(testSettings))
+            {
+                Assert.Inconclusive(MissingIntegrationConfigurationMessage);
+            }
 
-            papi = new PapiClient(papiSettings);
+            papi = new PapiClient(papiSettings!);
+            Settings = testSettings!;
+        }
 
-            Settings = config.Get<TestSettings>()
-                ?? throw new InvalidOperationException("Missing test settings configuration.");
+        private static bool HasRequiredPapiSettings(PapiSettings? settings)
+        {
+            return settings != null
+                && !string.IsNullOrWhiteSpace(settings.AccessId)
+                && !string.IsNullOrWhiteSpace(settings.AccessKey)
+                && !string.IsNullOrWhiteSpace(settings.Hostname);
+        }
+
+        private static bool HasRequiredTestSettings(TestSettings? settings)
+        {
+            return settings != null
+                && settings.PatronId > 0
+                && !string.IsNullOrWhiteSpace(settings.PatronBarcode)
+                && !string.IsNullOrWhiteSpace(settings.PatronPin)
+                && !string.IsNullOrWhiteSpace(settings.FreeTextBlock)
+                && !string.IsNullOrWhiteSpace(settings.PatronListName)
+                && !string.IsNullOrWhiteSpace(settings.OrgEmail);
         }
 
         [TestMethod()]


### PR DESCRIPTION
### Motivation
- Prevent non-integration test runs from failing when `appsettings.Test.json` is not present in CI or developer environments. 
- Keep the class marked `[TestCategory("Integration")]` while ensuring missing integration configuration does not break filtered test runs.

### Description
- Load configuration with `AddJsonFile("appsettings.Test.json", optional: true)` so the test settings file is optional. 
- Remove eager integration setup from the test constructor and move initialization into an MSTest `[TestInitialize]` method that calls `InitializeIntegrationConfiguration()`. 
- Add validation helpers `HasRequiredPapiSettings` and `HasRequiredTestSettings` and call `Assert.Inconclusive(...)` with a clear message when required integration configuration is missing. 
- Use null-forgiving where appropriate to satisfy nullable warnings and preserve existing `[TestCategory("Integration")]` annotation; no real credentials or secrets were added.

### Testing
- Ran `dotnet build src/polaris-api-csharp.sln`, which succeeded. 
- Ran `dotnet test src/polaris-api-csharp.sln --no-build -v:minimal --filter "TestCategory!=Integration"`, which succeeded and reported `Passed: 95, Failed: 0` for the non-integration test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c4a6a4d188323b742c3a84133ac35)