### PR TITLE
Harden integration test safety gates

### DIFF
--- a/src/polaris-api-csharpTests/Integration/HoldAndCirculationIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/HoldAndCirculationIntegrationTests.cs
@@ -8,7 +8,7 @@ namespace Clc.Polaris.Api.Tests.Integration;
 public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
 {
     [TestMethod]
-    public void HoldRequestCancelAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void HoldRequestCancelAsync_RequiresDisposableHoldFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.HoldRequestCancelAsync),
@@ -18,7 +18,7 @@ public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public void HoldRequestCreateAsync_WithNonexistentBib_ReturnsDocumentedError()
+    public void HoldRequestCreateAsync_RequiresDisposableHoldFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.HoldRequestCreateAsync),
@@ -28,7 +28,7 @@ public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public void HoldRequestCreateAsync_ConvenienceOverload_WithNonexistentBib_ReturnsDocumentedError()
+    public void HoldRequestCreateAsync_ConvenienceOverload_RequiresDisposableHoldFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(PapiClient.HoldRequestCreateAsync),
@@ -49,7 +49,7 @@ public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public void HoldRequestReactivateAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void HoldRequestReactivateAsync_RequiresDisposableHoldFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.HoldRequestReactivateAsync),
@@ -59,7 +59,7 @@ public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public void HoldRequestReplyAsync_WithEmptyGuid_ReturnsDocumentedError()
+    public void HoldRequestReplyAsync_RequiresDisposableHoldFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.HoldRequestReplyAsync),
@@ -69,7 +69,7 @@ public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public void HoldRequestSuspendAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void HoldRequestSuspendAsync_RequiresDisposableHoldFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.HoldRequestSuspendAsync),
@@ -79,7 +79,7 @@ public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public void UpdatePickupBranchIDAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void UpdatePickupBranchIDAsync_RequiresDisposableHoldFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.UpdatePickupBranchIDAsync),
@@ -89,7 +89,7 @@ public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public void ItemRenewAsync_WithNonexistentItem_ReturnsDocumentedError()
+    public void ItemRenewAsync_RequiresDisposableCheckoutFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.ItemRenewAsync),
@@ -109,7 +109,7 @@ public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public void ItemUpdateBarcodeAsync_WithNonexistentItem_IsGatedAsMutatingReachabilityTest()
+    public void ItemUpdateBarcodeAsync_RequiresDisposableItemFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.ItemUpdateBarcodeAsync),

--- a/src/polaris-api-csharpTests/Integration/HoldAndCirculationIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/HoldAndCirculationIntegrationTests.cs
@@ -8,40 +8,39 @@ namespace Clc.Polaris.Api.Tests.Integration;
 public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
 {
     [TestMethod]
-    public async Task HoldRequestCancelAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void HoldRequestCancelAsync_WithNonexistentRequest_ReturnsDocumentedError()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.HoldRequestCancelAsync(Settings.PatronBarcode, NonexistentRequestId, Settings.PatronPin, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4201);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestCancelAsync),
+            "canceling a hold request mutates patron hold state and a hard-coded request ID might exist in a live Polaris database",
+            "disposable patron credentials plus a configured disposable hold request ID created for this test",
+            "call HoldRequestCancelAsync only for the disposable hold request and assert the documented success or domain error without touching pre-existing holds");
     }
 
     [TestMethod]
-    public async Task HoldRequestCreateAsync_WithNonexistentBib_ReturnsDocumentedError()
+    public void HoldRequestCreateAsync_WithNonexistentBib_ReturnsDocumentedError()
     {
-        RequirePatronId();
-
-        var holdParams = new HoldRequestCreateParams(Settings.PatronId, NonexistentBibId, BranchIdOrConfiguredOrganizationId, OrganizationIdOrConfigured);
-        var response = await Papi.HoldRequestCreateAsync(holdParams);
-
-        PapiIntegrationAssert.PapiError(response, -4006);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestCreateAsync),
+            "creating a hold request mutates patron hold state and a hard-coded bib ID might exist in a live Polaris database",
+            "a disposable patron ID and disposable bibliographic scenario data explicitly approved for hold creation",
+            "call HoldRequestCreateAsync with disposable fixture data and assert the documented PAPIErrorCode while cleaning up any created hold");
     }
 
     [TestMethod]
-    public async Task HoldRequestCreateAsync_ConvenienceOverload_WithNonexistentBib_ReturnsDocumentedError()
+    public void HoldRequestCreateAsync_ConvenienceOverload_WithNonexistentBib_ReturnsDocumentedError()
     {
-        RequirePatronId();
-
-        var response = await ((PapiClient)Papi).HoldRequestCreateAsync(Settings.PatronId, NonexistentBibId, BranchIdOrConfiguredOrganizationId, requestingOrgId: OrganizationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4006);
+        DocumentScenarioDependentPlaceholder(
+            nameof(PapiClient.HoldRequestCreateAsync),
+            "creating a hold request mutates patron hold state and a hard-coded bib ID might exist in a live Polaris database",
+            "a disposable patron ID and disposable bibliographic scenario data explicitly approved for hold creation",
+            "call the convenience overload with disposable fixture data and assert the documented PAPIErrorCode while cleaning up any created hold");
     }
 
     [TestMethod]
     public async Task HoldRequestGetListAsync_WithConfiguredBranch_ReturnsSuccessShape()
     {
-        RequirePapiConfiguration();
+        RequireStaffProtectedTestsEnabled();
 
         var response = await Papi.HoldRequestGetListAsync(BranchIdOrConfiguredOrganizationId);
         var data = PapiIntegrationAssert.Success(response);
@@ -50,73 +49,72 @@ public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public async Task HoldRequestReactivateAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void HoldRequestReactivateAsync_WithNonexistentRequest_ReturnsDocumentedError()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.HoldRequestReactivateAsync(Settings.PatronBarcode, Settings.PatronPin, NonexistentRequestId, DateTime.UtcNow, UserIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4201);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestReactivateAsync),
+            "reactivating a hold request mutates patron hold state and a hard-coded request ID might exist in a live Polaris database",
+            "disposable patron credentials plus a configured disposable suspended hold request ID",
+            "call HoldRequestReactivateAsync only for the disposable hold and assert the documented response");
     }
 
     [TestMethod]
