### PR TITLE
Refine integration test scenario structure (add IntegrationScenarioSettings, improve gates, split reference/synch tests)

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -48,6 +48,11 @@ jobs:
       TestSettings__RemoteStorageBranchId: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_BRANCH_ID }}
       TestSettings__RemoteStorageStartDate: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_START_DATE }}
       TestSettings__RemoteStorageEndDate: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_END_DATE }}
+      TestSettings__RecordSetId: ${{ secrets.PAPI_TEST_RECORD_SET_ID }}
+      TestSettings__ItemRecordId: ${{ secrets.PAPI_TEST_ITEM_RECORD_ID }}
+      TestSettings__ItemBarcode: ${{ secrets.PAPI_TEST_ITEM_BARCODE }}
+      TestSettings__PatronAccountTransactionId: ${{ secrets.PAPI_TEST_PATRON_ACCOUNT_TRANSACTION_ID }}
+      TestSettings__HoldRequestId: ${{ secrets.PAPI_TEST_HOLD_REQUEST_ID }}
       IntegrationTestOptions__EnableMutatingIntegrationTests: ${{ inputs.enable_mutating_tests }}
       IntegrationTestOptions__EnableStaffProtectedTests: ${{ inputs.enable_staff_protected_tests }}
       IntegrationTestOptions__EnableScenarioDependentTests: ${{ inputs.enable_scenario_dependent_tests }}

--- a/src/polaris-api-csharpTests/Integration/ApiAuthenticationIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/ApiAuthenticationIntegrationTests.cs
@@ -56,10 +56,7 @@ public sealed class ApiAuthenticationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public void AuthenticatePatronAsync_FailedLogin_IsDisabledByDefaultToAvoidAccountLockout()
     {
-        if (!Options.EnableAuthenticationFailureTests)
-        {
-            Assert.Inconclusive("Failed-authentication tests are disabled by default because repeated bad PIN/password attempts can lock real accounts. Set IntegrationTestOptions:EnableAuthenticationFailureTests=true only for disposable credentials, then add a local test case.");
-        }
+        RequireAuthenticationFailureTestsEnabled();
 
         Assert.Inconclusive("No failed-authentication scenario is checked in. Configure disposable credentials locally before adding assertions.");
     }

--- a/src/polaris-api-csharpTests/Integration/CatalogLookupIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/CatalogLookupIntegrationTests.cs
@@ -92,17 +92,4 @@ public sealed class CatalogLookupIntegrationTests : IntegrationTestBase
 
         Assert.ThrowsException<NotImplementedException>(() => Papi.HeadingsSearchAsync(NonexistentBibId));
     }
-
-    [TestMethod]
-    public async Task Synch_BibsByIdGetAsync_WithConfiguredBib_ReturnsSynchronisationPayload()
-    {
-        RequireBibScenario();
-
-        var response = await Papi.Synch_BibsByIdGetAsync(Settings.BibId);
-        var data = PapiIntegrationAssert.HasData(response);
-
-        Assert.IsNotNull(response.Response);
-        Assert.IsTrue(response.Response!.IsSuccessStatusCode);
-        Assert.IsTrue(data.PAPIErrorCode >= 0, data.ErrorMessage?.ToString());
-    }
 }

--- a/src/polaris-api-csharpTests/Integration/IntegrationScenarioSettings.cs
+++ b/src/polaris-api-csharpTests/Integration/IntegrationScenarioSettings.cs
@@ -1,0 +1,38 @@
+namespace Clc.Polaris.Api.Tests.Integration;
+
+public sealed class IntegrationScenarioSettings
+{
+    public const string SectionName = "TestSettings";
+
+    public int PatronId { get; set; }
+    public string PatronBarcode { get; set; } = string.Empty;
+    public string PatronPin { get; set; } = string.Empty;
+    public int BibId { get; set; }
+
+    public int KnownBibId
+    {
+        get => BibId;
+        set => BibId = value;
+    }
+
+    public int BranchId { get; set; }
+    public int OrganizationId { get; set; }
+    public int WorkstationId { get; set; }
+    public int UserId { get; set; }
+    public string OrgEmail { get; set; } = string.Empty;
+    public string PatronListName { get; set; } = string.Empty;
+    public string FreeTextBlock { get; set; } = string.Empty;
+    public int RemoteStorageBranchId { get; set; }
+    public string RemoteStorageStartDate { get; set; } = string.Empty;
+    public string RemoteStorageEndDate { get; set; } = string.Empty;
+    public int RecordSetId { get; set; }
+    public int ItemRecordId { get; set; }
+    public string ItemBarcode { get; set; } = string.Empty;
+    public int PatronAccountTransactionId { get; set; }
+    public int HoldRequestId { get; set; }
+
+    public int EffectiveOrganizationId(int configuredOrganizationId) => OrganizationId > 0 ? OrganizationId : configuredOrganizationId;
+    public int EffectiveBranchId(int configuredOrganizationId) => BranchId > 0 ? BranchId : configuredOrganizationId;
+    public int EffectiveWorkstationId(int configuredWorkstationId) => WorkstationId > 0 ? WorkstationId : configuredWorkstationId;
+    public int EffectiveUserId(int configuredUserId) => UserId > 0 ? UserId : configuredUserId;
+}

