### PR TITLE
Expose bib search convenience methods on IPapiClient

### DIFF
--- a/src/polaris-api-csharp/IPapiClient.cs
+++ b/src/polaris-api-csharp/IPapiClient.cs
@@ -40,6 +40,8 @@ namespace Clc.Polaris.Api
         Task<IRestResponse<ProtectedToken>> AuthenticateStaffUserAsync(PolarisUser staffUser, CancellationToken cancellationToken = default);
         Task<IRestResponse<BibGetResult>> BibGetAsync(int bibId, int? branchId = null, CancellationToken cancellationToken = default);
         Task<IRestResponse<BibSearchResult>> BibSearchAsync(BibSearchOptions options, CancellationToken cancellationToken = default);
+        Task<IRestResponse<BibSearchResult>> BibKeywordSearchAsync(string keyword, int? branchId = null, int page = 1, int pageSize = 10, SearchSortOptions sortBy = SearchSortOptions.MP, CancellationToken cancellationToken = default);
+        Task<IRestResponse<BibSearchResult>> BibBooleanSearchAsync(string ccl, int? branchId = null, int page = 1, int pageSize = 10, SearchSortOptions sortBy = SearchSortOptions.MP, CancellationToken cancellationToken = default);
         Task<IRestResponse<CollectionsGetResult>> CollectionsGetAsync(int? branchId = null, CancellationToken cancellationToken = default);
         Task<IRestResponse<CreatePatronBlocksResult>> CreatePatronBlocksAsync(string barcode, BlockType blockType, string blockValue, int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default);
         Task<IRestResponse<DatesClosedGetResult>> DatesClosedGetAsync(int organizationId, CancellationToken cancellationToken = default);

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -588,6 +588,50 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public async Task BibKeywordSearchAsync_CanBeCalledThroughInterfaceAndPreservesRequestShape()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            IPapiClient client = CreateClient(handler);
+
+            var response = await client.BibKeywordSearchAsync("harry potter & stone", branchId: 7, page: 3, pageSize: 20, sortBy: SearchSortOptions.TI);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
+            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/public/v1/1033/100/7/search/bibs/keyword/KW");
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/7/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=TI&page=3&bibsperpage=20", handler.LastRequest.RequestUri.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.AreEqual("harry potter & stone", query["q"]);
+            Assert.AreEqual("TI", query["sort"]);
+            Assert.AreEqual("3", query["page"]);
+            Assert.AreEqual("20", query["bibsperpage"]);
+            Assert.IsNull(handler.LastRequest.Content);
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task BibBooleanSearchAsync_CanBeCalledThroughInterfaceAndPreservesRequestShape()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            IPapiClient client = CreateClient(handler);
+
+            var response = await client.BibBooleanSearchAsync("AU=Rowling AND TI=Stone", branchId: 8, page: 4, pageSize: 25, sortBy: SearchSortOptions.PD);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
+            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/public/v1/1033/100/8/search/bibs/boolean");
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/8/search/bibs/boolean?q=AU%3DRowling%20AND%20TI%3DStone&sort=PD&page=4&bibsperpage=25", handler.LastRequest.RequestUri.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.AreEqual("AU=Rowling AND TI=Stone", query["q"]);
+            Assert.AreEqual("PD", query["sort"]);
+            Assert.AreEqual("4", query["page"]);
+            Assert.AreEqual("25", query["bibsperpage"]);
+            Assert.IsNull(handler.LastRequest.Content);
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
         public async Task BibSearchAsync_DefaultLimit_OmitsLimitAndHashesSentUri()
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");


### PR DESCRIPTION
### Motivation
- Consumers using the `IPapiClient` interface could not call the documented bib search convenience methods even though `PapiClient` implemented them.\
- Provide parity between the concrete client and the interface so DI/interface-based usage matches README/basic usage.\
- Keep the change narrow and preserve existing PAPI hashing and request behavior.\

### Description
- Add two async convenience signatures to `IPapiClient`: `Task<IRestResponse<BibSearchResult>> BibKeywordSearchAsync(string keyword, int? branchId = null, int page = 1, int pageSize = 10, SearchSortOptions sortBy = SearchSortOptions.MP, CancellationToken cancellationToken = default)` and `Task<IRestResponse<BibSearchResult>> BibBooleanSearchAsync(string ccl, int? branchId = null, int page = 1, int pageSize = 10, SearchSortOptions sortBy = SearchSortOptions.MP, CancellationToken cancellationToken = default)` in `src/polaris-api-csharp/IPapiClient.cs`.\
- Add non-integration tests to `src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs` that assign a `PapiClient` to an `IPapiClient` variable and call `BibKeywordSearchAsync` and `BibBooleanSearchAsync` through the interface.\
- Tests verify the outgoing request shape and signing: HTTP `GET`, path contains `/public/v1/1033/100/{branch}/search/bibs/keyword/KW` or `/public/v1/1033/100/{branch}/search/bibs/boolean`, query parameters `q`, `sort`, `page`, `bibsperpage` are sent, and the `Authorization` header hashes the full outgoing absolute URL.\
- No changes to PAPI hashing behavior, no sync wrappers added, and no package/version/README/migration-doc changes were made.\

### Testing
- Ran `dotnet build src/polaris-api-csharp.sln -v:minimal` and the solution built successfully.\
- Ran `dotnet test src/polaris-api-csharp.sln --no-build -v:minimal --filter "TestCategory!=Integration"` and the non-integration test suite passed (97 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c850be9ac83238da579d8183bcddd)