-    public async Task HoldRequestReplyAsync_WithEmptyGuid_ReturnsDocumentedError()
+    public void HoldRequestReplyAsync_WithEmptyGuid_ReturnsDocumentedError()
     {
-        RequirePapiConfiguration();
-
-        var hold = new HoldRequestCreateResult { RequestGuid = Guid.Empty };
-        var response = await Papi.HoldRequestReplyAsync(hold, OrganizationIdOrConfigured, HoldRequestReplyAnswer.Yes, HoldRequestReplyState.AcceptEvenWithExistingHolds);
-
-        PapiIntegrationAssert.PapiError(response, -4101);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestReplyAsync),
+            "replying to a hold request can mutate hold state and should not be exercised by default with synthetic request identifiers",
+            "a disposable hold request fixture with a request GUID that is safe to reply to",
+            "call HoldRequestReplyAsync only for the disposable request and assert the documented response");
     }
 
     [TestMethod]
-    public async Task HoldRequestSuspendAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void HoldRequestSuspendAsync_WithNonexistentRequest_ReturnsDocumentedError()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.HoldRequestSuspendAsync(Settings.PatronBarcode, NonexistentRequestId, DateTime.UtcNow, Settings.PatronPin, UserIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4201);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestSuspendAsync),
+            "suspending a hold request mutates patron hold state and a hard-coded request ID might exist in a live Polaris database",
+            "disposable patron credentials plus a configured disposable active hold request ID",
+            "call HoldRequestSuspendAsync only for the disposable hold and assert the documented response");
     }
 
     [TestMethod]
-    public async Task UpdatePickupBranchIDAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void UpdatePickupBranchIDAsync_WithNonexistentRequest_ReturnsDocumentedError()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.UpdatePickupBranchIDAsync(Settings.PatronBarcode, NonexistentRequestId, BranchIdOrConfiguredOrganizationId, Settings.PatronPin, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4201);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.UpdatePickupBranchIDAsync),
+            "changing pickup branch mutates patron hold state and a hard-coded request ID might exist in a live Polaris database",
+            "disposable patron credentials, a configured disposable hold request ID, and a safe pickup branch ID",
+            "call UpdatePickupBranchIDAsync only for the disposable hold and assert the documented response");
     }
 
     [TestMethod]
-    public async Task ItemRenewAsync_WithNonexistentItem_ReturnsDocumentedError()
+    public void ItemRenewAsync_WithNonexistentItem_ReturnsDocumentedError()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.ItemRenewAsync(Settings.PatronBarcode, NonexistentItemRecordId, Settings.PatronPin);
-
-        PapiIntegrationAssert.PapiError(response, -6001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.ItemRenewAsync),
+            "renewing an item mutates circulation state and a hard-coded item ID might exist in a live Polaris database",
+            "disposable patron credentials plus a configured disposable checked-out item ID",
+            "call ItemRenewAsync only for the disposable item and assert success or documented item-level errors");
     }
 
     [TestMethod]
     public void ItemRenewAllForPatronAsync_RequiresScenarioDataAndIsDisabledByDefault()
     {
-        RequireScenarioDependentTestsEnabled(
+        DocumentScenarioDependentPlaceholder(
             nameof(Papi.ItemRenewAllForPatronAsync),
+            "renew-all mutates circulation state for every renewable item on the patron account",
             "TestSettings:PatronBarcode and TestSettings:PatronPin for a disposable patron with renewable checked-out items",
             "call ItemRenewAllForPatronAsync and assert a deserialized ItemRenewResultWrapper with either success item rows or documented item-level errors");
     }
 
     [TestMethod]
-    public async Task ItemUpdateBarcodeAsync_WithNonexistentItem_IsGatedAsMutatingReachabilityTest()
+    public void ItemUpdateBarcodeAsync_WithNonexistentItem_IsGatedAsMutatingReachabilityTest()
     {
-        RequireMutatingTestsEnabled();
-
-        var response = await Papi.ItemUpdateBarcodeAsync("PAPI-INTEGRATION-NONEXISTENT-BARCODE", NonexistentItemRecordId, BranchIdOrConfiguredOrganizationId);
-        var data = PapiIntegrationAssert.HasPapiData(response);
-
-        Assert.IsTrue(data.PAPIErrorCode < 0, "A nonexistent item/barcode update should reach PAPI and return a documented domain error instead of mutating real data.");
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.ItemUpdateBarcodeAsync),
+            "updating an item barcode mutates item data and must not target a hard-coded item ID that might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true plus TestSettings:ItemRecordId and TestSettings:ItemBarcode for a disposable item fixture",
+            "call ItemUpdateBarcodeAsync only with explicitly configured disposable item data and assert the documented PAPI response");
     }
 }

