### PR TITLE
Harden integration test mutation gates

### DIFF
--- a/src/polaris-api-csharpTests/Integration/HoldAndCirculationIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/HoldAndCirculationIntegrationTests.cs
@@ -8,55 +8,54 @@ namespace Clc.Polaris.Api.Tests.Integration;
 public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
 {
     [TestMethod]
-    public async Task HoldRequestCancelAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void HoldRequestCancelAsync_RequiresDisposableHoldScenarioAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.HoldRequestCancelAsync(Settings.PatronBarcode, NonexistentRequestId, Settings.PatronPin, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4201);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestCancelAsync),
+            "cancelling a hold request mutates patron hold state and must not target a hard-coded request id that might exist",
+            "a disposable patron barcode/PIN and a disposable hold request id created specifically for cancellation",
+            "enable mutating tests, cancel only the disposable hold request, and assert the documented PAPIErrorCode without deleting pre-existing patron data");
     }
 
     [TestMethod]
-    public async Task HoldRequestCreateAsync_WithNonexistentBib_ReturnsDocumentedError()
+    public void HoldRequestCreateAsync_RequiresDisposableBibScenarioAndIsDisabledByDefault()
     {
-        RequirePatronId();
-
-        var holdParams = new HoldRequestCreateParams(Settings.PatronId, NonexistentBibId, BranchIdOrConfiguredOrganizationId, OrganizationIdOrConfigured);
-        var response = await Papi.HoldRequestCreateAsync(holdParams);
-
-        PapiIntegrationAssert.PapiError(response, -4006);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestCreateAsync),
+            "creating a hold mutates patron hold state and must not target a hard-coded bib id that might exist",
+            "a disposable patron id, disposable/approved bib id, pickup branch, requesting organization, and cleanup plan for the created hold",
+            "enable mutating tests, create a hold for the disposable fixture, assert PAPIErrorCode 0 or another documented success code, then cancel/clean up only the created hold");
     }
 
     [TestMethod]
-    public async Task HoldRequestCreateAsync_ConvenienceOverload_WithNonexistentBib_ReturnsDocumentedError()
+    public void HoldRequestCreateAsync_ConvenienceOverload_RequiresDisposableBibScenarioAndIsDisabledByDefault()
     {
-        RequirePatronId();
-
-        var response = await ((PapiClient)Papi).HoldRequestCreateAsync(Settings.PatronId, NonexistentBibId, BranchIdOrConfiguredOrganizationId, requestingOrgId: OrganizationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4006);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestCreateAsync),
+            "creating a hold through the convenience overload mutates patron hold state and must not target a hard-coded bib id that might exist",
+            "a disposable patron id, disposable/approved bib id, pickup branch, requesting organization, and cleanup plan for the created hold",
+            "enable mutating tests, create a hold for the disposable fixture through the overload, assert PAPIErrorCode 0 or another documented success code, then cancel/clean up only the created hold");
     }
 
     [TestMethod]
     public async Task HoldRequestGetListAsync_WithConfiguredBranch_ReturnsSuccessShape()
     {
-        RequirePapiConfiguration();
+        RequireStaffProtectedTestsEnabled();
 
         var response = await Papi.HoldRequestGetListAsync(BranchIdOrConfiguredOrganizationId);
-        var data = PapiIntegrationAssert.Success(response);
+        var data = PapiIntegrationAssert.HasPapiData(response);
 
-        Assert.IsNotNull(data.RequestPicklistRows);
+        Assert.IsTrue(data.PAPIErrorCode >= 0, data.ErrorMessage);
     }
 
     [TestMethod]
-    public async Task HoldRequestReactivateAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void HoldRequestReactivateAsync_RequiresDisposableHoldScenarioAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.HoldRequestReactivateAsync(Settings.PatronBarcode, Settings.PatronPin, NonexistentRequestId, DateTime.UtcNow, UserIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4201);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestReactivateAsync),
+            "reactivating a hold request mutates patron hold state and must not target a hard-coded request id that might exist",
+            "a disposable patron barcode/PIN and a disposable suspended hold request id created specifically for reactivation",
+            "enable mutating tests, reactivate only the disposable hold request, and assert the documented PAPIErrorCode without changing pre-existing holds");
     }
 
     [TestMethod]
