### PR TITLE
Use local time for protected token test expirations

### DIFF
--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -516,7 +516,7 @@ namespace Clc.Polaris.Api.Tests
 
             public CapturingHttpMessageHandler(string? responseJson = null)
             {
-                _responseJson = responseJson ?? CreateProtectedTokenJson("new-token", "new-secret", DateTime.UtcNow.AddHours(1));
+                _responseJson = responseJson ?? CreateProtectedTokenJson("new-token", "new-secret", DateTime.Now.AddHours(1));
             }
 
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
@@ -116,7 +116,7 @@ namespace Clc.Polaris.Api.Tests
             {
                 AccessToken = "token-segment",
                 AccessSecret = "token-secret",
-                ExpirationDate = DateTime.UtcNow.AddHours(1)
+                ExpirationDate = DateTime.Now.AddHours(1)
             };
 
             await client.CreatePatronBlocksAsync(barcode, BlockType.FreeText, "note", userId: 888, workstationId: 999);
@@ -139,7 +139,7 @@ namespace Clc.Polaris.Api.Tests
             {
                 AccessToken = "token-segment",
                 AccessSecret = "token-secret",
-                ExpirationDate = DateTime.UtcNow.AddHours(1)
+                ExpirationDate = DateTime.Now.AddHours(1)
             };
 
             await client.Patron_GetBarcodeFromIdAsync(patronId);
