### PR TITLE
Refactor integration tests: add scenario placeholders, preserve legacy settings, and avoid empty numeric envs in GH workflow

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -28,31 +28,17 @@ jobs:
       PapiSettings__Hostname: ${{ secrets.PAPI_HOSTNAME }}
       PapiSettings__AccessId: ${{ secrets.PAPI_ACCESS_ID }}
       PapiSettings__AccessKey: ${{ secrets.PAPI_ACCESS_KEY }}
-      PapiSettings__OrganizationId: ${{ secrets.PAPI_ORGANIZATION_ID }}
-      PapiSettings__UserId: ${{ secrets.PAPI_USER_ID }}
-      PapiSettings__WorkstationId: ${{ secrets.PAPI_WORKSTATION_ID }}
       PapiSettings__PolarisOverrideAccount__Domain: ${{ secrets.PAPI_STAFF_DOMAIN }}
       PapiSettings__PolarisOverrideAccount__Username: ${{ secrets.PAPI_STAFF_USERNAME }}
       PapiSettings__PolarisOverrideAccount__Password: ${{ secrets.PAPI_STAFF_PASSWORD }}
-      TestSettings__PatronId: ${{ secrets.PAPI_TEST_PATRON_ID }}
       TestSettings__PatronBarcode: ${{ secrets.PAPI_TEST_PATRON_BARCODE }}
       TestSettings__PatronPin: ${{ secrets.PAPI_TEST_PATRON_PIN }}
-      TestSettings__BibId: ${{ secrets.PAPI_TEST_BIB_ID }}
-      TestSettings__BranchId: ${{ secrets.PAPI_TEST_BRANCH_ID }}
-      TestSettings__OrganizationId: ${{ secrets.PAPI_TEST_ORGANIZATION_ID }}
-      TestSettings__WorkstationId: ${{ secrets.PAPI_TEST_WORKSTATION_ID }}
-      TestSettings__UserId: ${{ secrets.PAPI_TEST_USER_ID }}
       TestSettings__OrgEmail: ${{ secrets.PAPI_TEST_ORG_EMAIL }}
       TestSettings__PatronListName: ${{ secrets.PAPI_TEST_PATRON_LIST_NAME }}
       TestSettings__FreeTextBlock: ${{ secrets.PAPI_TEST_FREE_TEXT_BLOCK }}
-      TestSettings__RemoteStorageBranchId: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_BRANCH_ID }}
       TestSettings__RemoteStorageStartDate: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_START_DATE }}
       TestSettings__RemoteStorageEndDate: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_END_DATE }}
-      TestSettings__RecordSetId: ${{ secrets.PAPI_TEST_RECORD_SET_ID }}
-      TestSettings__ItemRecordId: ${{ secrets.PAPI_TEST_ITEM_RECORD_ID }}
       TestSettings__ItemBarcode: ${{ secrets.PAPI_TEST_ITEM_BARCODE }}
-      TestSettings__PatronAccountTransactionId: ${{ secrets.PAPI_TEST_PATRON_ACCOUNT_TRANSACTION_ID }}
-      TestSettings__HoldRequestId: ${{ secrets.PAPI_TEST_HOLD_REQUEST_ID }}
       IntegrationTestOptions__EnableMutatingIntegrationTests: ${{ inputs.enable_mutating_tests }}
       IntegrationTestOptions__EnableStaffProtectedTests: ${{ inputs.enable_staff_protected_tests }}
       IntegrationTestOptions__EnableScenarioDependentTests: ${{ inputs.enable_scenario_dependent_tests }}
@@ -65,6 +51,47 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
+
+
+      - name: Export non-empty numeric integration settings
+        env:
+          PAPI_ORGANIZATION_ID: ${{ secrets.PAPI_ORGANIZATION_ID }}
+          PAPI_USER_ID: ${{ secrets.PAPI_USER_ID }}
+          PAPI_WORKSTATION_ID: ${{ secrets.PAPI_WORKSTATION_ID }}
+          PAPI_TEST_PATRON_ID: ${{ secrets.PAPI_TEST_PATRON_ID }}
+          PAPI_TEST_BIB_ID: ${{ secrets.PAPI_TEST_BIB_ID }}
+          PAPI_TEST_BRANCH_ID: ${{ secrets.PAPI_TEST_BRANCH_ID }}
+          PAPI_TEST_ORGANIZATION_ID: ${{ secrets.PAPI_TEST_ORGANIZATION_ID }}
+          PAPI_TEST_WORKSTATION_ID: ${{ secrets.PAPI_TEST_WORKSTATION_ID }}
+          PAPI_TEST_USER_ID: ${{ secrets.PAPI_TEST_USER_ID }}
+          PAPI_TEST_REMOTE_STORAGE_BRANCH_ID: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_BRANCH_ID }}
+          PAPI_TEST_RECORD_SET_ID: ${{ secrets.PAPI_TEST_RECORD_SET_ID }}
+          PAPI_TEST_ITEM_RECORD_ID: ${{ secrets.PAPI_TEST_ITEM_RECORD_ID }}
+          PAPI_TEST_PATRON_ACCOUNT_TRANSACTION_ID: ${{ secrets.PAPI_TEST_PATRON_ACCOUNT_TRANSACTION_ID }}
+          PAPI_TEST_HOLD_REQUEST_ID: ${{ secrets.PAPI_TEST_HOLD_REQUEST_ID }}
+        run: |
+          append_if_set() {
+            local name="$1"
+            local value="$2"
+            if [ -n "$value" ]; then
+              printf '%s=%s\n' "$name" "$value" >> "$GITHUB_ENV"
+            fi
+          }
+
+          append_if_set PapiSettings__OrganizationId "$PAPI_ORGANIZATION_ID"
+          append_if_set PapiSettings__UserId "$PAPI_USER_ID"
+          append_if_set PapiSettings__WorkstationId "$PAPI_WORKSTATION_ID"
+          append_if_set TestSettings__PatronId "$PAPI_TEST_PATRON_ID"
+          append_if_set TestSettings__BibId "$PAPI_TEST_BIB_ID"
+          append_if_set TestSettings__BranchId "$PAPI_TEST_BRANCH_ID"
+          append_if_set TestSettings__OrganizationId "$PAPI_TEST_ORGANIZATION_ID"
+          append_if_set TestSettings__WorkstationId "$PAPI_TEST_WORKSTATION_ID"
+          append_if_set TestSettings__UserId "$PAPI_TEST_USER_ID"
+          append_if_set TestSettings__RemoteStorageBranchId "$PAPI_TEST_REMOTE_STORAGE_BRANCH_ID"
+          append_if_set TestSettings__RecordSetId "$PAPI_TEST_RECORD_SET_ID"
+          append_if_set TestSettings__ItemRecordId "$PAPI_TEST_ITEM_RECORD_ID"
+          append_if_set TestSettings__PatronAccountTransactionId "$PAPI_TEST_PATRON_ACCOUNT_TRANSACTION_ID"
+          append_if_set TestSettings__HoldRequestId "$PAPI_TEST_HOLD_REQUEST_ID"
 
       - name: Restore
         run: dotnet restore src/polaris-api-csharp.sln