@@ -71,52 +70,52 @@ public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public async Task HoldRequestSuspendAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void HoldRequestSuspendAsync_RequiresDisposableHoldScenarioAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.HoldRequestSuspendAsync(Settings.PatronBarcode, NonexistentRequestId, DateTime.UtcNow, Settings.PatronPin, UserIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4201);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestSuspendAsync),
+            "suspending a hold request mutates patron hold state and must not target a hard-coded request id that might exist",
+            "a disposable patron barcode/PIN and a disposable active hold request id created specifically for suspension",
+            "enable mutating tests, suspend only the disposable hold request, and assert the documented PAPIErrorCode without changing pre-existing holds");
     }
 
     [TestMethod]
-    public async Task UpdatePickupBranchIDAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void UpdatePickupBranchIDAsync_RequiresDisposableHoldScenarioAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.UpdatePickupBranchIDAsync(Settings.PatronBarcode, NonexistentRequestId, BranchIdOrConfiguredOrganizationId, Settings.PatronPin, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4201);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.UpdatePickupBranchIDAsync),
+            "updating a hold pickup branch mutates patron hold state and must not target a hard-coded request id that might exist",
+            "a disposable patron barcode/PIN, disposable hold request id, source pickup branch, and target pickup branch",
+            "enable mutating tests, update only the disposable hold request, assert the documented PAPIErrorCode, and restore/delete the fixture hold as appropriate");
     }
 
     [TestMethod]
-    public async Task ItemRenewAsync_WithNonexistentItem_ReturnsDocumentedError()
+    public void ItemRenewAsync_RequiresDisposableCheckoutScenarioAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.ItemRenewAsync(Settings.PatronBarcode, NonexistentItemRecordId, Settings.PatronPin);
-
-        PapiIntegrationAssert.PapiError(response, -6001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.ItemRenewAsync),
+            "renewing an item mutates circulation state and must not target a hard-coded item record id that might exist",
+            "a disposable patron barcode/PIN and a checked-out disposable item record id that is safe to renew",
+            "enable mutating tests, renew only the disposable checkout fixture, and assert a deserialized ItemRenewResult with documented success or item-level error details");
     }
 
     [TestMethod]
     public void ItemRenewAllForPatronAsync_RequiresScenarioDataAndIsDisabledByDefault()
     {
-        RequireScenarioDependentTestsEnabled(
+        DocumentScenarioDependentPlaceholder(
             nameof(Papi.ItemRenewAllForPatronAsync),
-            "TestSettings:PatronBarcode and TestSettings:PatronPin for a disposable patron with renewable checked-out items",
+            "renew-all mutates every renewable checkout for the configured patron and requires an intentionally prepared patron fixture",
+            "a patron with renewable checked-out items and a site-approved renewal policy fixture",
             "call ItemRenewAllForPatronAsync and assert a deserialized ItemRenewResultWrapper with either success item rows or documented item-level errors");
     }
 
     [TestMethod]
-    public async Task ItemUpdateBarcodeAsync_WithNonexistentItem_IsGatedAsMutatingReachabilityTest()
+    public void ItemUpdateBarcodeAsync_RequiresDisposableItemFixtureAndIsDisabledByDefault()
     {
-        RequireMutatingTestsEnabled();
-
-        var response = await Papi.ItemUpdateBarcodeAsync("PAPI-INTEGRATION-NONEXISTENT-BARCODE", NonexistentItemRecordId, BranchIdOrConfiguredOrganizationId);
-        var data = PapiIntegrationAssert.HasPapiData(response);
-
-        Assert.IsTrue(data.PAPIErrorCode < 0, "A nonexistent item/barcode update should reach PAPI and return a documented domain error instead of mutating real data.");
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.ItemUpdateBarcodeAsync),
+            "updating an item barcode mutates item data and must not target a hard-coded item record id that might exist",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true plus TestSettings:ItemRecordId and TestSettings:ItemBarcode for a disposable item fixture",
+            "call ItemUpdateBarcodeAsync only for the configured disposable item record/barcode and assert the documented success or fixture-specific error response");
     }
 }

--- a/src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs
+++ b/src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs
@@ -146,12 +146,17 @@ public abstract class IntegrationTestBase
 
     protected void RequireMutatingTestsEnabled()
     {
-        RequirePatronCredentials();
+        RequirePapiConfiguration();
 
         if (!Options.EnableMutatingIntegrationTests)
         {
             Assert.Inconclusive("Mutating integration tests are disabled. Set IntegrationTestOptions:EnableMutatingIntegrationTests=true only for safe test fixtures.");
         }
+    }
+
+    protected void DocumentScenarioDependentPlaceholder(string methodName, string reason, string requiredSettings, string assertionStrategy)
+    {
+        Assert.Inconclusive($"{methodName} is a documented scenario-dependent placeholder and has no executable fixture-backed implementation yet. Reason: {reason}. Required settings: {requiredSettings}. Intended assertion strategy: {assertionStrategy}. No live PAPI call was made.");
     }
 
     protected void RequireScenarioDependentTestsEnabled(string methodName, string requiredSettings, string assertionStrategy)