--- a/src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs
+++ b/src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs
@@ -54,14 +54,14 @@ public abstract class IntegrationTestBase
     {
         RequirePapiConfiguration();
         InconclusiveIfMissing(MissingScenarioSettings(
-            (Settings.PatronBarcode, "TestSettings:PatronBarcode"),
-            (Settings.PatronPin, "TestSettings:PatronPin")));
+            (Settings.PatronBarcode, SettingName(nameof(IntegrationScenarioSettings.PatronBarcode))),
+            (Settings.PatronPin, SettingName(nameof(IntegrationScenarioSettings.PatronPin)))));
     }
 
     protected void RequirePatronId()
     {
         RequirePapiConfiguration();
-        RequirePositiveScenarioId(Settings.PatronId, "TestSettings:PatronId", "a patron record that can be safely read by the integration suite");
+        RequirePositiveScenarioId(Settings.PatronId, SettingName(nameof(IntegrationScenarioSettings.PatronId)), "a patron record that can be safely read by the integration suite");
     }
 
     protected void RequireBibId() => RequireBibScenario();
@@ -69,7 +69,7 @@ public abstract class IntegrationTestBase
     protected void RequireBibScenario()
     {
         RequirePapiConfiguration();
-        RequirePositiveScenarioId(Settings.BibId, "TestSettings:BibId", "a bibliographic record that can be safely read by the integration suite");
+        RequirePositiveScenarioId(Settings.BibId, SettingName(nameof(IntegrationScenarioSettings.BibId)), "a bibliographic record that can be safely read by the integration suite");
     }
 
     protected void RequireBranchId() => RequireBranchScenario();
@@ -77,46 +77,46 @@ public abstract class IntegrationTestBase
     protected void RequireBranchScenario()
     {
         RequirePapiConfiguration();
-        RequirePositiveScenarioId(Settings.BranchId, "TestSettings:BranchId", "a branch/organization ID that can be safely read by the integration suite");
+        RequirePositiveScenarioId(Settings.BranchId, SettingName(nameof(IntegrationScenarioSettings.BranchId)), "a branch/organization ID that can be safely read by the integration suite");
     }
 
     protected void RequireRecordSetId()
     {
         RequirePapiConfiguration();
-        RequirePositiveScenarioId(Settings.RecordSetId, "TestSettings:RecordSetId", "a real record set intended for scenario-dependent assertions");
+        RequirePositiveScenarioId(Settings.RecordSetId, SettingName(nameof(IntegrationScenarioSettings.RecordSetId)), "a real record set intended for scenario-dependent assertions");
     }
 
     protected void RequireItemRecordId()
     {
         RequirePapiConfiguration();
-        RequirePositiveScenarioId(Settings.ItemRecordId, "TestSettings:ItemRecordId", "an item record intended for scenario-dependent assertions");
+        RequirePositiveScenarioId(Settings.ItemRecordId, SettingName(nameof(IntegrationScenarioSettings.ItemRecordId)), "an item record intended for scenario-dependent assertions");
     }
 
     protected void RequireItemBarcode()
     {
         RequirePapiConfiguration();
-        InconclusiveIfMissing(MissingScenarioSettings((Settings.ItemBarcode, "TestSettings:ItemBarcode")));
+        InconclusiveIfMissing(MissingScenarioSettings((Settings.ItemBarcode, SettingName(nameof(IntegrationScenarioSettings.ItemBarcode)))));
     }
 
     protected void RequirePatronAccountTransactionId()
     {
         RequirePapiConfiguration();
-        RequirePositiveScenarioId(Settings.PatronAccountTransactionId, "TestSettings:PatronAccountTransactionId", "a patron account transaction intended for scenario-dependent assertions");
+        RequirePositiveScenarioId(Settings.PatronAccountTransactionId, SettingName(nameof(IntegrationScenarioSettings.PatronAccountTransactionId)), "a patron account transaction intended for scenario-dependent assertions");
     }
 
     protected void RequireHoldRequestId()
     {
         RequirePapiConfiguration();
-        RequirePositiveScenarioId(Settings.HoldRequestId, "TestSettings:HoldRequestId", "a hold request intended for scenario-dependent assertions");
+        RequirePositiveScenarioId(Settings.HoldRequestId, SettingName(nameof(IntegrationScenarioSettings.HoldRequestId)), "a hold request intended for scenario-dependent assertions");
     }
 
     protected void RequireRemoteStorageScenario()
     {
         RequirePapiConfiguration();
-        RequirePositiveScenarioId(Settings.RemoteStorageBranchId, "TestSettings:RemoteStorageBranchId", "a branch with remote-storage activity for the configured date range");
+        RequirePositiveScenarioId(Settings.RemoteStorageBranchId, SettingName(nameof(IntegrationScenarioSettings.RemoteStorageBranchId)), "a branch with remote-storage activity for the configured date range");
         InconclusiveIfMissing(MissingScenarioSettings(
-            (Settings.RemoteStorageStartDate, "TestSettings:RemoteStorageStartDate"),
-            (Settings.RemoteStorageEndDate, "TestSettings:RemoteStorageEndDate")));
+            (Settings.RemoteStorageStartDate, SettingName(nameof(IntegrationScenarioSettings.RemoteStorageStartDate))),
+            (Settings.RemoteStorageEndDate, SettingName(nameof(IntegrationScenarioSettings.RemoteStorageEndDate)))));
     }
 
     protected void RequireStaffProtectedTestsEnabled()