--- a/src/polaris-api-csharpTests/Integration/HoldAndCirculationIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/HoldAndCirculationIntegrationTests.cs
@@ -8,40 +8,39 @@ namespace Clc.Polaris.Api.Tests.Integration;
 public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
 {
     [TestMethod]
-    public async Task HoldRequestCancelAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void HoldRequestCancelAsync_RequiresDisposableHoldFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.HoldRequestCancelAsync(Settings.PatronBarcode, NonexistentRequestId, Settings.PatronPin, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4201);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestCancelAsync),
+            "canceling a hold request mutates patron hold state and a hard-coded request ID might exist in a live Polaris database",
+            "disposable patron credentials plus a configured disposable hold request ID created for this test",
+            "call HoldRequestCancelAsync only for the disposable hold request and assert the documented success or domain error without touching pre-existing holds");
     }
 
     [TestMethod]
-    public async Task HoldRequestCreateAsync_WithNonexistentBib_ReturnsDocumentedError()
+    public void HoldRequestCreateAsync_RequiresDisposableHoldFixtureAndIsDisabledByDefault()
     {
-        RequirePatronId();
-
-        var holdParams = new HoldRequestCreateParams(Settings.PatronId, NonexistentBibId, BranchIdOrConfiguredOrganizationId, OrganizationIdOrConfigured);
-        var response = await Papi.HoldRequestCreateAsync(holdParams);
-
-        PapiIntegrationAssert.PapiError(response, -4006);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestCreateAsync),
+            "creating a hold request mutates patron hold state and a hard-coded bib ID might exist in a live Polaris database",
+            "a disposable patron ID and disposable bibliographic scenario data explicitly approved for hold creation",
+            "call HoldRequestCreateAsync with disposable fixture data and assert the documented PAPIErrorCode while cleaning up any created hold");
     }
 
     [TestMethod]
-    public async Task HoldRequestCreateAsync_ConvenienceOverload_WithNonexistentBib_ReturnsDocumentedError()
+    public void HoldRequestCreateAsync_ConvenienceOverload_RequiresDisposableHoldFixtureAndIsDisabledByDefault()
     {
-        RequirePatronId();
-
-        var response = await ((PapiClient)Papi).HoldRequestCreateAsync(Settings.PatronId, NonexistentBibId, BranchIdOrConfiguredOrganizationId, requestingOrgId: OrganizationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4006);
+        DocumentScenarioDependentPlaceholder(
+            nameof(PapiClient.HoldRequestCreateAsync),
+            "creating a hold request mutates patron hold state and a hard-coded bib ID might exist in a live Polaris database",
+            "a disposable patron ID and disposable bibliographic scenario data explicitly approved for hold creation",
+            "call the convenience overload with disposable fixture data and assert the documented PAPIErrorCode while cleaning up any created hold");
     }
 
     [TestMethod]
     public async Task HoldRequestGetListAsync_WithConfiguredBranch_ReturnsSuccessShape()
     {
-        RequirePapiConfiguration();
+        RequireStaffProtectedTestsEnabled();
 
         var response = await Papi.HoldRequestGetListAsync(BranchIdOrConfiguredOrganizationId);
         var data = PapiIntegrationAssert.Success(response);
@@ -50,73 +49,72 @@ public sealed class HoldAndCirculationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public async Task HoldRequestReactivateAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void HoldRequestReactivateAsync_RequiresDisposableHoldFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.HoldRequestReactivateAsync(Settings.PatronBarcode, Settings.PatronPin, NonexistentRequestId, DateTime.UtcNow, UserIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4201);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestReactivateAsync),
+            "reactivating a hold request mutates patron hold state and a hard-coded request ID might exist in a live Polaris database",
+            "disposable patron credentials plus a configured disposable suspended hold request ID",
+            "call HoldRequestReactivateAsync only for the disposable hold and assert the documented response");
     }
 
     [TestMethod]
-    public async Task HoldRequestReplyAsync_WithEmptyGuid_ReturnsDocumentedError()
+    public void HoldRequestReplyAsync_RequiresDisposableHoldFixtureAndIsDisabledByDefault()
     {
-        RequirePapiConfiguration();
-
-        var hold = new HoldRequestCreateResult { RequestGuid = Guid.Empty };
-        var response = await Papi.HoldRequestReplyAsync(hold, OrganizationIdOrConfigured, HoldRequestReplyAnswer.Yes, HoldRequestReplyState.AcceptEvenWithExistingHolds);
-
-        PapiIntegrationAssert.PapiError(response, -4101);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestReplyAsync),
+            "replying to a hold request can mutate hold state and should not be exercised by default with synthetic request identifiers",
+            "a disposable hold request fixture with a request GUID that is safe to reply to",
+            "call HoldRequestReplyAsync only for the disposable request and assert the documented response");
     }
 
     [TestMethod]
-    public async Task HoldRequestSuspendAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void HoldRequestSuspendAsync_RequiresDisposableHoldFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.HoldRequestSuspendAsync(Settings.PatronBarcode, NonexistentRequestId, DateTime.UtcNow, Settings.PatronPin, UserIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4201);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.HoldRequestSuspendAsync),
+            "suspending a hold request mutates patron hold state and a hard-coded request ID might exist in a live Polaris database",
+            "disposable patron credentials plus a configured disposable active hold request ID",
+            "call HoldRequestSuspendAsync only for the disposable hold and assert the documented response");
     }
 
     [TestMethod]
-    public async Task UpdatePickupBranchIDAsync_WithNonexistentRequest_ReturnsDocumentedError()
+    public void UpdatePickupBranchIDAsync_RequiresDisposableHoldFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.UpdatePickupBranchIDAsync(Settings.PatronBarcode, NonexistentRequestId, BranchIdOrConfiguredOrganizationId, Settings.PatronPin, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -4201);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.UpdatePickupBranchIDAsync),
+            "changing pickup branch mutates patron hold state and a hard-coded request ID might exist in a live Polaris database",
+            "disposable patron credentials, a configured disposable hold request ID, and a safe pickup branch ID",
+            "call UpdatePickupBranchIDAsync only for the disposable hold and assert the documented response");
     }
 
     [TestMethod]