--- a/src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs
@@ -30,79 +30,76 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     }
 
     [TestMethod]
-    public async Task PatronAccountPayAsync_WithNonexistentCharge_ReturnsDocumentedError()
+    public void PatronAccountPayAsync_RequiresDisposableAccountFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronAccountPayAsync(Settings.PatronBarcode, NonexistentNotificationId, .01, PaymentMethod.Cash, note: "integration testing");
-
-        PapiIntegrationAssert.PapiError(response, -3600);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronAccountPayAsync),
+            "paying a patron charge mutates account/payment state and must not target a hard-coded charge id that might exist",
+            "a disposable patron barcode/PIN, a disposable charge/fee id, payment method, and an approved cleanup/reversal plan",
+            "enable mutating tests, pay only the configured disposable charge fixture, and assert the documented PAPIErrorCode without affecting real patron balances");
     }
 
     [TestMethod]
-    public async Task PatronAccountPayAllAsync_WithExcessiveAmount_ReturnsDocumentedError()
+    public void PatronAccountPayAllAsync_RequiresDisposableAccountFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronAccountPayAllAsync(Settings.PatronBarcode, 999999.99, PaymentMethod.Cash, note: "integration testing");
-
-        PapiIntegrationAssert.PapiError(response, -3610);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronAccountPayAllAsync),
+            "pay-all mutates patron account/payment state and an excessive amount is not a safe default reachability check",
+            "a disposable patron barcode/PIN with fixture charges and an approved payment/reversal plan",
+            "enable mutating tests, pay only the prepared disposable account fixture, and assert the documented PAPIErrorCode without affecting real patron balances");
     }
 
     [TestMethod]
-    public async Task PatronAccountRefundCreditAsync_WithExcessiveAmount_ReturnsDocumentedError()
+    public void PatronAccountRefundCreditAsync_RequiresDisposableAccountFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronAccountRefundCreditAsync(Settings.PatronBarcode, 999999.99, note: "integration testing");
-
-        PapiIntegrationAssert.PapiError(response, -3606);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronAccountRefundCreditAsync),
+            "refunding credit mutates patron account/payment state and must not run as a default reachability check",
+            "a disposable patron barcode/PIN with disposable account credit and an approved fixture-specific refund plan",
+            "enable mutating tests, refund only the prepared disposable credit fixture, and assert the documented PAPIErrorCode without affecting real patron balances");
     }
 
     [TestMethod]
-    public async Task PatronAccountVoidAsync_WithNonexistentTransaction_ReturnsDocumentedError()
+    public void PatronAccountVoidAsync_RequiresDisposableAccountFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronAccountVoidAsync(Settings.PatronBarcode, NonexistentNotificationId, note: "integration testing");
-
-        PapiIntegrationAssert.PapiError(response, -3606);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronAccountVoidAsync),
+            "voiding a transaction mutates patron account/payment state and must not target a hard-coded transaction id that might exist",
+            "a disposable patron barcode/PIN and disposable transaction id created specifically for a void test",
+            "enable mutating tests, void only the configured disposable transaction fixture, and assert the documented PAPIErrorCode without affecting real patron balances");
     }
 
     [TestMethod]