@@ -181,7 +181,7 @@ namespace Clc.Polaris.Api.Tests
             {
                 AccessToken = "token-segment",
                 AccessSecret = "token-secret",
-                ExpirationDate = DateTime.UtcNow.AddHours(1)
+                ExpirationDate = DateTime.Now.AddHours(1)
             };
 
             await client.NotificationQueueGetAsync(1);

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -116,7 +116,7 @@ namespace Clc.Polaris.Api.Tests
             {
                 AccessToken = "protected-token",
                 AccessSecret = "protected-secret",
-                ExpirationDate = DateTime.UtcNow.AddHours(1)
+                ExpirationDate = DateTime.Now.AddHours(1)
             };
             var request = new PapiRestRequest(HttpMethod.Get, "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
 
@@ -189,7 +189,7 @@ namespace Clc.Polaris.Api.Tests
             {
                 AccessToken = "staff-token",
                 AccessSecret = "staff-secret",
-                ExpirationDate = DateTime.UtcNow.AddHours(1)
+                ExpirationDate = DateTime.Now.AddHours(1)
             };
 
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/apikeyvalidate");
@@ -212,7 +212,7 @@ namespace Clc.Polaris.Api.Tests
             {
                 AccessToken = "staff-token",
                 AccessSecret = "staff-secret",
-                ExpirationDate = DateTime.UtcNow.AddHours(1)
+                ExpirationDate = DateTime.Now.AddHours(1)
             };
 
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/apikeyvalidate")
@@ -237,7 +237,7 @@ namespace Clc.Polaris.Api.Tests
             {
                 AccessToken = "staff-token",
                 AccessSecret = "staff-secret",
-                ExpirationDate = DateTime.UtcNow.AddHours(1)
+                ExpirationDate = DateTime.Now.AddHours(1)
             };
 
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/apikeyvalidate");
@@ -259,7 +259,7 @@ namespace Clc.Polaris.Api.Tests
             {
                 AccessToken = "staff-token",
                 AccessSecret = "staff-secret",
-                ExpirationDate = DateTime.UtcNow.AddHours(1)
+                ExpirationDate = DateTime.Now.AddHours(1)
             };
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/apikeyvalidate");
 
@@ -386,7 +386,7 @@ namespace Clc.Polaris.Api.Tests
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
             var client = CreateClient(handler);
-            client.Token = new ProtectedToken { AccessToken = "real-token", AccessSecret = "real-secret", ExpirationDate = DateTime.UtcNow.AddHours(1) };
+            client.Token = new ProtectedToken { AccessToken = "real-token", AccessSecret = "real-secret", ExpirationDate = DateTime.Now.AddHours(1) };
 
             var response = await client.PatronSearchAsync("name=Smith", orgId: 9);
 
@@ -401,7 +401,7 @@ namespace Clc.Polaris.Api.Tests
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
             var client = CreateClient(handler);
-            client.Token = new ProtectedToken { AccessToken = "hash-token", AccessSecret = "hash-secret", ExpirationDate = DateTime.UtcNow.AddHours(1) };
+            client.Token = new ProtectedToken { AccessToken = "hash-token", AccessSecret = "hash-secret", ExpirationDate = DateTime.Now.AddHours(1) };
 
             await client.PatronSearchAsync("name=Smith", orgId: 9);
 
@@ -454,7 +454,7 @@ namespace Clc.Polaris.Api.Tests
             {
                 AccessToken = "expired-token",
                 AccessSecret = "expired-secret",
-                ExpirationDate = DateTime.UtcNow.AddHours(-1)
+                ExpirationDate = DateTime.Now.AddHours(-1)
             };
 
             var response = await client.PatronSearchAsync("name=Smith", orgId: 9);
@@ -483,7 +483,7 @@ namespace Clc.Polaris.Api.Tests
             {
                 AccessToken = "expired-token",
                 AccessSecret = "expired-secret",
-                ExpirationDate = DateTime.UtcNow.AddHours(-1)
+                ExpirationDate = DateTime.Now.AddHours(-1)
             };
 
             var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
@@ -817,7 +817,7 @@ namespace Clc.Polaris.Api.Tests
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
             var client = CreateClient(handler);
-            client.Token = new ProtectedToken { AccessToken = "token", AccessSecret = "secret", ExpirationDate = DateTime.UtcNow.AddHours(1) };
+            client.Token = new ProtectedToken { AccessToken = "token", AccessSecret = "secret", ExpirationDate = DateTime.Now.AddHours(1) };
 
             var response = await client.PatronSearchAsync("name = Smith & status: active", page: 3, pageSize: 25, sortBy: PatronSortKeys.PATNL, orgId: 9);
 


### PR DESCRIPTION
### Motivation
- Some protected-token tests used `DateTime.UtcNow` to set `ProtectedToken.ExpirationDate`, causing failures in non-UTC environments because production logic compares against local time (`DateTime.Now`).
- The change makes test token lifetimes consistent with production behavior so expired/valid token scenarios behave deterministically across time zones.

### Description
- Replaced `DateTime.UtcNow.AddHours(...)` with `DateTime.Now.AddHours(...)` for `ProtectedToken.ExpirationDate` in `RestClientMigrationCharacterizationTests.cs` to ensure tests create tokens relative to local/server time.
- Updated the same `DateTime.Now` replacements in `Methods/PapiClientUrlEncodingTests.cs` for protected-route tests and in `Methods/PapiClientTokenTests.cs` for the helper `CapturingHttpMessageHandler` default response.
- Kept production code unchanged; `PapiClient` continues to evaluate token expiration against `DateTime.Now`.

### Testing
- Ran `dotnet build src/polaris-api-csharp.sln` and the solution built successfully.
- Ran `dotnet test src/polaris-api-csharp.sln --no-build -v:minimal --filter "TestCategory!=Integration"` and all non-integration tests passed (95 passed, 0 failed).
- Ran the two previously failing tests with `dotnet test src/polaris-api-csharp.sln --no-build -v:minimal --filter "FullyQualifiedName~ProtectedTokenPathRequest_WhenAuthenticationCannotProvideValidToken_ThrowsPlaceholderExceptionBeforeProtectedRequest|FullyQualifiedName~ProtectedTokenPathRequest_WithExpiredToken_AcquiresProtectedTokenBeforePlaceholderReplacement"` and both tests passed (2 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c51fce7448323bdde9e11c67138e3)