--- a/src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs
+++ b/src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs
@@ -7,12 +7,12 @@ namespace Clc.Polaris.Api.Tests.Integration;
 
 public abstract class IntegrationTestBase
 {
-    protected const int NonexistentBibId = 1234;
-    protected const int NonexistentItemRecordId = 1234;
-    protected const int NonexistentRequestId = 1234;
-    protected const int NonexistentRecordSetId = 1234;
-    protected const int NonexistentTitleListId = 1234;
-    protected const int NonexistentNotificationId = 1234;
+    protected const int NonexistentBibId = 2_147_483_647;
+    protected const int NonexistentItemRecordId = 2_147_483_647;
+    protected const int NonexistentRequestId = 2_147_483_647;
+    protected const int NonexistentRecordSetId = 2_147_483_647;
+    protected const int NonexistentTitleListId = 2_147_483_647;
+    protected const int NonexistentNotificationId = 2_147_483_647;
 
     private const string MissingConfigurationMessage = "Integration test configuration is missing. Provide appsettings.Test.json or environment variables to run live PAPI tests.";
 
@@ -146,12 +146,17 @@ public abstract class IntegrationTestBase
 
     protected void RequireMutatingTestsEnabled()
     {
-        RequirePatronCredentials();
+        RequirePapiConfiguration();
 
         if (!Options.EnableMutatingIntegrationTests)
         {
-            Assert.Inconclusive("Mutating integration tests are disabled. Set IntegrationTestOptions:EnableMutatingIntegrationTests=true only for safe test fixtures.");
+            Assert.Inconclusive("Mutating integration tests are disabled. Set IntegrationTestOptions:EnableMutatingIntegrationTests=true only for safe disposable test fixtures.");
         }
+    }
+
+    protected void DocumentScenarioDependentPlaceholder(string methodName, string whyScenarioDataIsRequired, string requiredSettings, string assertionStrategy)
+    {
+        Assert.Inconclusive($"{methodName} is a scenario-dependent placeholder and has no executable fixture-backed implementation yet. Reason: {whyScenarioDataIsRequired}. Required settings: {requiredSettings}. Intended assertion strategy: {assertionStrategy}. No live API call was made.");
     }
 
     protected void RequireScenarioDependentTestsEnabled(string methodName, string requiredSettings, string assertionStrategy)

--- a/src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs
@@ -30,7 +30,7 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     }
 
     [TestMethod]
-    public void PatronAccountPayAsync_WithNonexistentCharge_ReturnsDocumentedError()
+    public void PatronAccountPayAsync_RequiresDisposableAccountFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.PatronAccountPayAsync),
@@ -40,7 +40,7 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     }
 
     [TestMethod]
-    public void PatronAccountPayAllAsync_WithExcessiveAmount_ReturnsDocumentedError()
+    public void PatronAccountPayAllAsync_RequiresDisposableAccountFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.PatronAccountPayAllAsync),
@@ -50,7 +50,7 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     }
 
     [TestMethod]
-    public void PatronAccountRefundCreditAsync_WithExcessiveAmount_ReturnsDocumentedError()
+    public void PatronAccountRefundCreditAsync_RequiresDisposableAccountFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.PatronAccountRefundCreditAsync),
@@ -60,7 +60,7 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     }
 
     [TestMethod]
-    public void PatronAccountVoidAsync_WithNonexistentTransaction_ReturnsDocumentedError()
+    public void PatronAccountVoidAsync_RequiresDisposableAccountFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.PatronAccountVoidAsync),
@@ -70,7 +70,7 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     }
 
     [TestMethod]
-    public void PatronTitleListMethods_WithNonexistentLists_ReturnDocumentedErrors()
+    public void PatronTitleListMethods_RequireDisposableTitleListFixturesAndAreDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             "PatronTitleList add/copy/delete/move methods",

--- a/src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs
@@ -30,79 +30,76 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     }
 
     [TestMethod]
-    public async Task PatronAccountPayAsync_WithNonexistentCharge_ReturnsDocumentedError()
+    public void PatronAccountPayAsync_WithNonexistentCharge_ReturnsDocumentedError()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronAccountPayAsync(Settings.PatronBarcode, NonexistentNotificationId, .01, PaymentMethod.Cash, note: "integration testing");
-
-        PapiIntegrationAssert.PapiError(response, -3600);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronAccountPayAsync),
+            "paying a charge mutates patron account/payment state and a hard-coded charge ID might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and a configured disposable charge fixture",
+            "call PatronAccountPayAsync only for disposable charge data and assert the documented payment response");
     }
 
     [TestMethod]
-    public async Task PatronAccountPayAllAsync_WithExcessiveAmount_ReturnsDocumentedError()
+    public void PatronAccountPayAllAsync_WithExcessiveAmount_ReturnsDocumentedError()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronAccountPayAllAsync(Settings.PatronBarcode, 999999.99, PaymentMethod.Cash, note: "integration testing");
-
-        PapiIntegrationAssert.PapiError(response, -3610);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronAccountPayAllAsync),
+            "pay-all mutates patron account/payment state and should not run against a real patron without disposable account fixtures",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and configured disposable account balance data",
+            "call PatronAccountPayAllAsync only for disposable account data and assert the documented response without affecting real balances");
     }
 
     [TestMethod]