-    public async Task PatronTitleListMethods_WithNonexistentLists_ReturnDocumentedErrors()
+    public void PatronTitleListMutations_RequireDisposableTitleListFixturesAndAreDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListAddTitleAsync(Settings.PatronBarcode, NonexistentTitleListId, NonexistentBibId, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListCopyAllTitlesAsync(Settings.PatronBarcode, NonexistentTitleListId, NonexistentTitleListId + 1, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListCopyTitleAsync(Settings.PatronBarcode, NonexistentTitleListId, 1, NonexistentTitleListId + 1, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListDeleteAllTitlesAsync(Settings.PatronBarcode, NonexistentTitleListId, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListDeleteTitleAsync(Settings.PatronBarcode, NonexistentTitleListId, 1, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListGetTitlesAsync(Settings.PatronBarcode, NonexistentTitleListId, password: Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListMoveTitleAsync(Settings.PatronBarcode, NonexistentTitleListId, 1, NonexistentTitleListId + 1, Settings.PatronPin), -1);
+        DocumentScenarioDependentPlaceholder(
+            "PatronTitleList add/copy/delete/move methods",
+            "title-list add, copy, delete, and move operations mutate patron title-list data and must not target hard-coded list or bib ids that might exist",
+            "a disposable patron barcode/PIN, disposable source/destination title lists, and disposable/approved bib/title entries",
+            "enable mutating tests, mutate only lists created by the fixture/test, assert documented PAPIErrorCode values, and delete only data the test definitely created");
     }
 
     [TestMethod]
     public async Task PatronAccountCreateAndDeleteTitleListAsync_WhenMutatingTestsEnabled_CleansUpList()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
         if (string.IsNullOrWhiteSpace(Settings.PatronListName))
         {
             Assert.Inconclusive("Mutating title-list flow requires TestSettings:PatronListName.");
         }
 
+        var uniqueListName = $"{Settings.PatronListName}-{Guid.NewGuid():N}";
         int? createdListId = null;
         try
         {
-            var createResponse = await Papi.PatronAccountCreateTitleListAsync(Settings.PatronBarcode, Settings.PatronListName, Settings.PatronPin);
-            var createData = PapiIntegrationAssert.HasPapiData(createResponse);
-            Assert.IsTrue(createData.PAPIErrorCode == 0 || createData.PAPIErrorCode == -1, createData.ErrorMessage);
+            var createResponse = await Papi.PatronAccountCreateTitleListAsync(Settings.PatronBarcode, uniqueListName, Settings.PatronPin);
+            PapiIntegrationAssert.ExactZeroSuccess(createResponse);
 
             var getResponse = await Papi.PatronAccountGetTitleListsAsync(Settings.PatronBarcode, Settings.PatronPin);
             var getData = PapiIntegrationAssert.Success(getResponse);
-            var list = getData.PatronAccountTitleListsRows.SingleOrDefault(l => l.RecordStoreName == Settings.PatronListName);
-            Assert.IsNotNull(list, "The created or pre-existing test title list should be visible before cleanup.");
+            var list = getData.PatronAccountTitleListsRows.SingleOrDefault(l => l.RecordStoreName == uniqueListName);
+            Assert.IsNotNull(list, "The title list created by this test should be visible before cleanup.");
             createdListId = list.RecordStoreId;
         }
         finally
@@ -119,6 +116,7 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     public async Task PatronAccountCreateCreditAsync_WhenMutatingTestsEnabled_CreatesCredit()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.PatronAccountCreateCreditAsync(Settings.PatronBarcode, .01, PaymentMethod.Cash, WorkstationIdOrConfigured, UserIdOrConfigured, "integration testing");
 
@@ -129,6 +127,7 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     public async Task PatronAccountDepositCreditAsync_WhenMutatingTestsEnabled_DepositsCredit()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.PatronAccountDepositCreditAsync(Settings.PatronBarcode, .01, WorkstationIdOrConfigured, UserIdOrConfigured, "integration testing");
 

--- a/src/polaris-api-csharpTests/Integration/PatronMutationIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronMutationIntegrationTests.cs
@@ -12,6 +12,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     public async Task CreatePatronBlocksAsync_FreeText_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
         if (string.IsNullOrWhiteSpace(Settings.FreeTextBlock))
         {
             Assert.Inconclusive("Mutating patron block tests require TestSettings:FreeTextBlock.");
@@ -27,6 +28,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     public async Task CreatePatronBlocksAsync_SystemBlock_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.System, "128", UserIdOrConfigured, WorkstationIdOrConfigured);
         var data = PapiIntegrationAssert.HasPapiData(response);
@@ -38,6 +40,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     public async Task CreatePatronBlocksAsync_LibraryAssignedBlock_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.LibraryAssigned, "1", UserIdOrConfigured, WorkstationIdOrConfigured);
         var data = PapiIntegrationAssert.HasPapiData(response);
@@ -46,39 +49,40 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public async Task PatronMessageDeleteAsync_WithNonexistentMessage_ReturnsDocumentedError()
+    public void PatronMessageDeleteAsync_RequiresDisposableMessageFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronMessageDeleteAsync(Settings.PatronBarcode, PatronMessageType.freetext, NonexistentNotificationId, Settings.PatronPin);
-
-        PapiIntegrationAssert.PapiError(response, -1);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronMessageDeleteAsync),
+            "deleting a patron message mutates patron data and must not target a hard-coded message/notification id that might exist",
+            "a disposable patron barcode/PIN and a disposable patron message id created specifically for deletion",
+            "enable mutating tests, delete only the disposable message fixture, and assert the documented PAPIErrorCode without affecting real patron messages");
     }
 
     [TestMethod]