-    public async Task ItemRenewAsync_WithNonexistentItem_ReturnsDocumentedError()
+    public void ItemRenewAsync_RequiresDisposableCheckoutFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.ItemRenewAsync(Settings.PatronBarcode, NonexistentItemRecordId, Settings.PatronPin);
-
-        PapiIntegrationAssert.PapiError(response, -6001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.ItemRenewAsync),
+            "renewing an item mutates circulation state and a hard-coded item ID might exist in a live Polaris database",
+            "disposable patron credentials plus a configured disposable checked-out item ID",
+            "call ItemRenewAsync only for the disposable item and assert success or documented item-level errors");
     }
 
     [TestMethod]
     public void ItemRenewAllForPatronAsync_RequiresScenarioDataAndIsDisabledByDefault()
     {
-        RequireScenarioDependentTestsEnabled(
+        DocumentScenarioDependentPlaceholder(
             nameof(Papi.ItemRenewAllForPatronAsync),
+            "renew-all mutates circulation state for every renewable item on the patron account",
             "TestSettings:PatronBarcode and TestSettings:PatronPin for a disposable patron with renewable checked-out items",
             "call ItemRenewAllForPatronAsync and assert a deserialized ItemRenewResultWrapper with either success item rows or documented item-level errors");
     }
 
     [TestMethod]
-    public async Task ItemUpdateBarcodeAsync_WithNonexistentItem_IsGatedAsMutatingReachabilityTest()
+    public void ItemUpdateBarcodeAsync_RequiresDisposableItemFixtureAndIsDisabledByDefault()
     {
-        RequireMutatingTestsEnabled();
-
-        var response = await Papi.ItemUpdateBarcodeAsync("PAPI-INTEGRATION-NONEXISTENT-BARCODE", NonexistentItemRecordId, BranchIdOrConfiguredOrganizationId);
-        var data = PapiIntegrationAssert.HasPapiData(response);
-
-        Assert.IsTrue(data.PAPIErrorCode < 0, "A nonexistent item/barcode update should reach PAPI and return a documented domain error instead of mutating real data.");
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.ItemUpdateBarcodeAsync),
+            "updating an item barcode mutates item data and must not target a hard-coded item ID that might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true plus TestSettings:ItemRecordId and TestSettings:ItemBarcode for a disposable item fixture",
+            "call ItemUpdateBarcodeAsync only with explicitly configured disposable item data and assert the documented PAPI response");
     }
 }

--- a/src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs
+++ b/src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs
@@ -7,12 +7,12 @@ namespace Clc.Polaris.Api.Tests.Integration;
 
 public abstract class IntegrationTestBase
 {
-    protected const int NonexistentBibId = 1234;
-    protected const int NonexistentItemRecordId = 1234;
-    protected const int NonexistentRequestId = 1234;
-    protected const int NonexistentRecordSetId = 1234;
-    protected const int NonexistentTitleListId = 1234;
-    protected const int NonexistentNotificationId = 1234;
+    protected const int NonexistentBibId = 2_147_483_647;
+    protected const int NonexistentItemRecordId = 2_147_483_647;
+    protected const int NonexistentRequestId = 2_147_483_647;
+    protected const int NonexistentRecordSetId = 2_147_483_647;
+    protected const int NonexistentTitleListId = 2_147_483_647;
+    protected const int NonexistentNotificationId = 2_147_483_647;
 
     private const string MissingConfigurationMessage = "Integration test configuration is missing. Provide appsettings.Test.json or environment variables to run live PAPI tests.";
 
@@ -30,10 +30,23 @@ public abstract class IntegrationTestBase
             .Build();
 
         PapiSettings = config.GetSection(PapiSettings.SECTION_NAME).Get<PapiSettings>() ?? new PapiSettings();
-        Settings = config.GetSection(IntegrationScenarioSettings.SectionName).Get<IntegrationScenarioSettings>() ?? new IntegrationScenarioSettings();
+        Settings = LoadScenarioSettings(config);
         Options = config.GetSection(nameof(IntegrationTestOptions)).Get<IntegrationTestOptions>() ?? new IntegrationTestOptions();
 
         Papi = new PapiClient(PapiSettings);
+    }
+
+
+    private static IntegrationScenarioSettings LoadScenarioSettings(IConfiguration config)
+    {
+        var settings = config.Get<IntegrationScenarioSettings>() ?? new IntegrationScenarioSettings();
+        var testSettingsSection = config.GetSection(IntegrationScenarioSettings.SectionName);
+        if (testSettingsSection.Exists())
+        {
+            testSettingsSection.Bind(settings);
+        }
+
+        return settings;
     }
 
     protected void RequirePapiConfiguration()
@@ -146,12 +159,17 @@ public abstract class IntegrationTestBase
 
     protected void RequireMutatingTestsEnabled()
     {
-        RequirePatronCredentials();
+        RequirePapiConfiguration();
 
         if (!Options.EnableMutatingIntegrationTests)
         {
-            Assert.Inconclusive("Mutating integration tests are disabled. Set IntegrationTestOptions:EnableMutatingIntegrationTests=true only for safe test fixtures.");
+            Assert.Inconclusive("Mutating integration tests are disabled. Set IntegrationTestOptions:EnableMutatingIntegrationTests=true only for safe disposable test fixtures.");
         }
+    }
+
+    protected void DocumentScenarioDependentPlaceholder(string methodName, string whyScenarioDataIsRequired, string requiredSettings, string assertionStrategy)
+    {
+        Assert.Inconclusive($"{methodName} is a scenario-dependent placeholder and has no executable fixture-backed implementation yet. Reason: {whyScenarioDataIsRequired}. Required settings: {requiredSettings}. Intended assertion strategy: {assertionStrategy}. No live API call was made.");
     }
 
     protected void RequireScenarioDependentTestsEnabled(string methodName, string requiredSettings, string assertionStrategy)

--- a/src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs
@@ -30,95 +30,133 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     }
 
     [TestMethod]