-    public async Task PatronAccountRefundCreditAsync_WithExcessiveAmount_ReturnsDocumentedError()
+    public void PatronAccountRefundCreditAsync_WithExcessiveAmount_ReturnsDocumentedError()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronAccountRefundCreditAsync(Settings.PatronBarcode, 999999.99, note: "integration testing");
-
-        PapiIntegrationAssert.PapiError(response, -3606);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronAccountRefundCreditAsync),
+            "refund-credit mutates patron account/payment state and should not run against a real patron without disposable credit fixtures",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and configured disposable credit balance data",
+            "call PatronAccountRefundCreditAsync only for disposable credit data and assert the documented response without affecting real balances");
     }
 
     [TestMethod]
-    public async Task PatronAccountVoidAsync_WithNonexistentTransaction_ReturnsDocumentedError()
+    public void PatronAccountVoidAsync_WithNonexistentTransaction_ReturnsDocumentedError()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronAccountVoidAsync(Settings.PatronBarcode, NonexistentNotificationId, note: "integration testing");
-
-        PapiIntegrationAssert.PapiError(response, -3606);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronAccountVoidAsync),
+            "voiding a payment mutates patron account/payment state and a hard-coded transaction ID might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and a configured disposable transaction fixture",
+            "call PatronAccountVoidAsync only for disposable transaction data and assert the documented response");
     }
 
     [TestMethod]
-    public async Task PatronTitleListMethods_WithNonexistentLists_ReturnDocumentedErrors()
+    public void PatronTitleListMethods_WithNonexistentLists_ReturnDocumentedErrors()
     {
-        RequirePatronCredentials();
-
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListAddTitleAsync(Settings.PatronBarcode, NonexistentTitleListId, NonexistentBibId, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListCopyAllTitlesAsync(Settings.PatronBarcode, NonexistentTitleListId, NonexistentTitleListId + 1, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListCopyTitleAsync(Settings.PatronBarcode, NonexistentTitleListId, 1, NonexistentTitleListId + 1, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListDeleteAllTitlesAsync(Settings.PatronBarcode, NonexistentTitleListId, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListDeleteTitleAsync(Settings.PatronBarcode, NonexistentTitleListId, 1, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListGetTitlesAsync(Settings.PatronBarcode, NonexistentTitleListId, password: Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListMoveTitleAsync(Settings.PatronBarcode, NonexistentTitleListId, 1, NonexistentTitleListId + 1, Settings.PatronPin), -1);
+        DocumentScenarioDependentPlaceholder(
+            "PatronTitleList add/copy/delete/move methods",
+            "most title-list operations mutate patron title-list content and hard-coded list or bib IDs might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and configured disposable source/destination title-list plus bib fixtures",
+            "call each title-list method only against disposable title lists and assert documented PAPIErrorCode values while preserving pre-existing lists");
     }
 
     [TestMethod]
     public async Task PatronAccountCreateAndDeleteTitleListAsync_WhenMutatingTestsEnabled_CleansUpList()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
         if (string.IsNullOrWhiteSpace(Settings.PatronListName))
         {
             Assert.Inconclusive("Mutating title-list flow requires TestSettings:PatronListName.");
         }
 
+        var uniqueListName = $"{Settings.PatronListName}-{Guid.NewGuid():N}";
         int? createdListId = null;
         try
         {
-            var createResponse = await Papi.PatronAccountCreateTitleListAsync(Settings.PatronBarcode, Settings.PatronListName, Settings.PatronPin);
-            var createData = PapiIntegrationAssert.HasPapiData(createResponse);
-            Assert.IsTrue(createData.PAPIErrorCode == 0 || createData.PAPIErrorCode == -1, createData.ErrorMessage);
+            var createResponse = await Papi.PatronAccountCreateTitleListAsync(Settings.PatronBarcode, uniqueListName, Settings.PatronPin);
+            PapiIntegrationAssert.ExactZeroSuccess(createResponse);
 
             var getResponse = await Papi.PatronAccountGetTitleListsAsync(Settings.PatronBarcode, Settings.PatronPin);
             var getData = PapiIntegrationAssert.Success(getResponse);
-            var list = getData.PatronAccountTitleListsRows.SingleOrDefault(l => l.RecordStoreName == Settings.PatronListName);
-            Assert.IsNotNull(list, "The created or pre-existing test title list should be visible before cleanup.");
+            var list = getData.PatronAccountTitleListsRows.SingleOrDefault(l => l.RecordStoreName == uniqueListName);
+            Assert.IsNotNull(list, "The title list created by this test should be visible before cleanup.");
             createdListId = list.RecordStoreId;
         }
         finally
@@ -119,6 +116,7 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     public async Task PatronAccountCreateCreditAsync_WhenMutatingTestsEnabled_CreatesCredit()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.PatronAccountCreateCreditAsync(Settings.PatronBarcode, .01, PaymentMethod.Cash, WorkstationIdOrConfigured, UserIdOrConfigured, "integration testing");
 
@@ -129,6 +127,7 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     public async Task PatronAccountDepositCreditAsync_WhenMutatingTestsEnabled_DepositsCredit()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.PatronAccountDepositCreditAsync(Settings.PatronBarcode, .01, WorkstationIdOrConfigured, UserIdOrConfigured, "integration testing");
 

--- a/src/polaris-api-csharpTests/Integration/PatronMutationIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronMutationIntegrationTests.cs
@@ -12,6 +12,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     public async Task CreatePatronBlocksAsync_FreeText_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
         if (string.IsNullOrWhiteSpace(Settings.FreeTextBlock))
         {
             Assert.Inconclusive("Mutating patron block tests require TestSettings:FreeTextBlock.");
@@ -27,6 +28,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     public async Task CreatePatronBlocksAsync_SystemBlock_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.System, "128", UserIdOrConfigured, WorkstationIdOrConfigured);
         var data = PapiIntegrationAssert.HasPapiData(response);
@@ -38,6 +40,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     public async Task CreatePatronBlocksAsync_LibraryAssignedBlock_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.LibraryAssigned, "1", UserIdOrConfigured, WorkstationIdOrConfigured);
         var data = PapiIntegrationAssert.HasPapiData(response);
@@ -46,39 +49,40 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public async Task PatronMessageDeleteAsync_WithNonexistentMessage_ReturnsDocumentedError()
+    public void PatronMessageDeleteAsync_WithNonexistentMessage_ReturnsDocumentedError()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronMessageDeleteAsync(Settings.PatronBarcode, PatronMessageType.freetext, NonexistentNotificationId, Settings.PatronPin);
-
-        PapiIntegrationAssert.PapiError(response, -1);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronMessageDeleteAsync),
+            "deleting a patron message mutates patron notification/message state and a hard-coded notification ID might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and a configured disposable patron message fixture",
+            "call PatronMessageDeleteAsync only for a disposable message and assert the documented response");
     }
 
     [TestMethod]
-    public async Task PatronMessageUpdateStatusAsync_WithNonexistentMessage_ReturnsDocumentedError()
+    public void PatronMessageUpdateStatusAsync_WithNonexistentMessage_ReturnsDocumentedError()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronMessageUpdateStatusAsync(Settings.PatronBarcode, PatronMessageType.freetext, NonexistentNotificationId, Settings.PatronPin);
-
-        PapiIntegrationAssert.PapiError(response, -1);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronMessageUpdateStatusAsync),
+            "updating patron message status mutates patron notification/message state and a hard-coded notification ID might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and a configured disposable patron message fixture",
+            "call PatronMessageUpdateStatusAsync only for a disposable message and assert the documented response");
     }
 
     [TestMethod]