-    public async Task PatronMessageUpdateStatusAsync_WithNonexistentMessage_ReturnsDocumentedError()
+    public void PatronMessageUpdateStatusAsync_RequiresDisposableMessageFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronMessageUpdateStatusAsync(Settings.PatronBarcode, PatronMessageType.freetext, NonexistentNotificationId, Settings.PatronPin);
-
-        PapiIntegrationAssert.PapiError(response, -1);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronMessageUpdateStatusAsync),
+            "updating patron message status mutates patron data and must not target a hard-coded message/notification id that might exist",
+            "a disposable patron barcode/PIN and a disposable patron message id created specifically for status updates",
+            "enable mutating tests, update only the disposable message fixture, and assert the documented PAPIErrorCode without affecting real patron messages");
     }
 
     [TestMethod]
-    public async Task PatronReadingHistoryClearAsync_WithNonexistentTitle_ReturnsDocumentedError()
+    public void PatronReadingHistoryClearAsync_RequiresDisposableReadingHistoryFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronReadingHistoryClearAsync(Settings.PatronBarcode, new[] { NonexistentBibId });
-
-        PapiIntegrationAssert.PapiError(response, -10);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronReadingHistoryClearAsync),
+            "clearing reading history mutates patron history and must not target a hard-coded bib id that might exist",
+            "a disposable patron barcode/PIN with disposable reading-history entries that are safe to clear",
+            "enable mutating tests, clear only configured disposable reading-history entries, and assert the documented PAPIErrorCode without affecting real patron history");
     }
 
     [TestMethod]
     public async Task PatronUpdateAsync_WhenMutatingTestsEnabled_AllowsEmptyNoOpUpdate()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.PatronUpdateAsync(Settings.PatronBarcode, new PatronUpdateParams(), Settings.PatronPin);
 
@@ -99,8 +103,9 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public void PatronRegistrationCreateAsync_RequiresScenarioDataAndIsDisabledByDefault()
     {
-        RequireScenarioDependentTestsEnabled(
+        DocumentScenarioDependentPlaceholder(
             nameof(Papi.PatronRegistrationCreateAsync),
+            "patron registration creates a new patron record and requires a complete site-specific disposable registration profile",
             "a complete PatronRegistrationParams fixture for a disposable patron registration profile",
             "create a disposable patron, assert a non-negative PAPIErrorCode and returned patron id/barcode, then clean up manually if the site supports it");
     }
@@ -108,36 +113,28 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public void PatronRegistrationCreateV2Async_RequiresScenarioDataAndIsDisabledByDefault()
     {
-        RequireScenarioDependentTestsEnabled(
+        DocumentScenarioDependentPlaceholder(
             nameof(Papi.PatronRegistrationCreateV2Async),
+            "patron registration v2 creates a new patron record and requires a complete site-specific disposable registration profile",
             "a complete PatronRegistrationData fixture for a disposable patron registration profile",
             "create a disposable patron with the v2 payload and assert a non-negative PAPIErrorCode plus returned patron id/barcode");
     }
 
     [TestMethod]
-    public async Task NotificationUpdateAsync_WithNonexistentNotification_ReturnsDocumentedError()
+    public void NotificationUpdateAsync_RequiresDisposableNotificationFixtureAndIsDisabledByDefault()
     {
-        RequirePatronId();
-
-        var response = await Papi.NotificationUpdateAsync(new NotificationUpdateParams
-        {
-            PatronId = Settings.PatronId,
-            DeliveryString = "test@example.org",
-            ReportingOrgID = OrganizationIdOrConfigured,
-            NotificationDeliveryDate = DateTime.UtcNow,
-            DeliveryOptionId = 2,
-            Details = "integration test reachability",
-            NotificationStatusId = NotificationStatus.EmailCompleted,
-            NotificationTypeId = NonexistentNotificationId
-        });
-
-        PapiIntegrationAssert.PapiError(response, -1);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.NotificationUpdateAsync),
+            "updating notification data mutates patron notification state and must not target hard-coded notification values that might exist",
+            "a disposable patron id and notification fixture values approved for update testing",
+            "enable mutating tests, update only the disposable notification fixture, and assert the documented PAPIErrorCode without affecting real patron notification data");
     }
 
     [TestMethod]
     public async Task UpdatePatronNotesDataAsync_WhenMutatingTestsEnabled_UpdatesConfiguredPatronNotes()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.UpdatePatronNotesDataAsync(Settings.PatronBarcode, nonBlockingNote: "PAPI integration test note", updateMode: UpdateNoteMode.Prepend, workstationId: WorkstationIdOrConfigured);
 