-    public async Task PatronAccountPayAsync_WithNonexistentCharge_ReturnsDocumentedError()
+    public void PatronAccountPayAsync_RequiresDisposableAccountFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronAccountPayAsync(Settings.PatronBarcode, NonexistentNotificationId, .01, PaymentMethod.Cash, note: "integration testing");
-
-        PapiIntegrationAssert.PapiError(response, -3600);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronAccountPayAsync),
+            "paying a charge mutates patron account/payment state and a hard-coded charge ID might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and a configured disposable charge fixture",
+            "call PatronAccountPayAsync only for disposable charge data and assert the documented payment response");
     }
 
     [TestMethod]
-    public async Task PatronAccountPayAllAsync_WithExcessiveAmount_ReturnsDocumentedError()
+    public void PatronAccountPayAllAsync_RequiresDisposableAccountFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronAccountPayAllAsync(Settings.PatronBarcode, 999999.99, PaymentMethod.Cash, note: "integration testing");
-
-        PapiIntegrationAssert.PapiError(response, -3610);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronAccountPayAllAsync),
+            "pay-all mutates patron account/payment state and should not run against a real patron without disposable account fixtures",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and configured disposable account balance data",
+            "call PatronAccountPayAllAsync only for disposable account data and assert the documented response without affecting real balances");
     }
 
     [TestMethod]
-    public async Task PatronAccountRefundCreditAsync_WithExcessiveAmount_ReturnsDocumentedError()
+    public void PatronAccountRefundCreditAsync_RequiresDisposableAccountFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronAccountRefundCreditAsync(Settings.PatronBarcode, 999999.99, note: "integration testing");
-
-        PapiIntegrationAssert.PapiError(response, -3606);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronAccountRefundCreditAsync),
+            "refund-credit mutates patron account/payment state and should not run against a real patron without disposable credit fixtures",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and configured disposable credit balance data",
+            "call PatronAccountRefundCreditAsync only for disposable credit data and assert the documented response without affecting real balances");
     }
 
     [TestMethod]
-    public async Task PatronAccountVoidAsync_WithNonexistentTransaction_ReturnsDocumentedError()
+    public void PatronAccountVoidAsync_RequiresDisposableAccountFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronAccountVoidAsync(Settings.PatronBarcode, NonexistentNotificationId, note: "integration testing");
-
-        PapiIntegrationAssert.PapiError(response, -3606);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronAccountVoidAsync),
+            "voiding a payment mutates patron account/payment state and a hard-coded transaction ID might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and a configured disposable transaction fixture",
+            "call PatronAccountVoidAsync only for disposable transaction data and assert the documented response");
     }
 
     [TestMethod]
-    public async Task PatronTitleListMethods_WithNonexistentLists_ReturnDocumentedErrors()
+    public void PatronTitleListMethods_RequireDisposableTitleListFixturesAndAreDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListAddTitleAsync(Settings.PatronBarcode, NonexistentTitleListId, NonexistentBibId, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListCopyAllTitlesAsync(Settings.PatronBarcode, NonexistentTitleListId, NonexistentTitleListId + 1, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListCopyTitleAsync(Settings.PatronBarcode, NonexistentTitleListId, 1, NonexistentTitleListId + 1, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListDeleteAllTitlesAsync(Settings.PatronBarcode, NonexistentTitleListId, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListDeleteTitleAsync(Settings.PatronBarcode, NonexistentTitleListId, 1, Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListGetTitlesAsync(Settings.PatronBarcode, NonexistentTitleListId, password: Settings.PatronPin), -1);
-        PapiIntegrationAssert.PapiError(await Papi.PatronTitleListMoveTitleAsync(Settings.PatronBarcode, NonexistentTitleListId, 1, NonexistentTitleListId + 1, Settings.PatronPin), -1);
+        DocumentScenarioDependentPlaceholder(
+            "PatronTitleList add/copy/delete/move methods",
+            "most title-list operations mutate patron title-list content and hard-coded list or bib IDs might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and configured disposable source/destination title-list plus bib fixtures",
+            "call each title-list method only against disposable title lists and assert documented PAPIErrorCode values while preserving pre-existing lists");
     }
 
     [TestMethod]
     public async Task PatronAccountCreateAndDeleteTitleListAsync_WhenMutatingTestsEnabled_CleansUpList()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
         if (string.IsNullOrWhiteSpace(Settings.PatronListName))
         {
             Assert.Inconclusive("Mutating title-list flow requires TestSettings:PatronListName.");
         }
 
+        var uniqueListName = $"{Settings.PatronListName}-{Guid.NewGuid():N}";
+        var createSucceeded = false;
         int? createdListId = null;
+        Exception? testFailure = null;
+        Exception? cleanupFailure = null;
+
         try
         {
-            var createResponse = await Papi.PatronAccountCreateTitleListAsync(Settings.PatronBarcode, Settings.PatronListName, Settings.PatronPin);
-            var createData = PapiIntegrationAssert.HasPapiData(createResponse);
-            Assert.IsTrue(createData.PAPIErrorCode == 0 || createData.PAPIErrorCode == -1, createData.ErrorMessage);
+            var createResponse = await Papi.PatronAccountCreateTitleListAsync(Settings.PatronBarcode, uniqueListName, Settings.PatronPin);
+            PapiIntegrationAssert.ExactZeroSuccess(createResponse);
+            createSucceeded = true;
 
-            var getResponse = await Papi.PatronAccountGetTitleListsAsync(Settings.PatronBarcode, Settings.PatronPin);
-            var getData = PapiIntegrationAssert.Success(getResponse);
-            var list = getData.PatronAccountTitleListsRows.SingleOrDefault(l => l.RecordStoreName == Settings.PatronListName);
-            Assert.IsNotNull(list, "The created or pre-existing test title list should be visible before cleanup.");
-            createdListId = list.RecordStoreId;
+            createdListId = await TryFindTitleListIdAsync(uniqueListName);
+            Assert.IsTrue(createdListId.HasValue, "The title list created by this test should be visible before cleanup.");
+        }
+        catch (Exception ex)
+        {
+            testFailure = ex;
         }
         finally
         {
-            if (createdListId.HasValue)
+            if (createSucceeded)
             {
-                var deleteResponse = await Papi.PatronAccountDeleteTitleListAsync(Settings.PatronBarcode, createdListId.Value, Settings.PatronPin);
-                PapiIntegrationAssert.Success(deleteResponse);
+                try
+                {
+                    createdListId ??= await TryFindTitleListIdAsync(uniqueListName);
+                    if (createdListId.HasValue)
+                    {
+                        var deleteResponse = await Papi.PatronAccountDeleteTitleListAsync(Settings.PatronBarcode, createdListId.Value, Settings.PatronPin);
+                        PapiIntegrationAssert.Success(deleteResponse);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    cleanupFailure = ex;
+                }
             }
         }
+
+        if (cleanupFailure != null)
+        {
+            if (testFailure != null)
+            {
+                Assert.Fail($"The title-list test failed after creating '{uniqueListName}', and cleanup also failed. Original failure: {testFailure}. Cleanup failure: {cleanupFailure}");
+            }
+
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(cleanupFailure).Throw();
+        }
+
+        if (testFailure != null)
+        {
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(testFailure).Throw();
+        }
+    }
+
+    private async Task<int?> TryFindTitleListIdAsync(string uniqueListName)
+    {
+        var getResponse = await Papi.PatronAccountGetTitleListsAsync(Settings.PatronBarcode, Settings.PatronPin);
+        var getData = PapiIntegrationAssert.Success(getResponse);
+        return getData.PatronAccountTitleListsRows.SingleOrDefault(l => l.RecordStoreName == uniqueListName)?.RecordStoreId;
     }
 
     [TestMethod]
     public async Task PatronAccountCreateCreditAsync_WhenMutatingTestsEnabled_CreatesCredit()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.PatronAccountCreateCreditAsync(Settings.PatronBarcode, .01, PaymentMethod.Cash, WorkstationIdOrConfigured, UserIdOrConfigured, "integration testing");
 
@@ -128,7 +166,9 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     [TestMethod]
     public async Task PatronAccountDepositCreditAsync_WhenMutatingTestsEnabled_DepositsCredit()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.PatronAccountDepositCreditAsync(Settings.PatronBarcode, .01, WorkstationIdOrConfigured, UserIdOrConfigured, "integration testing");
 

--- a/src/polaris-api-csharpTests/Integration/PatronMutationIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronMutationIntegrationTests.cs
@@ -11,7 +11,9 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task CreatePatronBlocksAsync_FreeText_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
         if (string.IsNullOrWhiteSpace(Settings.FreeTextBlock))
         {
             Assert.Inconclusive("Mutating patron block tests require TestSettings:FreeTextBlock.");
@@ -26,7 +28,9 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task CreatePatronBlocksAsync_SystemBlock_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.System, "128", UserIdOrConfigured, WorkstationIdOrConfigured);
         var data = PapiIntegrationAssert.HasPapiData(response);
@@ -37,7 +41,9 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task CreatePatronBlocksAsync_LibraryAssignedBlock_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.LibraryAssigned, "1", UserIdOrConfigured, WorkstationIdOrConfigured);
         var data = PapiIntegrationAssert.HasPapiData(response);
@@ -46,39 +52,40 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public async Task PatronMessageDeleteAsync_WithNonexistentMessage_ReturnsDocumentedError()
+    public void PatronMessageDeleteAsync_RequiresDisposableMessageFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronMessageDeleteAsync(Settings.PatronBarcode, PatronMessageType.freetext, NonexistentNotificationId, Settings.PatronPin);
-
-        PapiIntegrationAssert.PapiError(response, -1);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronMessageDeleteAsync),
+            "deleting a patron message mutates patron notification/message state and a hard-coded notification ID might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and a configured disposable patron message fixture",
+            "call PatronMessageDeleteAsync only for a disposable message and assert the documented response");
     }
 
     [TestMethod]