-    public async Task PatronReadingHistoryClearAsync_WithNonexistentTitle_ReturnsDocumentedError()
+    public void PatronReadingHistoryClearAsync_WithNonexistentTitle_ReturnsDocumentedError()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronReadingHistoryClearAsync(Settings.PatronBarcode, new[] { NonexistentBibId });
-
-        PapiIntegrationAssert.PapiError(response, -10);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronReadingHistoryClearAsync),
+            "clearing reading-history entries mutates patron history and a hard-coded bib ID might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and configured disposable reading-history title fixture",
+            "call PatronReadingHistoryClearAsync only for disposable reading-history data and assert the documented response");
     }
 
     [TestMethod]
     public async Task PatronUpdateAsync_WhenMutatingTestsEnabled_AllowsEmptyNoOpUpdate()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.PatronUpdateAsync(Settings.PatronBarcode, new PatronUpdateParams(), Settings.PatronPin);
 
@@ -88,6 +92,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task PatronUpdateUserNameAsync_WithUnsafeBarcode_ReturnsUnauthorizedWithoutChangingPatron()
     {
+        RequireMutatingTestsEnabled();
         RequirePatronCredentials();
 
         var response = await Papi.PatronUpdateUserNameAsync(Settings.PatronBarcode + "-nonexistent", Settings.PatronPin, Settings.PatronPin);
@@ -99,8 +104,9 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public void PatronRegistrationCreateAsync_RequiresScenarioDataAndIsDisabledByDefault()
     {
-        RequireScenarioDependentTestsEnabled(
+        DocumentScenarioDependentPlaceholder(
             nameof(Papi.PatronRegistrationCreateAsync),
+            "patron registration creates patron data and requires a complete site-specific disposable registration profile",
             "a complete PatronRegistrationParams fixture for a disposable patron registration profile",
             "create a disposable patron, assert a non-negative PAPIErrorCode and returned patron id/barcode, then clean up manually if the site supports it");
     }
@@ -108,36 +114,28 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public void PatronRegistrationCreateV2Async_RequiresScenarioDataAndIsDisabledByDefault()
     {
-        RequireScenarioDependentTestsEnabled(
+        DocumentScenarioDependentPlaceholder(
             nameof(Papi.PatronRegistrationCreateV2Async),
+            "patron registration v2 creates patron data and requires a complete site-specific disposable registration profile",
             "a complete PatronRegistrationData fixture for a disposable patron registration profile",
             "create a disposable patron with the v2 payload and assert a non-negative PAPIErrorCode plus returned patron id/barcode");
     }
 
     [TestMethod]
-    public async Task NotificationUpdateAsync_WithNonexistentNotification_ReturnsDocumentedError()
+    public void NotificationUpdateAsync_WithNonexistentNotification_ReturnsDocumentedError()
     {
-        RequirePatronId();
-
-        var response = await Papi.NotificationUpdateAsync(new NotificationUpdateParams
-        {
-            PatronId = Settings.PatronId,
-            DeliveryString = "test@example.org",
-            ReportingOrgID = OrganizationIdOrConfigured,
-            NotificationDeliveryDate = DateTime.UtcNow,
-            DeliveryOptionId = 2,
-            Details = "integration test reachability",
-            NotificationStatusId = NotificationStatus.EmailCompleted,
-            NotificationTypeId = NonexistentNotificationId
-        });
-
-        PapiIntegrationAssert.PapiError(response, -1);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.NotificationUpdateAsync),
+            "updating notification state mutates patron notification data and a hard-coded notification type/id might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true and a configured disposable notification fixture for a disposable patron",
+            "call NotificationUpdateAsync only for disposable notification data and assert the documented response");
     }
 
     [TestMethod]
     public async Task UpdatePatronNotesDataAsync_WhenMutatingTestsEnabled_UpdatesConfiguredPatronNotes()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.UpdatePatronNotesDataAsync(Settings.PatronBarcode, nonBlockingNote: "PAPI integration test note", updateMode: UpdateNoteMode.Prepend, workstationId: WorkstationIdOrConfigured);
 

--- a/src/polaris-api-csharpTests/Integration/PatronMutationIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronMutationIntegrationTests.cs
@@ -49,7 +49,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public void PatronMessageDeleteAsync_WithNonexistentMessage_ReturnsDocumentedError()
+    public void PatronMessageDeleteAsync_RequiresDisposableMessageFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.PatronMessageDeleteAsync),
@@ -59,7 +59,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public void PatronMessageUpdateStatusAsync_WithNonexistentMessage_ReturnsDocumentedError()
+    public void PatronMessageUpdateStatusAsync_RequiresDisposableMessageFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.PatronMessageUpdateStatusAsync),
@@ -69,7 +69,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public void PatronReadingHistoryClearAsync_WithNonexistentTitle_ReturnsDocumentedError()
+    public void PatronReadingHistoryClearAsync_RequiresDisposableReadingHistoryFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.PatronReadingHistoryClearAsync),
@@ -122,7 +122,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public void NotificationUpdateAsync_WithNonexistentNotification_ReturnsDocumentedError()
+    public void NotificationUpdateAsync_RequiresDisposableNotificationFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.NotificationUpdateAsync),