--- a/src/polaris-api-csharpTests/Integration/StaffProtectedAndRecordSetIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/StaffProtectedAndRecordSetIntegrationTests.cs
@@ -18,53 +18,53 @@ public sealed class StaffProtectedAndRecordSetIntegrationTests : IntegrationTest
     }
 
     [TestMethod]
-    public async Task RecordSetContentAddAsync_WithSingleRecordAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentAddAsync_WithSingleRecord_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentAddAsync(NonexistentRecordSetId, NonexistentBibId, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentAddAsync),
+            "adding a record to a record set mutates record-set content and must not target hard-coded record-set or bib ids that might exist",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and disposable TestSettings:RecordSetId/BibId fixture data",
+            "call RecordSetContentAddAsync only for the configured disposable record set and record, assert the documented PAPIErrorCode, and remove only content the test definitely added");
     }
 
     [TestMethod]
-    public async Task RecordSetContentAddAsync_WithRecordListAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentAddAsync_WithRecordList_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentAddAsync(NonexistentRecordSetId, new[] { NonexistentBibId }, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentAddAsync),
+            "adding records to a record set mutates record-set content and must not target hard-coded record-set or bib ids that might exist",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and disposable TestSettings:RecordSetId/BibId fixture data",
+            "call the record-list overload only for the configured disposable record set and records, assert the documented PAPIErrorCode, and remove only content the test definitely added");
     }
 
     [TestMethod]
-    public async Task RecordSetContentRemoveAsync_WithSingleRecordAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentRemoveAsync_WithSingleRecord_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentRemoveAsync(NonexistentRecordSetId, NonexistentBibId, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentRemoveAsync),
+            "removing a record from a record set mutates record-set content and must not target hard-coded record-set or bib ids that might exist",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and disposable TestSettings:RecordSetId/BibId fixture data preloaded by the test",
+            "call RecordSetContentRemoveAsync only for content the test definitely added to the disposable record set and assert the documented PAPIErrorCode");
     }
 
     [TestMethod]
-    public async Task RecordSetContentRemoveAsync_WithRecordListAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentRemoveAsync_WithRecordList_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentRemoveAsync(NonexistentRecordSetId, new[] { NonexistentBibId }, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentRemoveAsync),
+            "removing records from a record set mutates record-set content and must not target hard-coded record-set or bib ids that might exist",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and disposable TestSettings:RecordSetId/BibId fixture data preloaded by the test",
+            "call the record-list overload only for content the test definitely added to the disposable record set and assert the documented PAPIErrorCode");
     }
 
     [TestMethod]
-    public async Task RecordSetContentPutAsync_WithNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentPutAsync_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentPutAsync(NonexistentRecordSetId, new[] { NonexistentBibId }, RecordSetContentPutActions.Add, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentPutAsync),
+            "putting record-set content mutates record-set content and must not target hard-coded record-set or bib ids that might exist",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and disposable TestSettings:RecordSetId/BibId fixture data",
+            "call RecordSetContentPutAsync only for the configured disposable record set and records, assert the documented PAPIErrorCode, and restore/remove only content the test definitely changed");
     }
 
     [TestMethod]

--- a/src/polaris-api-csharpTests/README.md
+++ b/src/polaris-api-csharpTests/README.md
@@ -88,7 +88,7 @@ Additional success-path scenarios require:
 - Remote storage: `TestSettings:RemoteStorageBranchId`, `RemoteStorageStartDate`, and `RemoteStorageEndDate`, plus scenario-dependent tests enabled
 - Optional scenario fixtures for local extensions: `TestSettings:RecordSetId`, `ItemRecordId`, `ItemBarcode`, `PatronAccountTransactionId`, and `HoldRequestId`
 
-Do not use production patrons/items unless the site owner has explicitly approved the tests. Prefer disposable patrons, fixture records, and non-production PAPI instances.
+Do not use production patrons/items unless the site owner has explicitly approved the tests. Prefer disposable patrons, fixture records, and non-production PAPI instances. Any live mutating scenario must use disposable configured fixtures; hard-coded invalid IDs are not a safety mechanism for endpoints that can change data.
 
 ## Mutating tests
 