-    public async Task PatronMessageUpdateStatusAsync_WithNonexistentMessage_ReturnsDocumentedError()
+    public void PatronMessageUpdateStatusAsync_RequiresDisposableMessageFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronMessageUpdateStatusAsync(Settings.PatronBarcode, PatronMessageType.freetext, NonexistentNotificationId, Settings.PatronPin);
-
-        PapiIntegrationAssert.PapiError(response, -1);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronMessageUpdateStatusAsync),
+            "updating patron message status mutates patron notification/message state and a hard-coded notification ID might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and a configured disposable patron message fixture",
+            "call PatronMessageUpdateStatusAsync only for a disposable message and assert the documented response");
     }
 
     [TestMethod]
-    public async Task PatronReadingHistoryClearAsync_WithNonexistentTitle_ReturnsDocumentedError()
+    public void PatronReadingHistoryClearAsync_RequiresDisposableReadingHistoryFixtureAndIsDisabledByDefault()
     {
-        RequirePatronCredentials();
-
-        var response = await Papi.PatronReadingHistoryClearAsync(Settings.PatronBarcode, new[] { NonexistentBibId });
-
-        PapiIntegrationAssert.PapiError(response, -10);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.PatronReadingHistoryClearAsync),
+            "clearing reading-history entries mutates patron history and a hard-coded bib ID might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true, disposable patron credentials, and configured disposable reading-history title fixture",
+            "call PatronReadingHistoryClearAsync only for disposable reading-history data and assert the documented response");
     }
 
     [TestMethod]
     public async Task PatronUpdateAsync_WhenMutatingTestsEnabled_AllowsEmptyNoOpUpdate()
     {
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.PatronUpdateAsync(Settings.PatronBarcode, new PatronUpdateParams(), Settings.PatronPin);
 
@@ -88,6 +95,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task PatronUpdateUserNameAsync_WithUnsafeBarcode_ReturnsUnauthorizedWithoutChangingPatron()
     {
+        RequireMutatingTestsEnabled();
         RequirePatronCredentials();
 
         var response = await Papi.PatronUpdateUserNameAsync(Settings.PatronBarcode + "-nonexistent", Settings.PatronPin, Settings.PatronPin);
@@ -99,8 +107,9 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public void PatronRegistrationCreateAsync_RequiresScenarioDataAndIsDisabledByDefault()
     {
-        RequireScenarioDependentTestsEnabled(
+        DocumentScenarioDependentPlaceholder(
             nameof(Papi.PatronRegistrationCreateAsync),
+            "patron registration creates patron data and requires a complete site-specific disposable registration profile",
             "a complete PatronRegistrationParams fixture for a disposable patron registration profile",
             "create a disposable patron, assert a non-negative PAPIErrorCode and returned patron id/barcode, then clean up manually if the site supports it");
     }
@@ -108,36 +117,29 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public void PatronRegistrationCreateV2Async_RequiresScenarioDataAndIsDisabledByDefault()
     {
-        RequireScenarioDependentTestsEnabled(
+        DocumentScenarioDependentPlaceholder(
             nameof(Papi.PatronRegistrationCreateV2Async),
+            "patron registration v2 creates patron data and requires a complete site-specific disposable registration profile",
             "a complete PatronRegistrationData fixture for a disposable patron registration profile",
             "create a disposable patron with the v2 payload and assert a non-negative PAPIErrorCode plus returned patron id/barcode");
     }
 
     [TestMethod]
-    public async Task NotificationUpdateAsync_WithNonexistentNotification_ReturnsDocumentedError()
+    public void NotificationUpdateAsync_RequiresDisposableNotificationFixtureAndIsDisabledByDefault()
     {
-        RequirePatronId();
-
-        var response = await Papi.NotificationUpdateAsync(new NotificationUpdateParams
-        {
-            PatronId = Settings.PatronId,
-            DeliveryString = "test@example.org",
-            ReportingOrgID = OrganizationIdOrConfigured,
-            NotificationDeliveryDate = DateTime.UtcNow,
-            DeliveryOptionId = 2,
-            Details = "integration test reachability",
-            NotificationStatusId = NotificationStatus.EmailCompleted,
-            NotificationTypeId = NonexistentNotificationId
-        });
-
-        PapiIntegrationAssert.PapiError(response, -1);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.NotificationUpdateAsync),
+            "updating notification state mutates patron notification data and a hard-coded notification type/id might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableMutatingIntegrationTests=true and a configured disposable notification fixture for a disposable patron",
+            "call NotificationUpdateAsync only for disposable notification data and assert the documented response");
     }
 
     [TestMethod]
     public async Task UpdatePatronNotesDataAsync_WhenMutatingTestsEnabled_UpdatesConfiguredPatronNotes()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireMutatingTestsEnabled();
+        RequirePatronCredentials();
 
         var response = await Papi.UpdatePatronNotesDataAsync(Settings.PatronBarcode, nonBlockingNote: "PAPI integration test note", updateMode: UpdateNoteMode.Prepend, workstationId: WorkstationIdOrConfigured);
 

--- a/src/polaris-api-csharpTests/Integration/PatronReadIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronReadIntegrationTests.cs
@@ -22,6 +22,7 @@ public sealed class PatronReadIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task Patron_GetBarcodeFromIdAsync_WithConfiguredPatron_ReturnsBarcode()
     {
+        RequireStaffProtectedTestsEnabled();
         RequirePatronId();
         RequirePatronCredentials();
 
@@ -124,6 +125,7 @@ public sealed class PatronReadIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task PatronRenewBlocksGetAsync_WithConfiguredPatron_ReturnsSuccessShape()
     {
+        RequireStaffProtectedTestsEnabled();
         RequirePatronId();
 
         var response = await Papi.PatronRenewBlocksGetAsync(Settings.PatronId, BranchIdOrConfiguredOrganizationId);
@@ -142,6 +144,7 @@ public sealed class PatronReadIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task PatronSearchAsync_WithConfiguredPatronId_ReturnsMatchingRows()
     {
+        RequireStaffProtectedTestsEnabled();
         RequirePatronId();
 
         var response = await Papi.PatronSearchAsync($"PRID={Settings.PatronId}", orgId: OrganizationIdOrConfigured);

--- a/src/polaris-api-csharpTests/Integration/StaffProtectedAndRecordSetIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/StaffProtectedAndRecordSetIntegrationTests.cs
@@ -18,53 +18,53 @@ public sealed class StaffProtectedAndRecordSetIntegrationTests : IntegrationTest
     }
 
     [TestMethod]
-    public async Task RecordSetContentAddAsync_WithSingleRecordAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentAddAsync_WithSingleRecord_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentAddAsync(NonexistentRecordSetId, NonexistentBibId, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentAddAsync),
+            "adding record-set content mutates staff/protected record-set state and hard-coded record-set or bib IDs might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and configured disposable record-set plus bib fixtures",
+            "call RecordSetContentAddAsync only against a disposable record set and assert the documented response before cleanup");
     }
 
     [TestMethod]
-    public async Task RecordSetContentAddAsync_WithRecordListAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentAddAsync_WithRecordList_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentAddAsync(NonexistentRecordSetId, new[] { NonexistentBibId }, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentAddAsync),
+            "adding record-set content mutates staff/protected record-set state and hard-coded record-set or bib IDs might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and configured disposable record-set plus bib fixtures",
+            "call the record-list overload only against a disposable record set and assert the documented response before cleanup");
     }
 
     [TestMethod]