@@ -175,13 +175,15 @@ public abstract class IntegrationTestBase
     protected void RequireOrgEmailScenario()
     {
         RequirePapiConfiguration();
-        InconclusiveIfMissing(MissingScenarioSettings((Settings.OrgEmail, "TestSettings:OrgEmail")));
+        InconclusiveIfMissing(MissingScenarioSettings((Settings.OrgEmail, SettingName(nameof(IntegrationScenarioSettings.OrgEmail)))));
     }
 
     protected int BranchIdOrConfiguredOrganizationId => Settings.EffectiveBranchId(PapiSettings.OrganizationId);
     protected int OrganizationIdOrConfigured => Settings.EffectiveOrganizationId(PapiSettings.OrganizationId);
     protected int UserIdOrConfigured => Settings.EffectiveUserId(PapiSettings.UserId);
     protected int WorkstationIdOrConfigured => Settings.EffectiveWorkstationId(PapiSettings.WorkstationId);
+
+    private static string SettingName(string propertyName) => $"{IntegrationScenarioSettings.SectionName}:{propertyName}";
 
     private static void RequirePositiveScenarioId(int value, string settingName, string reason)
     {

--- a/src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs
+++ b/src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs
@@ -18,7 +18,7 @@ public abstract class IntegrationTestBase
 
     protected IPapiClient Papi { get; private set; } = null!;
     protected PapiSettings PapiSettings { get; private set; } = null!;
-    protected TestSettings Settings { get; private set; } = null!;
+    protected IntegrationScenarioSettings Settings { get; private set; } = null!;
     protected IntegrationTestOptions Options { get; private set; } = null!;
 
     [TestInitialize]
@@ -30,7 +30,7 @@ public abstract class IntegrationTestBase
             .Build();
 
         PapiSettings = config.GetSection(PapiSettings.SECTION_NAME).Get<PapiSettings>() ?? new PapiSettings();
-        Settings = config.GetSection(TestSettings.SECTION_NAME).Get<TestSettings>() ?? new TestSettings();
+        Settings = config.GetSection(IntegrationScenarioSettings.SectionName).Get<IntegrationScenarioSettings>() ?? new IntegrationScenarioSettings();
         Options = config.GetSection(nameof(IntegrationTestOptions)).Get<IntegrationTestOptions>() ?? new IntegrationTestOptions();
 
         Papi = new PapiClient(PapiSettings);
@@ -53,42 +53,70 @@ public abstract class IntegrationTestBase
     protected void RequirePatronCredentials()
     {
         RequirePapiConfiguration();
-
-        var missing = new List<string>();
-        if (!HasValue(Settings.PatronBarcode) || IsPlaceholder(Settings.PatronBarcode)) missing.Add("TestSettings:PatronBarcode");
-        if (!HasValue(Settings.PatronPin) || IsPlaceholder(Settings.PatronPin)) missing.Add("TestSettings:PatronPin");
-
-        InconclusiveIfMissing(missing);
+        InconclusiveIfMissing(MissingScenarioSettings(
+            (Settings.PatronBarcode, "TestSettings:PatronBarcode"),
+            (Settings.PatronPin, "TestSettings:PatronPin")));
     }
 
     protected void RequirePatronId()
     {
         RequirePapiConfiguration();
-
-        if (Settings.PatronId <= 0)
-        {
-            Assert.Inconclusive($"{MissingConfigurationMessage} Missing setting: TestSettings:PatronId.");
-        }
+        RequirePositiveScenarioId(Settings.PatronId, "TestSettings:PatronId", "a patron record that can be safely read by the integration suite");
     }
+
+    protected void RequireBibId() => RequireBibScenario();
 
     protected void RequireBibScenario()
     {
         RequirePapiConfiguration();
-
-        if (Settings.BibId <= 0)
-        {
-            Assert.Inconclusive($"Scenario data required: set TestSettings:KnownBibId to a bibliographic record that can be safely read.");
-        }
+        RequirePositiveScenarioId(Settings.BibId, "TestSettings:BibId", "a bibliographic record that can be safely read by the integration suite");
     }
+
+    protected void RequireBranchId() => RequireBranchScenario();
 
     protected void RequireBranchScenario()
     {
         RequirePapiConfiguration();
+        RequirePositiveScenarioId(Settings.BranchId, "TestSettings:BranchId", "a branch/organization ID that can be safely read by the integration suite");
+    }
 
-        if (Settings.BranchId <= 0)
-        {
-            Assert.Inconclusive($"Scenario data required: set TestSettings:BranchId to a branch/organization ID that can be safely read.");
-        }
+    protected void RequireRecordSetId()
+    {
+        RequirePapiConfiguration();
+        RequirePositiveScenarioId(Settings.RecordSetId, "TestSettings:RecordSetId", "a real record set intended for scenario-dependent assertions");
+    }
+
+    protected void RequireItemRecordId()
+    {
+        RequirePapiConfiguration();
+        RequirePositiveScenarioId(Settings.ItemRecordId, "TestSettings:ItemRecordId", "an item record intended for scenario-dependent assertions");
+    }
+
+    protected void RequireItemBarcode()
+    {
+        RequirePapiConfiguration();
+        InconclusiveIfMissing(MissingScenarioSettings((Settings.ItemBarcode, "TestSettings:ItemBarcode")));
+    }
+
+    protected void RequirePatronAccountTransactionId()
+    {
+        RequirePapiConfiguration();
+        RequirePositiveScenarioId(Settings.PatronAccountTransactionId, "TestSettings:PatronAccountTransactionId", "a patron account transaction intended for scenario-dependent assertions");
+    }
+
+    protected void RequireHoldRequestId()
+    {
+        RequirePapiConfiguration();
+        RequirePositiveScenarioId(Settings.HoldRequestId, "TestSettings:HoldRequestId", "a hold request intended for scenario-dependent assertions");
+    }
+
+    protected void RequireRemoteStorageScenario()
+    {
+        RequirePapiConfiguration();
+        RequirePositiveScenarioId(Settings.RemoteStorageBranchId, "TestSettings:RemoteStorageBranchId", "a branch with remote-storage activity for the configured date range");
+        InconclusiveIfMissing(MissingScenarioSettings(
+            (Settings.RemoteStorageStartDate, "TestSettings:RemoteStorageStartDate"),
+            (Settings.RemoteStorageEndDate, "TestSettings:RemoteStorageEndDate")));
     }
 
     protected void RequireStaffProtectedTestsEnabled()
@@ -130,24 +158,44 @@ public abstract class IntegrationTestBase
     {
         if (!Options.EnableScenarioDependentTests)
         {
-            Assert.Inconclusive($"{methodName} requires scenario data and is disabled by default. Required settings: {requiredSettings}. Intended assertions: {assertionStrategy}.");
+            Assert.Inconclusive($"{methodName} requires scenario data and is disabled by default. Reason: the endpoint depends on local fixture state that cannot be safely inferred. Required settings: {requiredSettings}. Intended assertion strategy: {assertionStrategy}.");
+        }
+    }
+
+    protected void RequireAuthenticationFailureTestsEnabled()
+    {
+        RequirePapiConfiguration();
+
+        if (!Options.EnableAuthenticationFailureTests)
+        {
+            Assert.Inconclusive("Authentication-failure integration tests are disabled. Set IntegrationTestOptions:EnableAuthenticationFailureTests=true only with disposable credentials where failed login attempts are safe.");
         }
     }
 
     protected void RequireOrgEmailScenario()
     {
         RequirePapiConfiguration();
+        InconclusiveIfMissing(MissingScenarioSettings((Settings.OrgEmail, "TestSettings:OrgEmail")));
+    }
 
-        if (!HasValue(Settings.OrgEmail) || IsPlaceholder(Settings.OrgEmail))
+    protected int BranchIdOrConfiguredOrganizationId => Settings.EffectiveBranchId(PapiSettings.OrganizationId);
+    protected int OrganizationIdOrConfigured => Settings.EffectiveOrganizationId(PapiSettings.OrganizationId);
+    protected int UserIdOrConfigured => Settings.EffectiveUserId(PapiSettings.UserId);
+    protected int WorkstationIdOrConfigured => Settings.EffectiveWorkstationId(PapiSettings.WorkstationId);
+
+    private static void RequirePositiveScenarioId(int value, string settingName, string reason)
+    {
+        if (value <= 0)
         {
-            Assert.Inconclusive("Scenario data required: set TestSettings:OrgEmail to the expected ORGEMAIL System Administration value for the configured organization.");
+            Assert.Inconclusive($"Scenario data required: set {settingName} to {reason}.");
         }
     }
 
-    protected int BranchIdOrConfiguredOrganizationId => Settings.BranchId > 0 ? Settings.BranchId : PapiSettings.OrganizationId;
-    protected int OrganizationIdOrConfigured => Settings.OrganizationId > 0 ? Settings.OrganizationId : PapiSettings.OrganizationId;
-    protected int UserIdOrConfigured => Settings.UserId > 0 ? Settings.UserId : PapiSettings.UserId;
-    protected int WorkstationIdOrConfigured => Settings.WorkstationId > 0 ? Settings.WorkstationId : PapiSettings.WorkstationId;
+    private static IReadOnlyCollection<string> MissingScenarioSettings(params (string? Value, string SettingName)[] settings) =>
+        settings
+            .Where(setting => !HasValue(setting.Value) || IsPlaceholder(setting.Value))
+            .Select(setting => setting.SettingName)
+            .ToList();
 
     private static void InconclusiveIfMissing(IReadOnlyCollection<string> missing)
     {
@@ -162,5 +210,9 @@ public abstract class IntegrationTestBase
     private static bool IsPlaceholder(string? value) =>
         value?.Contains("REPLACE_WITH_", StringComparison.OrdinalIgnoreCase) == true ||
         string.Equals(value, "https://example.org", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(value, "test@example.org", StringComparison.OrdinalIgnoreCase);
+        string.Equals(value, "http://example.org", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "https://example.com", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "http://example.com", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "test@example.org", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "test@example.com", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/polaris-api-csharpTests/Integration/PapiIntegrationAssert.cs
+++ b/src/polaris-api-csharpTests/Integration/PapiIntegrationAssert.cs
@@ -26,7 +26,15 @@ internal static class PapiIntegrationAssert
     {
         var data = HasPapiData(response);
         var errorCode = GetPapiErrorCode(data);
-        Assert.AreEqual(0, errorCode, $"Expected PAPI success but received {errorCode}: {GetErrorMessage(data)}");
+        Assert.IsTrue(errorCode >= 0, $"Expected PAPI success/no error but received {errorCode}: {GetErrorMessage(data)}");
+        return data;
+    }
+
+    public static T ExactZeroSuccess<T>(IRestResponse<T> response)
+    {
+        var data = HasPapiData(response);
+        var errorCode = GetPapiErrorCode(data);
+        Assert.AreEqual(0, errorCode, $"Expected PAPIErrorCode 0 but received {errorCode}: {GetErrorMessage(data)}");
         return data;
     }
 
@@ -41,7 +49,9 @@ internal static class PapiIntegrationAssert
     public static void RowCountMatchesPapiCode<T>(IRestResponse<T> response, int rowCount)
     {
         var data = HasPapiData(response);
-        Assert.AreEqual(rowCount, GetPapiErrorCode(data), "For list endpoints, the Polaris guide documents the PAPIErrorCode as the returned row count on success.");
+        var errorCode = GetPapiErrorCode(data);
+        Assert.IsTrue(errorCode >= 0, $"Expected non-negative row-count PAPI code but received {errorCode}: {GetErrorMessage(data)}");
+        Assert.AreEqual(rowCount, errorCode, "For list endpoints, the Polaris guide documents the PAPIErrorCode as the returned row count on success.");
     }
 
     public static void RequestUriContains<T>(IRestResponse<T> response, string expectedSegment)

--- a/src/polaris-api-csharpTests/Integration/PatronMutationIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronMutationIntegrationTests.cs
@@ -102,7 +102,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
         RequireScenarioDependentTestsEnabled(
             nameof(Papi.PatronRegistrationCreateAsync),
             "a complete PatronRegistrationParams fixture for a disposable patron registration profile",
-            "create a disposable patron, assert PAPIErrorCode=0 and returned patron id/barcode, then clean up manually if the site supports it");
+            "create a disposable patron, assert a non-negative PAPIErrorCode and returned patron id/barcode, then clean up manually if the site supports it");
     }
 
     [TestMethod]
@@ -111,7 +111,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
         RequireScenarioDependentTestsEnabled(
             nameof(Papi.PatronRegistrationCreateV2Async),
             "a complete PatronRegistrationData fixture for a disposable patron registration profile",
-            "create a disposable patron with the v2 payload and assert PAPIErrorCode=0 plus returned patron id/barcode");
+            "create a disposable patron with the v2 payload and assert a non-negative PAPIErrorCode plus returned patron id/barcode");
     }
 
     [TestMethod]