--- a/src/polaris-api-csharpTests/Integration/StaffProtectedAndRecordSetIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/StaffProtectedAndRecordSetIntegrationTests.cs
@@ -18,7 +18,7 @@ public sealed class StaffProtectedAndRecordSetIntegrationTests : IntegrationTest
     }
 
     [TestMethod]
-    public void RecordSetContentAddAsync_WithSingleRecordAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentAddAsync_WithSingleRecord_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.RecordSetContentAddAsync),
@@ -28,7 +28,7 @@ public sealed class StaffProtectedAndRecordSetIntegrationTests : IntegrationTest
     }
 
     [TestMethod]
-    public void RecordSetContentAddAsync_WithRecordListAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentAddAsync_WithRecordList_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.RecordSetContentAddAsync),
@@ -38,7 +38,7 @@ public sealed class StaffProtectedAndRecordSetIntegrationTests : IntegrationTest
     }
 
     [TestMethod]
-    public void RecordSetContentRemoveAsync_WithSingleRecordAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentRemoveAsync_WithSingleRecord_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.RecordSetContentRemoveAsync),
@@ -48,7 +48,7 @@ public sealed class StaffProtectedAndRecordSetIntegrationTests : IntegrationTest
     }
 
     [TestMethod]
-    public void RecordSetContentRemoveAsync_WithRecordListAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentRemoveAsync_WithRecordList_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.RecordSetContentRemoveAsync),
@@ -58,7 +58,7 @@ public sealed class StaffProtectedAndRecordSetIntegrationTests : IntegrationTest
     }
 
     [TestMethod]
-    public void RecordSetContentPutAsync_WithNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentPutAsync_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
         DocumentScenarioDependentPlaceholder(
             nameof(Papi.RecordSetContentPutAsync),

--- a/src/polaris-api-csharpTests/Integration/StaffProtectedAndRecordSetIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/StaffProtectedAndRecordSetIntegrationTests.cs
@@ -18,53 +18,53 @@ public sealed class StaffProtectedAndRecordSetIntegrationTests : IntegrationTest
     }
 
     [TestMethod]
-    public async Task RecordSetContentAddAsync_WithSingleRecordAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentAddAsync_WithSingleRecordAndNonexistentRecordSet_ReturnsDocumentedError()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentAddAsync(NonexistentRecordSetId, NonexistentBibId, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentAddAsync),
+            "adding record-set content mutates staff/protected record-set state and hard-coded record-set or bib IDs might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and configured disposable record-set plus bib fixtures",
+            "call RecordSetContentAddAsync only against a disposable record set and assert the documented response before cleanup");
     }
 
     [TestMethod]
-    public async Task RecordSetContentAddAsync_WithRecordListAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentAddAsync_WithRecordListAndNonexistentRecordSet_ReturnsDocumentedError()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentAddAsync(NonexistentRecordSetId, new[] { NonexistentBibId }, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentAddAsync),
+            "adding record-set content mutates staff/protected record-set state and hard-coded record-set or bib IDs might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and configured disposable record-set plus bib fixtures",
+            "call the record-list overload only against a disposable record set and assert the documented response before cleanup");
     }
 
     [TestMethod]
-    public async Task RecordSetContentRemoveAsync_WithSingleRecordAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentRemoveAsync_WithSingleRecordAndNonexistentRecordSet_ReturnsDocumentedError()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentRemoveAsync(NonexistentRecordSetId, NonexistentBibId, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentRemoveAsync),
+            "removing record-set content mutates staff/protected record-set state and hard-coded record-set or bib IDs might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and configured disposable record-set plus bib fixtures",
+            "call RecordSetContentRemoveAsync only against a disposable record set and assert the documented response before cleanup");
     }
 
     [TestMethod]