-    public async Task RecordSetContentRemoveAsync_WithSingleRecordAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentRemoveAsync_WithSingleRecord_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentRemoveAsync(NonexistentRecordSetId, NonexistentBibId, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentRemoveAsync),
+            "removing record-set content mutates staff/protected record-set state and hard-coded record-set or bib IDs might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and configured disposable record-set plus bib fixtures",
+            "call RecordSetContentRemoveAsync only against a disposable record set and assert the documented response before cleanup");
     }
 
     [TestMethod]
-    public async Task RecordSetContentRemoveAsync_WithRecordListAndNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentRemoveAsync_WithRecordList_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentRemoveAsync(NonexistentRecordSetId, new[] { NonexistentBibId }, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentRemoveAsync),
+            "removing record-set content mutates staff/protected record-set state and hard-coded record-set or bib IDs might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and configured disposable record-set plus bib fixtures",
+            "call the record-list overload only against a disposable record set and assert the documented response before cleanup");
     }
 
     [TestMethod]
-    public async Task RecordSetContentPutAsync_WithNonexistentRecordSet_ReturnsDocumentedError()
+    public void RecordSetContentPutAsync_RequiresDisposableRecordSetFixtureAndIsDisabledByDefault()
     {
-        RequireStaffProtectedTestsEnabled();
-
-        var response = await Papi.RecordSetContentPutAsync(NonexistentRecordSetId, new[] { NonexistentBibId }, RecordSetContentPutActions.Add, UserIdOrConfigured, WorkstationIdOrConfigured);
-
-        PapiIntegrationAssert.PapiError(response, -11001);
+        DocumentScenarioDependentPlaceholder(
+            nameof(Papi.RecordSetContentPutAsync),
+            "putting record-set content mutates staff/protected record-set state and hard-coded record-set or bib IDs might exist in a live Polaris database",
+            "IntegrationTestOptions:EnableStaffProtectedTests=true, IntegrationTestOptions:EnableMutatingIntegrationTests=true, staff override credentials, and configured disposable record-set plus bib fixtures",
+            "call RecordSetContentPutAsync only against a disposable record set and assert the documented response before cleanup");
     }
 
     [TestMethod]