@@ -140,8 +140,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
         RequireMutatingTestsEnabled();
 
         var response = await Papi.UpdatePatronNotesDataAsync(Settings.PatronBarcode, nonBlockingNote: "PAPI integration test note", updateMode: UpdateNoteMode.Prepend, workstationId: WorkstationIdOrConfigured);
-        var data = PapiIntegrationAssert.HasPapiData(response);
 
-        Assert.IsTrue(data.PAPIErrorCode == 0 || data.PAPIErrorCode < 0, data.ErrorMessage);
+        PapiIntegrationAssert.Success(response);
     }
 }

--- a/src/polaris-api-csharpTests/Integration/PatronReadIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronReadIntegrationTests.cs
@@ -54,17 +54,6 @@ public sealed class PatronReadIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public async Task PatronCodesGetAsync_ReturnsConfiguredCodes()
-    {
-        RequirePapiConfiguration();
-
-        var response = await Papi.PatronCodesGetAsync();
-        var data = PapiIntegrationAssert.Success(response);
-
-        Assert.IsTrue(data.PatronCodesRows.Any());
-    }
-
-    [TestMethod]
     public async Task PatronHoldRequestsGetAsync_WithConfiguredPatron_ReturnsSuccessShape()
     {
         RequirePatronCredentials();

--- a/src/polaris-api-csharpTests/Integration/ReferenceDataIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/ReferenceDataIntegrationTests.cs
@@ -4,7 +4,7 @@ namespace Clc.Polaris.Api.Tests.Integration;
 
 [TestClass]
 [TestCategory("Integration")]
-public sealed class CollectionsAndLookupIntegrationTests : IntegrationTestBase
+public sealed class ReferenceDataIntegrationTests : IntegrationTestBase
 {
     [TestMethod]
     public async Task CollectionsGetAsync_ReturnsRowsAndRowCountCode()
@@ -81,6 +81,17 @@ public sealed class CollectionsAndLookupIntegrationTests : IntegrationTestBase
         var data = PapiIntegrationAssert.HasPapiData(response);
 
         PapiIntegrationAssert.RowCountMatchesPapiCode(response, data.OrganizationsGetRows.Count);
+    }
+
+    [TestMethod]
+    public async Task PatronCodesGetAsync_ReturnsConfiguredCodes()
+    {
+        RequirePapiConfiguration();
+
+        var response = await Papi.PatronCodesGetAsync();
+        var data = PapiIntegrationAssert.HasPapiData(response);
+
+        Assert.IsTrue(data.PatronCodesRows.Any());
     }
 
     [TestMethod]

--- a/src/polaris-api-csharpTests/Integration/StaffProtectedAndRecordSetIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/StaffProtectedAndRecordSetIntegrationTests.cs
@@ -99,10 +99,7 @@ public sealed class StaffProtectedAndRecordSetIntegrationTests : IntegrationTest
             "TestSettings:RemoteStorageBranchId, TestSettings:RemoteStorageStartDate, and TestSettings:RemoteStorageEndDate for a branch/date range with remote-storage activity",
             "call RemoteStorageItemsGetAsync and assert PAPIErrorCode equals the deserialized row count");
 
