### PR TITLE
Add bib search convenience methods to IPapiClient

### DIFF
--- a/src/polaris-api-csharp/IPapiClient.cs
+++ b/src/polaris-api-csharp/IPapiClient.cs
@@ -40,6 +40,8 @@ namespace Clc.Polaris.Api
         Task<IRestResponse<ProtectedToken>> AuthenticateStaffUserAsync(PolarisUser staffUser, CancellationToken cancellationToken = default);
         Task<IRestResponse<BibGetResult>> BibGetAsync(int bibId, int? branchId = null, CancellationToken cancellationToken = default);
         Task<IRestResponse<BibSearchResult>> BibSearchAsync(BibSearchOptions options, CancellationToken cancellationToken = default);
+        Task<IRestResponse<BibSearchResult>> BibKeywordSearchAsync(string keyword, int? branchId = null, int page = 1, int pageSize = 10, SearchSortOptions sortBy = SearchSortOptions.MP, CancellationToken cancellationToken = default);
+        Task<IRestResponse<BibSearchResult>> BibBooleanSearchAsync(string ccl, int? branchId = null, int page = 1, int pageSize = 10, SearchSortOptions sortBy = SearchSortOptions.MP, CancellationToken cancellationToken = default);
         Task<IRestResponse<CollectionsGetResult>> CollectionsGetAsync(int? branchId = null, CancellationToken cancellationToken = default);
         Task<IRestResponse<CreatePatronBlocksResult>> CreatePatronBlocksAsync(string barcode, BlockType blockType, string blockValue, int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default);
         Task<IRestResponse<DatesClosedGetResult>> DatesClosedGetAsync(int organizationId, CancellationToken cancellationToken = default);

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -617,6 +617,23 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public async Task BibKeywordSearchAsync_ThroughInterfaceWithoutBranchId_UsesOrganizationId()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var concreteClient = CreateClient(handler);
+            concreteClient.OrganizationId = 42;
+            IPapiClient client = concreteClient;
+
+            var response = await client.BibKeywordSearchAsync("default branch search");
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(handler.LastRequest);
+            StringAssert.Contains(handler.LastRequest!.RequestUri!.AbsolutePath, "/public/v1/1033/100/42/search/bibs/keyword/KW");
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/42/search/bibs/keyword/KW?q=default%20branch%20search&sort=MP&page=1&bibsperpage=10", handler.LastRequest.RequestUri.AbsoluteUri);
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
         public async Task BibBooleanSearchAsync_ThroughInterface_RequestShapeMatchesConcreteClient()
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -588,6 +588,64 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public async Task BibKeywordSearchAsync_ThroughInterface_RequestShapeMatchesConcreteClient()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            IPapiClient client = CreateClient(handler);
+
+            var response = await client.BibKeywordSearchAsync(
+                "harry potter & stone",
+                branchId: 7,
+                page: 2,
+                pageSize: 15,
+                sortBy: SearchSortOptions.MP);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
+            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/public/v1/1033/100/7/search/bibs/keyword/KW");
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/7/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15", handler.LastRequest.RequestUri.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.AreEqual("harry potter & stone", query["q"]);
+            Assert.AreEqual("MP", query["sort"]);
+            Assert.AreEqual("2", query["page"]);
+            Assert.AreEqual("15", query["bibsperpage"]);
+            Assert.IsNull(handler.LastRequest.Content);
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task BibBooleanSearchAsync_ThroughInterface_RequestShapeMatchesConcreteClient()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            IPapiClient client = CreateClient(handler);
+
+            var response = await client.BibBooleanSearchAsync(
+                "TI=Harry Potter",
+                branchId: 8,
+                page: 3,
+                pageSize: 20,
+                sortBy: SearchSortOptions.AU);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
+            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/public/v1/1033/100/8/search/bibs/boolean");
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/8/search/bibs/boolean?q=TI%3DHarry%20Potter&sort=AU&page=3&bibsperpage=20", handler.LastRequest.RequestUri.AbsoluteUri);
+            var query = ParseQuery(handler.LastRequest.RequestUri.Query);
+            Assert.AreEqual("TI=Harry Potter", query["q"]);
+            Assert.AreEqual("AU", query["sort"]);
+            Assert.AreEqual("3", query["page"]);
+            Assert.AreEqual("20", query["bibsperpage"]);
+            Assert.IsNull(handler.LastRequest.Content);
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
         public async Task BibSearchAsync_DefaultLimit_OmitsLimitAndHashesSentUri()
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -588,7 +588,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
-        public async Task BibKeywordSearchAsync_ThroughInterface_RequestShapeMatchesConcreteClient()
+        public async Task BibKeywordSearchAsync_ThroughInterface_RequestShapeIsStable()
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
             IPapiClient client = CreateClient(handler);