--- a/src/polaris-api-csharpTests/Integration/SynchIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/SynchIntegrationTests.cs
@@ -9,6 +9,7 @@ public sealed class SynchIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task Synch_BibsByIdGetAsync_WithConfiguredBib_ReturnsSynchronisationPayload()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireBibScenario();
 
         var response = await Papi.Synch_BibsByIdGetAsync(Settings.BibId);

--- a/src/polaris-api-csharpTests/README.md
+++ b/src/polaris-api-csharpTests/README.md
@@ -32,7 +32,7 @@ Copy the example file and replace placeholders with values for a disposable/safe
 cp src/polaris-api-csharpTests/appsettings.Test.example.json src/polaris-api-csharpTests/appsettings.Test.json
 ```
 
-`appsettings.Test.json` is intentionally not committed. The test project copies it to the output directory only when the file exists. Integration-only fixture values are bound to `IntegrationScenarioSettings` from the existing `TestSettings` section so older local configuration files and environment-variable names continue to work.
+`appsettings.Test.json` is intentionally not committed. The test project copies it to the output directory only when the file exists. Integration-only fixture values are bound to `IntegrationScenarioSettings` from the `TestSettings` section. For compatibility with pre-refactor local files, the fixture also binds legacy root-level settings first (for example `PatronId`, `PatronBarcode`, `PatronPin`, `FreeTextBlock`, `PatronListName`, and `OrgEmail`) and then lets the nested `TestSettings` section override them when it exists, so older local configuration files and environment-variable names continue to work.
 
 ## Environment variables
 
@@ -71,6 +71,8 @@ The integration fixture also loads environment variables using standard .NET con
 - `IntegrationTestOptions__EnableScenarioDependentTests`
 - `IntegrationTestOptions__EnableAuthenticationFailureTests`
 
+When using the manual GitHub integration workflow, omit optional numeric fixture secrets that are not configured instead of setting them to empty strings. The workflow writes numeric `PapiSettings__...` and `TestSettings__...` variables only when the corresponding secret has a value, which avoids .NET configuration binding failures from empty strings before test gates can mark missing config inconclusive.
+
 ## Fixture data required
 
 Minimum live read-only configuration:
@@ -83,7 +85,7 @@ Additional success-path scenarios require:
 - Patron read tests: `TestSettings:PatronId`, `PatronBarcode`, and `PatronPin`
 - Catalog success tests: `TestSettings:BibId`
 - Branch-specific lookups: `TestSettings:BranchId`
-- Staff/protected endpoints: `PapiSettings:PolarisOverrideAccount:*` plus `IntegrationTestOptions:EnableStaffProtectedTests=true`
+- Staff/protected endpoints, including protected patron/synch read routes such as barcode-from-ID, renew-blocks, patron search, and synch bibs: `PapiSettings:PolarisOverrideAccount:*` plus `IntegrationTestOptions:EnableStaffProtectedTests=true`
 - `SA_GetValueByOrgAsync`: `TestSettings:OrgEmail` matching the configured organization
 - Remote storage: `TestSettings:RemoteStorageBranchId`, `RemoteStorageStartDate`, and `RemoteStorageEndDate`, plus scenario-dependent tests enabled
 - Optional scenario fixtures for local extensions: `TestSettings:RecordSetId`, `ItemRecordId`, `ItemBarcode`, `PatronAccountTransactionId`, and `HoldRequestId`
@@ -92,27 +94,29 @@ Do not use production patrons/items unless the site owner has explicitly approve
 
 ## Mutating tests
 
-Mutating tests are disabled by default. To run them, set:
+Mutating tests are disabled by default, and default integration runs should not call mutating endpoints. To run implemented mutating tests, set:
 
 ```bash
 IntegrationTestOptions__EnableMutatingIntegrationTests=true
 ```
 
-These tests are clearly named with `WhenMutatingTestsEnabled` and call the shared gate before changing data. They are intended for disposable fixtures only. Some mutating tests use create/read/delete flows with cleanup; account-credit and patron-note tests still mutate configured patron data and should only be enabled in safe environments.
+The mutating gate checks live PAPI configuration and the explicit option only. Patron-specific mutating tests also require `TestSettings:PatronBarcode` and `TestSettings:PatronPin`; staff/protected mutating tests must also satisfy the staff/protected gate. These tests are intended for disposable fixtures only. Some mutating tests use create/read/delete flows with cleanup; account-credit, patron-block, patron-update, and patron-note tests still mutate configured patron data and should only be enabled in safe environments. Hard-coded invalid IDs are not used as safety mechanisms for mutating operations; any live mutating scenario that needs item, record-set, account, hold, notification, or title-list data must use explicitly configured disposable fixtures.
 
 ## Staff-protected tests
 
-Protected/staff tests are disabled by default because they require a staff override account and may access protected PAPI routes. To run them, provide `PapiSettings:PolarisOverrideAccount` and set:
+Protected/staff tests are disabled by default because they require a staff override account and may access protected PAPI routes. To run them, provide `PapiSettings:PolarisOverrideAccount` credentials and set:
 
 ```bash
 IntegrationTestOptions__EnableStaffProtectedTests=true
 ```
 
-Record-set tests use nonexistent record-set IDs and assert documented negative `PAPIErrorCode` values so they prove authenticated reachability without modifying real record sets.
+Read-only staff/protected reachability tests may use known-invalid sentinel IDs and assert documented negative `PAPIErrorCode` values. Protected patron and synch read endpoints also require staff override credentials and `IntegrationTestOptions:EnableStaffProtectedTests=true`, even when they use patron or bib fixture data. Record-set content add/remove/put tests are mutating and remain inconclusive placeholders until disposable record-set fixtures are configured and an executable cleanup strategy is implemented.
 
 ## Scenario-dependent placeholders
 
-Some client methods require real local data that cannot be safely invented, such as renewable checked-out items, complete patron registration payloads, or remote-storage activity windows. The suite includes inconclusive placeholder tests documenting the method name, why scenario data is required, the required fixture settings, and the intended assertion strategy. Enable them only after adding local fixture data:
+Some client methods require real local data that cannot be safely invented, such as renewable checked-out items, complete patron registration payloads, payment/refund/void fixtures, disposable item barcode fixtures, hold fixtures, record-set mutation fixtures, or remote-storage activity windows. Placeholder tests always call `Assert.Inconclusive(...)` and do not pass merely because `IntegrationTestOptions:EnableScenarioDependentTests=true`; they document the method name, why scenario data is required, the required fixture settings, and the intended assertion strategy until a fixture-backed implementation exists.
+
+Executable scenario-dependent tests may still use this option as an additional opt-in gate after validating all required fixture settings:
 
 ```bash
 IntegrationTestOptions__EnableScenarioDependentTests=true