-        if (Settings.RemoteStorageBranchId <= 0 || string.IsNullOrWhiteSpace(Settings.RemoteStorageStartDate) || string.IsNullOrWhiteSpace(Settings.RemoteStorageEndDate))
-        {
-            Assert.Inconclusive("Remote storage scenario settings are incomplete.");
-        }
+        RequireRemoteStorageScenario();
 
         var response = await Papi.RemoteStorageItemsGetAsync(Settings.RemoteStorageBranchId, Settings.RemoteStorageStartDate, Settings.RemoteStorageEndDate, 10, 1);
         var data = PapiIntegrationAssert.HasPapiData(response);

--- a/src/polaris-api-csharpTests/Integration/SynchIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/SynchIntegrationTests.cs
@@ -1,0 +1,21 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Clc.Polaris.Api.Tests.Integration;
+
+[TestClass]
+[TestCategory("Integration")]
+public sealed class SynchIntegrationTests : IntegrationTestBase
+{
+    [TestMethod]
+    public async Task Synch_BibsByIdGetAsync_WithConfiguredBib_ReturnsSynchronisationPayload()
+    {
+        RequireBibScenario();
+
+        var response = await Papi.Synch_BibsByIdGetAsync(Settings.BibId);
+        var data = PapiIntegrationAssert.HasData(response);
+
+        Assert.IsNotNull(response.Response);
+        Assert.IsTrue(response.Response!.IsSuccessStatusCode);
+        Assert.IsTrue(data.PAPIErrorCode >= 0, data.ErrorMessage?.ToString());
+    }
+}