@@ -620,9 +620,8 @@ namespace Clc.Polaris.Api.Tests
         public async Task BibKeywordSearchAsync_ThroughInterfaceWithoutBranchId_UsesOrganizationId()
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
-            var concreteClient = CreateClient(handler);
-            concreteClient.OrganizationId = 42;
-            IPapiClient client = concreteClient;
+            IPapiClient client = CreateClient(handler);
+            client.OrganizationId = 42;
 
             var response = await client.BibKeywordSearchAsync("default branch search");
 
@@ -634,7 +633,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
-        public async Task BibBooleanSearchAsync_ThroughInterface_RequestShapeMatchesConcreteClient()
+        public async Task BibBooleanSearchAsync_ThroughInterface_RequestShapeIsStable()
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
             IPapiClient client = CreateClient(handler);
@@ -659,6 +658,22 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNull(handler.LastRequest.Content);
             Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
             Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
+            AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task BibBooleanSearchAsync_ThroughInterfaceWithoutBranchId_UsesOrganizationId()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            IPapiClient client = CreateClient(handler);
+            client.OrganizationId = 42;
+
+            var response = await client.BibBooleanSearchAsync("TI=Default Branch");
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(handler.LastRequest);
+            StringAssert.Contains(handler.LastRequest!.RequestUri!.AbsolutePath, "/public/v1/1033/100/42/search/bibs/boolean");
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/42/search/bibs/boolean?q=TI%3DDefault%20Branch&sort=MP&page=1&bibsperpage=10", handler.LastRequest.RequestUri.AbsoluteUri);
             AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
         }
 


### PR DESCRIPTION
### Motivation

- Consumers using the `IPapiClient` interface (DI/contract-based usage) could not call the existing convenience helpers `BibKeywordSearchAsync` and `BibBooleanSearchAsync` that are implemented on `PapiClient`, causing a gap between the documented usage and the interface surface.

### Description

- Expose the two async convenience methods on the interface by adding the signatures for `BibKeywordSearchAsync(...)` and `BibBooleanSearchAsync(...)` to `src/polaris-api-csharp/IPapiClient.cs` so interface consumers can call them directly.
- Added unit tests that assign a `PapiClient` to an `IPapiClient` variable and call the convenience methods through the interface to validate outgoing request shape and behavior; tests live in `src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs` and are named `BibKeywordSearchAsync_ThroughInterface_RequestShapeMatchesConcreteClient` and `BibBooleanSearchAsync_ThroughInterface_RequestShapeMatchesConcreteClient`.
- Tests assert the request method/path/query shape and that the `Authorization` header hashes the full outgoing absolute URL (preserving existing PAPI hash behavior); no changes were made to hashing or sync wrappers.

### Testing

- Ran `dotnet build src/polaris-api-csharp.sln -v:minimal` which succeeded.
- Ran `dotnet test src/polaris-api-csharp.sln --no-build -v:minimal --filter "TestCategory!=Integration"` and all non-integration tests passed (tests added above executed and succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c850be9ac83238da579d8183bcddd)