@@ -98,7 +98,7 @@ Mutating tests are disabled by default. To run them, set:
 IntegrationTestOptions__EnableMutatingIntegrationTests=true
 ```
 
-These tests are clearly named with `WhenMutatingTestsEnabled` and call the shared gate before changing data. They are intended for disposable fixtures only. Some mutating tests use create/read/delete flows with cleanup; account-credit and patron-note tests still mutate configured patron data and should only be enabled in safe environments.
+These tests are clearly named with `WhenMutatingTestsEnabled` when they have an executable fixture-backed flow, and they call the shared mutating gate before changing data. The mutating gate validates base PAPI configuration and requires `IntegrationTestOptions:EnableMutatingIntegrationTests=true`; patron-specific mutating tests also require patron credentials, and staff/protected mutating tests also require staff/protected credentials. Default integration runs must not call mutating endpoints. Executable mutating tests are intended for disposable fixtures only. Some mutating tests use create/read/delete flows with cleanup; account-credit and patron-note tests still mutate configured patron data and should only be enabled in safe environments.
 
 ## Staff-protected tests
 
@@ -108,11 +108,13 @@ Protected/staff tests are disabled by default because they require a staff overr
 IntegrationTestOptions__EnableStaffProtectedTests=true
 ```
 
-Record-set tests use nonexistent record-set IDs and assert documented negative `PAPIErrorCode` values so they prove authenticated reachability without modifying real record sets.
+Read-only staff/protected reachability tests may use known-invalid IDs and assert documented negative `PAPIErrorCode` values. Record-set content add/remove/put endpoints mutate record-set content, so they remain inconclusive placeholders until an implementation uses `EnableStaffProtectedTests=true`, `EnableMutatingIntegrationTests=true`, staff override credentials, and disposable record-set fixture data.
 
 ## Scenario-dependent placeholders
 