--- a/src/polaris-api-csharpTests/README.md
+++ b/src/polaris-api-csharpTests/README.md
@@ -32,7 +32,7 @@ Copy the example file and replace placeholders with values for a disposable/safe
 cp src/polaris-api-csharpTests/appsettings.Test.example.json src/polaris-api-csharpTests/appsettings.Test.json
 ```
 
-`appsettings.Test.json` is intentionally not committed. The test project copies it to the output directory only when the file exists.
+`appsettings.Test.json` is intentionally not committed. The test project copies it to the output directory only when the file exists. Integration-only fixture values are bound to `IntegrationScenarioSettings` from the existing `TestSettings` section so older local configuration files and environment-variable names continue to work.
 
 ## Environment variables
 
@@ -61,6 +61,11 @@ The integration fixture also loads environment variables using standard .NET con
 - `TestSettings__RemoteStorageBranchId`
 - `TestSettings__RemoteStorageStartDate`
 - `TestSettings__RemoteStorageEndDate`
+- `TestSettings__RecordSetId`
+- `TestSettings__ItemRecordId`
+- `TestSettings__ItemBarcode`
+- `TestSettings__PatronAccountTransactionId`
+- `TestSettings__HoldRequestId`
 - `IntegrationTestOptions__EnableMutatingIntegrationTests`
 - `IntegrationTestOptions__EnableStaffProtectedTests`
 - `IntegrationTestOptions__EnableScenarioDependentTests`
@@ -81,6 +86,7 @@ Additional success-path scenarios require:
 - Staff/protected endpoints: `PapiSettings:PolarisOverrideAccount:*` plus `IntegrationTestOptions:EnableStaffProtectedTests=true`
 - `SA_GetValueByOrgAsync`: `TestSettings:OrgEmail` matching the configured organization
 - Remote storage: `TestSettings:RemoteStorageBranchId`, `RemoteStorageStartDate`, and `RemoteStorageEndDate`, plus scenario-dependent tests enabled
+- Optional scenario fixtures for local extensions: `TestSettings:RecordSetId`, `ItemRecordId`, `ItemBarcode`, `PatronAccountTransactionId`, and `HoldRequestId`
 
 Do not use production patrons/items unless the site owner has explicitly approved the tests. Prefer disposable patrons, fixture records, and non-production PAPI instances.
 
@@ -106,7 +112,7 @@ Record-set tests use nonexistent record-set IDs and assert documented negative `
 
 ## Scenario-dependent placeholders
 