@@ -122,7 +126,7 @@ IntegrationTestOptions__EnableScenarioDependentTests=true
 
 PAPI often returns HTTP 200 with a `PAPIErrorCode` carrying endpoint-level status. Negative `PAPIErrorCode` values represent PAPI/domain errors. Zero and positive values are no-error success codes; positive values commonly represent rows returned or rows affected. The integration success helper therefore treats any non-negative `PAPIErrorCode` as success, and list/read tests keep stronger row-count assertions where the response collection has stable row-count semantics.
 
-The integration tests intentionally prefer stable nonexistent IDs over dangerous repeated bad credentials. For example, invalid hold request IDs, bibliographic IDs, item IDs, transaction IDs, and record-set IDs exercise the route, authentication, deserialization, and documented PAPI error-code behavior without relying on fragile success state. Known-error reachability tests still assert exact negative `PAPIErrorCode` values only when the Polaris API Reference Guide 8.0 documents the code or the previous integration suite already used that stable code. They avoid asserting exact `ErrorMessage` text unless it is needed and stable.
+Read-only known-error reachability tests may use high known-invalid sentinel IDs to exercise the route, authentication, deserialization, and documented PAPI error-code behavior without relying on fragile success state. Mutating endpoints must not rely on hard-coded nonexistent IDs as their safety mechanism; they either require explicit disposable configured fixtures and mutating opt-in gates or remain inconclusive scenario-dependent placeholders. Known-error reachability tests still assert exact negative `PAPIErrorCode` values only when the Polaris API Reference Guide 8.0 documents the code or the previous integration suite already used that stable code. They avoid asserting exact `ErrorMessage` text unless it is needed and stable.
 
 ## Failed authentication tests
 
@@ -145,7 +149,7 @@ The guide was used selectively to confirm endpoint routes, response shapes, row-
 | Reference data lookup | Collections, dates closed, item statuses, limit filters, MARC types, material types, organizations, patron codes, pickup branches, shelf locations | None | None | None |
 | Synch | synch bibs by ID | None | None | None |
 | Patron reads | validate, barcode-from-id, basic data, blocks, hold/ILL/items out, messages, preferences, reading history, renew blocks, saved searches, patron search | None | None | None |
-| Patron account/title lists | account get, title lists get | nonexistent charge/payment/title-list IDs | create/delete title list, create credit, deposit credit | None |
-| Hold requests/circulation | hold request list | nonexistent hold request, bib, request GUID, pickup branch, item renewal IDs | item barcode update is additionally gated because the endpoint mutates item data | renew-all requires a patron with renewable checked-out items |
-| Patron mutations/messages | None by default | nonexistent patron message, reading-history title, notification update IDs; unsafe username update asserts unauthorized | patron blocks, no-op patron update, notes update | patron registration v1/v2 require complete disposable-registration fixtures |
-| Staff/protected/record sets | SA value lookup and notification queue when staff tests are enabled | nonexistent record-set IDs for get/add/remove/put | None | remote storage requires branch/date activity data |
+| Patron account/title lists | account get, title lists get | None by default for payment/refund/void/title-list mutations | unique create/delete title list, create credit, deposit credit | payment/refund/void and hard-coded title-list mutation reachability require disposable account/list fixtures |
+| Hold requests/circulation | hold request list (staff/protected-gated) | None by default for hold/item mutations | None without disposable fixtures | hold create/cancel/reactivate/suspend/reply/pickup updates, item renew, renew-all, and item barcode update require disposable fixtures |
+| Patron mutations/messages | None by default | None by default for patron message/reading-history/notification mutations | patron blocks, no-op patron update, username unauthorized check, notes update | patron message, reading-history, notification update, and registration v1/v2 require disposable fixtures |
+| Staff/protected/record sets | hold request list, SA value lookup, notification queue when staff tests are enabled | read-only record-set get with a known-invalid sentinel ID | None without disposable fixtures | record-set add/remove/put mutations and remote storage require explicit scenario data |


### PR DESCRIPTION
### Motivation

- Prevent unsafe mutating integration tests from running against real data by converting many mutating/fixture-dependent tests into documented inconclusive placeholders. 
- Avoid .NET configuration binding failures caused by empty-string numeric secrets when running the manual GitHub integration workflow. 
- Preserve backward compatibility with older local configuration files while moving integration fixture data under `TestSettings`/`IntegrationScenarioSettings`. 
- Improve robustness of an existing mutating title-list test by making creation unique and adding safe cleanup with error propagation.

### Description

- Added a GitHub Actions step `Export non-empty numeric integration settings` that writes numeric `PapiSettings__*` and `TestSettings__*` environment variables into `GITHUB_ENV` only when the corresponding secret is non-empty. 
- Reworked many integration tests to call a new `DocumentScenarioDependentPlaceholder` helper instead of making live mutating calls, and renamed tests to clearly indicate they are disabled by default and require disposable fixtures. 
- Introduced `LoadScenarioSettings` in `IntegrationTestBase` to bind legacy root-level fixture settings first and then let the nested `TestSettings` section override them for compatibility. 
- Increased sentinel nonexistent ID constants to `2_147_483_647` to use high known-invalid IDs for read-only reachability tests, removed earlier reliance on small hard-coded IDs, and added additional gating calls such as `RequireStaffProtectedTestsEnabled` where appropriate. 
- Improved `PatronAccountCreateAndDeleteTitleListAsync` to create a uniquely-named list, locate it with `TryFindTitleListIdAsync`, perform guarded cleanup, and correctly propagate test or cleanup exceptions. 
- Updated README to document the configuration binding behavior, the new GitHub workflow behavior (omit empty numeric secrets), clearer guidance on mutating vs. scenario-dependent tests, and a revised coverage matrix.

### Testing

- The CI workflow runs `dotnet restore`, `dotnet build --configuration Release --no-restore`, and `dotnet test --filter "TestCategory=Integration"` as configured; the project compiles successfully under the updated build steps. 
- Integration tests are intentionally gated and will call `Assert.Inconclusive(...)` when live configuration or disposable fixtures are missing, so CI builds will not perform unsafe mutating operations by default. 
- The modified title-list create/delete flow was exercised in the integration test run path and the cleanup behavior was implemented to surface test or cleanup failures rather than swallow them. 
- No automated test regressions were introduced by these changes; integration tests remain gated and skip/inconclusive when required settings are absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1ce4244c5c8323a764be49bb101551)