-    public async Task RecordSetContentRemoveAsync_WithRecordListAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentRemoveAsync_WithRecordListAndNonexistentRecordSet_ReturnsDocumentedError()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentRemoveAsync(NonexistentRecordSetId, new[] { NonexistentBibId }, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentRemoveAsync),
+            "removing record-set content mutates staff/protected record-set state and hard-coded record-set or bib IDs might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and configured disposable record-set plus bib fixtures",
+            "call the record-list overload only against a disposable record set and assert the documented response before cleanup");
     }
 
     [TestMethod]
-    public async Task RecordSetContentPutAsync_WithNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentPutAsync_WithNonexistentRecordSet_ReturnsDocumentedError()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentPutAsync(NonexistentRecordSetId, new[] { NonexistentBibId }, RecordSetContentPutActions.Add, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentPutAsync),
+            "putting record-set content mutates staff/protected record-set state and hard-coded record-set or bib IDs might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and configured disposable record-set plus bib fixtures",
+            "call RecordSetContentPutAsync only against a disposable record set and assert the documented response before cleanup");
     }
 
     [TestMethod]

--- a/src/polaris-api-csharpTests/README.md
+++ b/src/polaris-api-csharpTests/README.md
@@ -92,27 +92,29 @@ Do not use production patrons/items unless the site owner has explicitly approve
 
 ## Mutating tests
 
-Mutating tests are disabled by default. To run them, set:
+Mutating tests are disabled by default, and default integration runs should not call mutating endpoints. To run implemented mutating tests, set:
 
 ```bash
 IntegrationTestOptions__EnableMutatingIntegrationTests=true
 ```
 
-These tests are clearly named with `WhenMutatingTestsEnabled` and call the shared gate before changing data. They are intended for disposable fixtures only. Some mutating tests use create/read/delete flows with cleanup; account-credit and patron-note tests still mutate configured patron data and should only be enabled in safe environments.
+The mutating gate checks live PAPI configuration and the explicit option only. Patron-specific mutating tests also require `TestSettings:PatronBarcode` and `TestSettings:PatronPin`; staff/protected mutating tests must also satisfy the staff/protected gate. These tests are intended for disposable fixtures only. Some mutating tests use create/read/delete flows with cleanup; account-credit, patron-block, patron-update, and patron-note tests still mutate configured patron data and should only be enabled in safe environments. Hard-coded invalid IDs are not used as safety mechanisms for mutating operations; any live mutating scenario that needs item, record-set, account, hold, notification, or title-list data must use explicitly configured disposable fixtures.
 
 ## Staff-protected tests
 
-Protected/staff tests are disabled by default because they require a staff override account and may access protected PAPI routes. To run them, provide `PapiSettings:PolarisOverrideAccount` and set:
+Protected/staff tests are disabled by default because they require a staff override account and may access protected PAPI routes. To run them, provide `PapiSettings:PolarisOverrideAccount` credentials and set:
 
 ```bash
 IntegrationTestOptions__EnableStaffProtectedTests=true
 ```
 
-Record-set tests use nonexistent record-set IDs and assert documented negative `PAPIErrorCode` values so they prove authenticated reachability without modifying real record sets.
+Read-only staff/protected reachability tests may use known-invalid sentinel IDs and assert documented negative `PAPIErrorCode` values. Record-set content add/remove/put tests are mutating and remain inconclusive placeholders until disposable record-set fixtures are configured and an executable cleanup strategy is implemented.
 
 ## Scenario-dependent placeholders
 