-Some client methods require real local data that cannot be safely invented, such as renewable checked-out items, complete patron registration payloads, or remote-storage activity windows. The suite includes inconclusive placeholder tests documenting the method name, required fixture settings, and intended assertion strategy. Enable them only after adding local fixture data:
+Some client methods require real local data that cannot be safely invented, such as renewable checked-out items, complete patron registration payloads, or remote-storage activity windows. The suite includes inconclusive placeholder tests documenting the method name, why scenario data is required, the required fixture settings, and the intended assertion strategy. Enable them only after adding local fixture data:
 
 ```bash
 IntegrationTestOptions__EnableScenarioDependentTests=true
@@ -135,9 +141,10 @@ The guide was used selectively to confirm endpoint routes, response shapes, row-
 | Endpoint group | Success tests | Known-error reachability tests | Mutating tests gated by config | Placeholders requiring scenario data |
 | --- | --- | --- | --- | --- |
 | API/version/authentication | API key validation, API version, patron auth, staff auth when enabled | None by default | None | Failed-auth testing is a placeholder because account lockout is a risk |
-| Bibliographic/catalog lookup | Bib get, branch-specific bib get, keyword/boolean search, holdings, synch bibs by ID | None | None | `HeadingsSearchAsync` remains a client `NotImplementedException` check |
-| Collections/material/status lookup | Collections, dates closed, item statuses, limit filters, MARC types, material types, organizations, pickup branches, shelf locations | None | None | None |
-| Patron reads | validate, barcode-from-id, basic data, blocks, codes, hold/ILL/items out, messages, preferences, reading history, renew blocks, saved searches, patron search | None | None | None |
+| Bibliographic/catalog lookup | Bib get, branch-specific bib get, keyword/boolean search, holdings | None | None | `HeadingsSearchAsync` remains a client `NotImplementedException` check |
+| Reference data lookup | Collections, dates closed, item statuses, limit filters, MARC types, material types, organizations, patron codes, pickup branches, shelf locations | None | None | None |
+| Synch | synch bibs by ID | None | None | None |
+| Patron reads | validate, barcode-from-id, basic data, blocks, hold/ILL/items out, messages, preferences, reading history, renew blocks, saved searches, patron search | None | None | None |
 | Patron account/title lists | account get, title lists get | nonexistent charge/payment/title-list IDs | create/delete title list, create credit, deposit credit | None |
 | Hold requests/circulation | hold request list | nonexistent hold request, bib, request GUID, pickup branch, item renewal IDs | item barcode update is additionally gated because the endpoint mutates item data | renew-all requires a patron with renewable checked-out items |
 | Patron mutations/messages | None by default | nonexistent patron message, reading-history title, notification update IDs; unsafe username update asserts unauthorized | patron blocks, no-op patron update, notes update | patron registration v1/v2 require complete disposable-registration fixtures |

--- a/src/polaris-api-csharpTests/README.md
+++ b/src/polaris-api-csharpTests/README.md
@@ -120,9 +120,9 @@ IntegrationTestOptions__EnableScenarioDependentTests=true
 
 ## Known-error reachability tests
 
-PAPI often returns HTTP 200 with a negative `PAPIErrorCode` for domain-level failures. The integration tests intentionally prefer stable nonexistent IDs over dangerous repeated bad credentials. For example, invalid hold request IDs, bibliographic IDs, item IDs, transaction IDs, and record-set IDs exercise the route, authentication, deserialization, and documented PAPI error-code behavior without relying on fragile success state.
+PAPI often returns HTTP 200 with a `PAPIErrorCode` carrying endpoint-level status. Negative `PAPIErrorCode` values represent PAPI/domain errors. Zero and positive values are no-error success codes; positive values commonly represent rows returned or rows affected. The integration success helper therefore treats any non-negative `PAPIErrorCode` as success, and list/read tests keep stronger row-count assertions where the response collection has stable row-count semantics.
 
-The tests assert exact `PAPIErrorCode` values only when the Polaris API Reference Guide 8.0 documents the code or the previous integration suite already used that stable code. They avoid asserting exact `ErrorMessage` text unless it is needed and stable.
+The integration tests intentionally prefer stable nonexistent IDs over dangerous repeated bad credentials. For example, invalid hold request IDs, bibliographic IDs, item IDs, transaction IDs, and record-set IDs exercise the route, authentication, deserialization, and documented PAPI error-code behavior without relying on fragile success state. Known-error reachability tests still assert exact negative `PAPIErrorCode` values only when the Polaris API Reference Guide 8.0 documents the code or the previous integration suite already used that stable code. They avoid asserting exact `ErrorMessage` text unless it is needed and stable.
 
 ## Failed authentication tests
 

--- a/src/polaris-api-csharpTests/TestSettings.cs
+++ b/src/polaris-api-csharpTests/TestSettings.cs
@@ -1,27 +1,7 @@
 namespace Clc.Polaris.Api
 {
-    public class TestSettings
+    public static class TestSettings
     {
         public const string SECTION_NAME = "TestSettings";
-
-        public int PatronId { get; set; }
-        public string PatronBarcode { get; set; } = string.Empty;
-        public string PatronPin { get; set; } = string.Empty;
-        public int BibId { get; set; }
-        public int KnownBibId
-        {
-            get => BibId;
-            set => BibId = value;
-        }
-        public int BranchId { get; set; }
-        public int OrganizationId { get; set; }
-        public int WorkstationId { get; set; }
-        public int UserId { get; set; }
-        public string OrgEmail { get; set; } = string.Empty;
-        public string PatronListName { get; set; } = string.Empty;
-        public string FreeTextBlock { get; set; } = string.Empty;
-        public int RemoteStorageBranchId { get; set; }
-        public string RemoteStorageStartDate { get; set; } = string.Empty;
-        public string RemoteStorageEndDate { get; set; } = string.Empty;
     }
 }

--- a/src/polaris-api-csharpTests/TestSettings.cs
+++ b/src/polaris-api-csharpTests/TestSettings.cs
@@ -1,7 +1,0 @@
-namespace Clc.Polaris.Api
-{
-    public static class TestSettings
-    {
-        public const string SECTION_NAME = "TestSettings";
-    }
-}

--- a/src/polaris-api-csharpTests/appsettings.Test.example.json
+++ b/src/polaris-api-csharpTests/appsettings.Test.example.json
@@ -26,7 +26,12 @@
     "FreeTextBlock": "PAPI integration test block",
     "RemoteStorageBranchId": 0,
     "RemoteStorageStartDate": "",
-    "RemoteStorageEndDate": ""
+    "RemoteStorageEndDate": "",
+    "RecordSetId": 0,
+    "ItemRecordId": 0,
+    "ItemBarcode": "REPLACE_WITH_TEST_ITEM_BARCODE",
+    "PatronAccountTransactionId": 0,
+    "HoldRequestId": 0
   },
   "IntegrationTestOptions": {
     "EnableMutatingIntegrationTests": false,


### PR DESCRIPTION
### Motivation

- Build on PR #98’s integration-test suite by selectively carrying forward the best maintainability ideas from PR #99 without replacing the chosen implementation.
- Keep integration tests opt-in, fixture-safe, and easy to configure while improving scenario-data organization and test grouping.
- Correct PAPI success assertion semantics so positive `PAPIErrorCode` values are treated as successful row-count/rows-affected responses rather than failures.

### Description

- Added `IntegrationScenarioSettings` as the integration-only fixture model, bound from the existing `TestSettings` configuration section so existing local JSON files and `TestSettings__...` environment variables continue to work.
- Removed the old `TestSettings` class and made `IntegrationScenarioSettings.SectionName` the single source of truth for the `"TestSettings"` section name.
- Expanded integration fixture gates in `IntegrationTestBase` with focused helpers for patron, bib, branch, record set, item, account transaction, hold request, remote-storage, staff-protected, mutating, scenario-dependent, and authentication-failure test requirements.
- Improved missing-scenario messages so inconclusive tests explain the required setting, why scenario data is needed, and the intended assertion strategy.
- Split reference/lookup coverage into `ReferenceDataIntegrationTests` and moved synch coverage into `SynchIntegrationTests` for clearer organization.
- Updated `appsettings.Test.example.json`, the manual integration-test workflow, and the test README with new optional scenario fields and environment-variable names.
- Fixed `PapiIntegrationAssert.Success(...)` so general PAPI success means `PAPIErrorCode >= 0`.
- Added `PapiIntegrationAssert.ExactZeroSuccess(...)` for endpoints that intentionally require `PAPIErrorCode == 0`.
- Strengthened `RowCountMatchesPapiCode(...)` so row-count endpoints assert both non-negative PAPI status and equality between `PAPIErrorCode` and the returned row count.
- Updated documentation to clarify that negative `PAPIErrorCode` values are errors, while zero and positive values are successful responses.

### Testing

- Ran `dotnet restore src/polaris-api-csharp.sln` successfully.
- Ran `dotnet build src/polaris-api-csharp.sln --configuration Release -warnaserror` successfully.
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --configuration Release --filter "TestCategory!=Integration"` successfully; 99 tests passed.
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --configuration Release --filter "TestCategory=Integration"` without live config; integration tests skipped/inconclusive cleanly with no null-reference or config-binding failures.