-Some client methods require real local data that cannot be safely invented, such as renewable checked-out items, complete patron registration payloads, or remote-storage activity windows. The suite includes inconclusive placeholder tests documenting the method name, why scenario data is required, the required fixture settings, and the intended assertion strategy. Enable them only after adding local fixture data:
+Some client methods require real local data that cannot be safely invented, such as renewable checked-out items, complete patron registration payloads, disposable account-payment fixtures, disposable hold requests, disposable item-barcode fixtures, or disposable record sets. The suite includes inconclusive placeholder tests documenting the method name, why scenario data is required, the required fixture settings, and the intended assertion strategy. Documentation-only placeholders always remain `Assert.Inconclusive(...)` until they are replaced with a real fixture-backed implementation; setting `IntegrationTestOptions:EnableScenarioDependentTests=true` must not create false green coverage for unimplemented placeholders.
+
+Executable scenario-dependent tests, such as remote-storage reads, still use the scenario-dependent option plus explicit fixture settings:
 
 ```bash
 IntegrationTestOptions__EnableScenarioDependentTests=true
@@ -122,7 +124,7 @@ IntegrationTestOptions__EnableScenarioDependentTests=true
 
 PAPI often returns HTTP 200 with a `PAPIErrorCode` carrying endpoint-level status. Negative `PAPIErrorCode` values represent PAPI/domain errors. Zero and positive values are no-error success codes; positive values commonly represent rows returned or rows affected. The integration success helper therefore treats any non-negative `PAPIErrorCode` as success, and list/read tests keep stronger row-count assertions where the response collection has stable row-count semantics.
 
-The integration tests intentionally prefer stable nonexistent IDs over dangerous repeated bad credentials. For example, invalid hold request IDs, bibliographic IDs, item IDs, transaction IDs, and record-set IDs exercise the route, authentication, deserialization, and documented PAPI error-code behavior without relying on fragile success state. Known-error reachability tests still assert exact negative `PAPIErrorCode` values only when the Polaris API Reference Guide 8.0 documents the code or the previous integration suite already used that stable code. They avoid asserting exact `ErrorMessage` text unless it is needed and stable.
+Known-error reachability tests assert exact negative `PAPIErrorCode` values only when the endpoint is safe to call as a read-only operation and the Polaris API Reference Guide 8.0 documents the code or the previous integration suite already used that stable code. Hard-coded invalid IDs may be acceptable for read-only known-error tests, but they are not used as the safety mechanism for mutating endpoints because a supposedly nonexistent ID could exist in a real Polaris database. Mutating operations instead require disposable configured fixtures or remain documented inconclusive placeholders. Tests avoid asserting exact `ErrorMessage` text unless it is needed and stable.
 
 ## Failed authentication tests
 
@@ -145,7 +147,7 @@ The guide was used selectively to confirm endpoint routes, response shapes, row-
 | Reference data lookup | Collections, dates closed, item statuses, limit filters, MARC types, material types, organizations, patron codes, pickup branches, shelf locations | None | None | None |
 | Synch | synch bibs by ID | None | None | None |
 | Patron reads | validate, barcode-from-id, basic data, blocks, hold/ILL/items out, messages, preferences, reading history, renew blocks, saved searches, patron search | None | None | None |
-| Patron account/title lists | account get, title lists get | nonexistent charge/payment/title-list IDs | create/delete title list, create credit, deposit credit | None |
-| Hold requests/circulation | hold request list | nonexistent hold request, bib, request GUID, pickup branch, item renewal IDs | item barcode update is additionally gated because the endpoint mutates item data | renew-all requires a patron with renewable checked-out items |
-| Patron mutations/messages | None by default | nonexistent patron message, reading-history title, notification update IDs; unsafe username update asserts unauthorized | patron blocks, no-op patron update, notes update | patron registration v1/v2 require complete disposable-registration fixtures |
-| Staff/protected/record sets | SA value lookup and notification queue when staff tests are enabled | nonexistent record-set IDs for get/add/remove/put | None | remote storage requires branch/date activity data |
+| Patron account/title lists | account get, title lists get | None for payment/refund/void defaults | create/delete unique title list, create credit, deposit credit | payment/refund/void and title-list mutating reachability require disposable account/list fixtures |
+| Hold requests/circulation | hold request list requires staff/protected credentials | hold status by known-invalid request/GUID | None by default | hold create/cancel/reactivate/suspend/pickup-branch updates, item renew, renew-all, and item barcode update require disposable fixtures |
+| Patron mutations/messages | None by default | unsafe username update asserts unauthorized | patron blocks, no-op patron update, notes update | message delete/status, reading-history clear, notification update, and patron registration v1/v2 require disposable fixtures |
+| Staff/protected/record sets | record-set records get, SA value lookup, and notification queue when staff tests are enabled | known-invalid record-set get | None by default | record-set content add/remove/put require staff/protected plus mutating gates and disposable record-set fixtures; remote storage requires branch/date activity data |


### PR DESCRIPTION
### Motivation
- Prevent default integration runs from calling protected or mutating PAPI endpoints that could change real site data by tightening gates and removing reliance on hard-coded "nonexistent" IDs for mutating flows.
- Preserve existing integration-test structure and PAPI assertion semantics while making mutating and protected flows opt-in and explicit about required disposable fixtures.
- Avoid false-green placeholder tests by ensuring scenario-dependent placeholders remain `Assert.Inconclusive(...)` until a fixture-backed implementation is provided.

### Description
- Require staff/protected gating for the protected hold-request list test by changing `HoldRequestGetListAsync_WithConfiguredBranch_ReturnsSuccessShape` to call `RequireStaffProtectedTestsEnabled()` and keep the `PAPIErrorCode >= 0` success check.
- Split the mutating gate from patron credential checks by refactoring `RequireMutatingTestsEnabled()` to validate base PAPI configuration only, and require caller tests to call `RequirePatronCredentials()` or `RequireStaffProtectedTestsEnabled()` as appropriate; also add `DocumentScenarioDependentPlaceholder(...)` to mark documentation-only placeholders as inconclusive.
- Convert mutating reachability tests that targeted hard-coded IDs into documented scenario-dependent placeholders (including hold create/cancel/reactivate/suspend/pickup-branch, item renew, `ItemUpdateBarcodeAsync`, patron message delete/status, reading-history clear, notification update, patron account pay/payAll/refund/void, and title-list mutations), and convert record-set content add/remove/put into placeholders that require staff+mutating gates and disposable fixture data.
- Make the title-list create/delete test safe by generating a unique per-run name, requiring both mutating and patron credentials, asserting exact-zero success on create with `PapiIntegrationAssert.ExactZeroSuccess(...)`, and deleting only the list the test created.
- Add README clarifications about safe defaults, the separate mutating/staff gates, the requirement for disposable fixtures for any mutating scenario, and the guarantee that documentation-only placeholders remain inconclusive.

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` and the restore completed successfully.
- Ran `dotnet build src/polaris-api-csharp.sln --configuration Release -warnaserror` and the solution built successfully with no warnings or errors.
- Ran unit/fast tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --configuration Release --filter "TestCategory!=Integration"` and they passed (`Passed: 99, Failed: 0`).
- Ran the integration-only suite with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --configuration Release --filter "TestCategory=Integration"` and the run completed safely with integration tests skipped/inconclusive by gate (all integration tests were skipped/inconclusive and there were no failures, i.e., no attempted live mutating or protected calls using placeholder settings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1ce4244c5c8323a764be49bb101551)