-Some client methods require real local data that cannot be safely invented, such as renewable checked-out items, complete patron registration payloads, or remote-storage activity windows. The suite includes inconclusive placeholder tests documenting the method name, why scenario data is required, the required fixture settings, and the intended assertion strategy. Enable them only after adding local fixture data:
+Some client methods require real local data that cannot be safely invented, such as renewable checked-out items, complete patron registration payloads, payment/refund/void fixtures, disposable item barcode fixtures, hold fixtures, record-set mutation fixtures, or remote-storage activity windows. Placeholder tests always call `Assert.Inconclusive(...)` and do not pass merely because `IntegrationTestOptions:EnableScenarioDependentTests=true`; they document the method name, why scenario data is required, the required fixture settings, and the intended assertion strategy until a fixture-backed implementation exists.
+
+Executable scenario-dependent tests may still use this option as an additional opt-in gate after validating all required fixture settings:
 
 ```bash
 IntegrationTestOptions__EnableScenarioDependentTests=true
@@ -122,7 +124,7 @@ IntegrationTestOptions__EnableScenarioDependentTests=true
 
 PAPI often returns HTTP 200 with a `PAPIErrorCode` carrying endpoint-level status. Negative `PAPIErrorCode` values represent PAPI/domain errors. Zero and positive values are no-error success codes; positive values commonly represent rows returned or rows affected. The integration success helper therefore treats any non-negative `PAPIErrorCode` as success, and list/read tests keep stronger row-count assertions where the response collection has stable row-count semantics.
 
-The integration tests intentionally prefer stable nonexistent IDs over dangerous repeated bad credentials. For example, invalid hold request IDs, bibliographic IDs, item IDs, transaction IDs, and record-set IDs exercise the route, authentication, deserialization, and documented PAPI error-code behavior without relying on fragile success state. Known-error reachability tests still assert exact negative `PAPIErrorCode` values only when the Polaris API Reference Guide 8.0 documents the code or the previous integration suite already used that stable code. They avoid asserting exact `ErrorMessage` text unless it is needed and stable.
+Read-only known-error reachability tests may use high known-invalid sentinel IDs to exercise the route, authentication, deserialization, and documented PAPI error-code behavior without relying on fragile success state. Mutating endpoints must not rely on hard-coded nonexistent IDs as their safety mechanism; they either require explicit disposable configured fixtures and mutating opt-in gates or remain inconclusive scenario-dependent placeholders. Known-error reachability tests still assert exact negative `PAPIErrorCode` values only when the Polaris API Reference Guide 8.0 documents the code or the previous integration suite already used that stable code. They avoid asserting exact `ErrorMessage` text unless it is needed and stable.
 
 ## Failed authentication tests
 
@@ -145,7 +147,7 @@ The guide was used selectively to confirm endpoint routes, response shapes, row-
 | Reference data lookup | Collections, dates closed, item statuses, limit filters, MARC types, material types, organizations, patron codes, pickup branches, shelf locations | None | None | None |
 | Synch | synch bibs by ID | None | None | None |
 | Patron reads | validate, barcode-from-id, basic data, blocks, hold/ILL/items out, messages, preferences, reading history, renew blocks, saved searches, patron search | None | None | None |
-| Patron account/title lists | account get, title lists get | nonexistent charge/payment/title-list IDs | create/delete title list, create credit, deposit credit | None |
-| Hold requests/circulation | hold request list | nonexistent hold request, bib, request GUID, pickup branch, item renewal IDs | item barcode update is additionally gated because the endpoint mutates item data | renew-all requires a patron with renewable checked-out items |
-| Patron mutations/messages | None by default | nonexistent patron message, reading-history title, notification update IDs; unsafe username update asserts unauthorized | patron blocks, no-op patron update, notes update | patron registration v1/v2 require complete disposable-registration fixtures |
-| Staff/protected/record sets | SA value lookup and notification queue when staff tests are enabled | nonexistent record-set IDs for get/add/remove/put | None | remote storage requires branch/date activity data |
+| Patron account/title lists | account get, title lists get | None by default for payment/refund/void/title-list mutations | unique create/delete title list, create credit, deposit credit | payment/refund/void and hard-coded title-list mutation reachability require disposable account/list fixtures |
+| Hold requests/circulation | hold request list (staff/protected-gated) | None by default for hold/item mutations | None without disposable fixtures | hold create/cancel/reactivate/suspend/reply/pickup updates, item renew, renew-all, and item barcode update require disposable fixtures |
+| Patron mutations/messages | None by default | None by default for patron message/reading-history/notification mutations | patron blocks, no-op patron update, username unauthorized check, notes update | patron message, reading-history, notification update, and registration v1/v2 require disposable fixtures |
+| Staff/protected/record sets | hold request list, SA value lookup, notification queue when staff tests are enabled | read-only record-set get with a known-invalid sentinel ID | None without disposable fixtures | record-set add/remove/put mutations and remote storage require explicit scenario data |


### PR DESCRIPTION
### Motivation

- Prevent default integration runs from reaching protected or mutating Polaris PAPI endpoints and avoid relying on hard-coded "nonexistent" IDs that may exist in real deployments. 
- Preserve the existing integration-test structure and PAPI assertion semantics while making mutating/staff tests opt-in and safe. 
- Ensure scenario-placeholder tests cannot produce false-green results when `EnableScenarioDependentTests=true`.

### Description

- Separated the mutating gate from patron credentials by changing `RequireMutatingTestsEnabled()` to validate live PAPI config plus `IntegrationTestOptions:EnableMutatingIntegrationTests=true` and added explicit `RequirePatronCredentials()` calls for patron-scoped mutating tests. 
- Added `DocumentScenarioDependentPlaceholder(...)` and converted unsafe mutating/fixture-dependent tests to inconclusive placeholders (examples: hold create/cancel/reactivate/reply/suspend, pickup-branch updates, item renew/renew-all, `ItemUpdateBarcodeAsync`, patron message/delete/status/notification updates, payment/refund/void flows, and record-set add/remove/put). 
- Changed `HoldRequestGetListAsync_WithConfiguredBranch_ReturnsSuccessShape` to call `RequireStaffProtectedTestsEnabled()` so staff/protected routes are inconclusive unless staff override credentials and `EnableStaffProtectedTests=true`. 
- Made title-list create/delete safe by creating a unique GUID-suffixed list name, asserting exact zero-create success, locating only that unique list, and deleting only the list this test created. 
- Kept read-only staff/record-set get tests as staff-gated, but converted record-set content mutation tests into placeholders (or require both staff + mutating gates and explicit disposable fixtures). 
- Replaced low hard-coded "nonexistent" constants with a high sentinel value for read-only reachability and documented that hard-coded IDs are not a safety mechanism for mutating operations. 
- Updated README to document the new gating rules, scenario-placeholder behavior, and fixture requirements.

### Testing

- Ran `dotnet restore src/polaris-api-csharp.sln` and `dotnet build src/polaris-api-csharp.sln --configuration Release -warnaserror` and the build succeeded with zero warnings or errors. 
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --configuration Release --filter "TestCategory!=Integration"` and the non-integration suite passed (99 passed, 0 failed). 
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --configuration Release --filter "TestCategory=Integration"` and the integration-only run completed safely with all opt-in/mutating/staff tests skipped or marked inconclusive (78 skipped/inconclusive), with no null-reference/config-binding failures and no attempted live calls using placeholder settings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1ce4244c5c8323a764be49bb101551)