### PR TITLE
Harden integration test compatibility, staff-protected gates, title-list cleanup, and workflow exports

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -28,31 +28,17 @@ jobs:
       PapiSettings__Hostname: ${{ secrets.PAPI_HOSTNAME }}
       PapiSettings__AccessId: ${{ secrets.PAPI_ACCESS_ID }}
       PapiSettings__AccessKey: ${{ secrets.PAPI_ACCESS_KEY }}
-      PapiSettings__OrganizationId: ${{ secrets.PAPI_ORGANIZATION_ID }}
-      PapiSettings__UserId: ${{ secrets.PAPI_USER_ID }}
-      PapiSettings__WorkstationId: ${{ secrets.PAPI_WORKSTATION_ID }}
       PapiSettings__PolarisOverrideAccount__Domain: ${{ secrets.PAPI_STAFF_DOMAIN }}
       PapiSettings__PolarisOverrideAccount__Username: ${{ secrets.PAPI_STAFF_USERNAME }}
       PapiSettings__PolarisOverrideAccount__Password: ${{ secrets.PAPI_STAFF_PASSWORD }}
-      TestSettings__PatronId: ${{ secrets.PAPI_TEST_PATRON_ID }}
       TestSettings__PatronBarcode: ${{ secrets.PAPI_TEST_PATRON_BARCODE }}
       TestSettings__PatronPin: ${{ secrets.PAPI_TEST_PATRON_PIN }}
-      TestSettings__BibId: ${{ secrets.PAPI_TEST_BIB_ID }}
-      TestSettings__BranchId: ${{ secrets.PAPI_TEST_BRANCH_ID }}
-      TestSettings__OrganizationId: ${{ secrets.PAPI_TEST_ORGANIZATION_ID }}
-      TestSettings__WorkstationId: ${{ secrets.PAPI_TEST_WORKSTATION_ID }}
-      TestSettings__UserId: ${{ secrets.PAPI_TEST_USER_ID }}
       TestSettings__OrgEmail: ${{ secrets.PAPI_TEST_ORG_EMAIL }}
       TestSettings__PatronListName: ${{ secrets.PAPI_TEST_PATRON_LIST_NAME }}
       TestSettings__FreeTextBlock: ${{ secrets.PAPI_TEST_FREE_TEXT_BLOCK }}
-      TestSettings__RemoteStorageBranchId: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_BRANCH_ID }}
       TestSettings__RemoteStorageStartDate: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_START_DATE }}
       TestSettings__RemoteStorageEndDate: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_END_DATE }}
-      TestSettings__RecordSetId: ${{ secrets.PAPI_TEST_RECORD_SET_ID }}
-      TestSettings__ItemRecordId: ${{ secrets.PAPI_TEST_ITEM_RECORD_ID }}
       TestSettings__ItemBarcode: ${{ secrets.PAPI_TEST_ITEM_BARCODE }}
-      TestSettings__PatronAccountTransactionId: ${{ secrets.PAPI_TEST_PATRON_ACCOUNT_TRANSACTION_ID }}
-      TestSettings__HoldRequestId: ${{ secrets.PAPI_TEST_HOLD_REQUEST_ID }}
       IntegrationTestOptions__EnableMutatingIntegrationTests: ${{ inputs.enable_mutating_tests }}
       IntegrationTestOptions__EnableStaffProtectedTests: ${{ inputs.enable_staff_protected_tests }}
       IntegrationTestOptions__EnableScenarioDependentTests: ${{ inputs.enable_scenario_dependent_tests }}
@@ -65,6 +51,47 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
+
+      - name: Export configured numeric integration settings
+        env:
+          PAPI_ORGANIZATION_ID: ${{ secrets.PAPI_ORGANIZATION_ID }}
+          PAPI_USER_ID: ${{ secrets.PAPI_USER_ID }}
+          PAPI_WORKSTATION_ID: ${{ secrets.PAPI_WORKSTATION_ID }}
+          PAPI_TEST_PATRON_ID: ${{ secrets.PAPI_TEST_PATRON_ID }}
+          PAPI_TEST_BIB_ID: ${{ secrets.PAPI_TEST_BIB_ID }}
+          PAPI_TEST_BRANCH_ID: ${{ secrets.PAPI_TEST_BRANCH_ID }}
+          PAPI_TEST_ORGANIZATION_ID: ${{ secrets.PAPI_TEST_ORGANIZATION_ID }}
+          PAPI_TEST_WORKSTATION_ID: ${{ secrets.PAPI_TEST_WORKSTATION_ID }}
+          PAPI_TEST_USER_ID: ${{ secrets.PAPI_TEST_USER_ID }}
+          PAPI_TEST_REMOTE_STORAGE_BRANCH_ID: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_BRANCH_ID }}
+          PAPI_TEST_RECORD_SET_ID: ${{ secrets.PAPI_TEST_RECORD_SET_ID }}
+          PAPI_TEST_ITEM_RECORD_ID: ${{ secrets.PAPI_TEST_ITEM_RECORD_ID }}
+          PAPI_TEST_PATRON_ACCOUNT_TRANSACTION_ID: ${{ secrets.PAPI_TEST_PATRON_ACCOUNT_TRANSACTION_ID }}
+          PAPI_TEST_HOLD_REQUEST_ID: ${{ secrets.PAPI_TEST_HOLD_REQUEST_ID }}
+        run: |
+          append_if_set() {
+            local target_name="$1"
+            local value="$2"
+
+            if [ -n "$value" ]; then
+              printf '%s=%s\n' "$target_name" "$value" >> "$GITHUB_ENV"
+            fi
+          }
+
+          append_if_set "PapiSettings__OrganizationId" "$PAPI_ORGANIZATION_ID"
+          append_if_set "PapiSettings__UserId" "$PAPI_USER_ID"
+          append_if_set "PapiSettings__WorkstationId" "$PAPI_WORKSTATION_ID"
+          append_if_set "TestSettings__PatronId" "$PAPI_TEST_PATRON_ID"
+          append_if_set "TestSettings__BibId" "$PAPI_TEST_BIB_ID"
+          append_if_set "TestSettings__BranchId" "$PAPI_TEST_BRANCH_ID"
+          append_if_set "TestSettings__OrganizationId" "$PAPI_TEST_ORGANIZATION_ID"
+          append_if_set "TestSettings__WorkstationId" "$PAPI_TEST_WORKSTATION_ID"
+          append_if_set "TestSettings__UserId" "$PAPI_TEST_USER_ID"
+          append_if_set "TestSettings__RemoteStorageBranchId" "$PAPI_TEST_REMOTE_STORAGE_BRANCH_ID"
+          append_if_set "TestSettings__RecordSetId" "$PAPI_TEST_RECORD_SET_ID"
+          append_if_set "TestSettings__ItemRecordId" "$PAPI_TEST_ITEM_RECORD_ID"
+          append_if_set "TestSettings__PatronAccountTransactionId" "$PAPI_TEST_PATRON_ACCOUNT_TRANSACTION_ID"
+          append_if_set "TestSettings__HoldRequestId" "$PAPI_TEST_HOLD_REQUEST_ID"
 
       - name: Restore
         run: dotnet restore src/polaris-api-csharp.sln

--- a/src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs
+++ b/src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs
@@ -30,10 +30,23 @@ public abstract class IntegrationTestBase
             .Build();
 
         PapiSettings = config.GetSection(PapiSettings.SECTION_NAME).Get<PapiSettings>() ?? new PapiSettings();
-        Settings = config.GetSection(IntegrationScenarioSettings.SectionName).Get<IntegrationScenarioSettings>() ?? new IntegrationScenarioSettings();
+        Settings = LoadIntegrationScenarioSettings(config);
         Options = config.GetSection(nameof(IntegrationTestOptions)).Get<IntegrationTestOptions>() ?? new IntegrationTestOptions();
 
         Papi = new PapiClient(PapiSettings);
+    }
+
+    private static IntegrationScenarioSettings LoadIntegrationScenarioSettings(IConfiguration config)
+    {
+        var scenarioSettings = config.Get<IntegrationScenarioSettings>() ?? new IntegrationScenarioSettings();
+        var testSettingsSection = config.GetSection(IntegrationScenarioSettings.SectionName);
+
+        if (testSettingsSection.Exists())
+        {
+            testSettingsSection.Bind(scenarioSettings);
+        }
+
+        return scenarioSettings;
     }
 
     protected void RequirePapiConfiguration()

--- a/src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs
@@ -1,5 +1,6 @@
 using Clc.Polaris.Api.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Runtime.ExceptionServices;
 
 namespace Clc.Polaris.Api.Tests.Integration;
 
@@ -90,32 +91,64 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
         }
 
         var uniqueListName = $"{Settings.PatronListName}-{Guid.NewGuid():N}";
+        var createSucceeded = false;
         int? createdListId = null;
+        Exception? testFailure = null;
+
         try
         {
             var createResponse = await Papi.PatronAccountCreateTitleListAsync(Settings.PatronBarcode, uniqueListName, Settings.PatronPin);
             PapiIntegrationAssert.ExactZeroSuccess(createResponse);
+            createSucceeded = true;
 
-            var getResponse = await Papi.PatronAccountGetTitleListsAsync(Settings.PatronBarcode, Settings.PatronPin);
-            var getData = PapiIntegrationAssert.Success(getResponse);
-            var list = getData.PatronAccountTitleListsRows.SingleOrDefault(l => l.RecordStoreName == uniqueListName);
-            Assert.IsNotNull(list, "The title list created by this test should be visible before cleanup.");
-            createdListId = list.RecordStoreId;
+            createdListId = await TryFindTitleListIdAsync(uniqueListName);
+            Assert.IsTrue(createdListId.HasValue, "The title list created by this test should be visible before cleanup.");
+        }
+        catch (Exception ex)
+        {
+            testFailure = ex;
         }
         finally
         {
-            if (createdListId.HasValue)
+            if (createSucceeded)
             {
-                var deleteResponse = await Papi.PatronAccountDeleteTitleListAsync(Settings.PatronBarcode, createdListId.Value, Settings.PatronPin);
-                PapiIntegrationAssert.Success(deleteResponse);
+                try
+                {
+                    createdListId ??= await TryFindTitleListIdAsync(uniqueListName);
+
+                    if (createdListId.HasValue)
+                    {
+                        var deleteResponse = await Papi.PatronAccountDeleteTitleListAsync(Settings.PatronBarcode, createdListId.Value, Settings.PatronPin);
+                        PapiIntegrationAssert.Success(deleteResponse);
+                    }
+                }
+                catch (Exception cleanupException) when (testFailure != null)
+                {
+                    throw new AssertFailedException($"Title-list cleanup failed after the test had already failed. Cleanup failure: {cleanupException.Message}. Original test failure: {testFailure.Message}", cleanupException);
+                }
             }
         }
+
+        if (testFailure != null)
+        {
+            ExceptionDispatchInfo.Capture(testFailure).Throw();
+        }
+    }
+
+    private async Task<int?> TryFindTitleListIdAsync(string uniqueListName)
+    {
+        var getResponse = await Papi.PatronAccountGetTitleListsAsync(Settings.PatronBarcode, Settings.PatronPin);
+        var getData = PapiIntegrationAssert.Success(getResponse);
+        var list = getData.PatronAccountTitleListsRows.SingleOrDefault(l => l.RecordStoreName == uniqueListName);
+
+        return list?.RecordStoreId;
     }
 
     [TestMethod]
     public async Task PatronAccountCreateCreditAsync_WhenMutatingTestsEnabled_CreatesCredit()
     {
         RequireMutatingTestsEnabled();
+        RequireStaffProtectedTestsEnabled();
         RequirePatronCredentials();
 
         var response = await Papi.PatronAccountCreateCreditAsync(Settings.PatronBarcode, .01, PaymentMethod.Cash, WorkstationIdOrConfigured, UserIdOrConfigured, "integration testing");
@@ -127,6 +160,7 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     public async Task PatronAccountDepositCreditAsync_WhenMutatingTestsEnabled_DepositsCredit()
     {
         RequireMutatingTestsEnabled();
+        RequireStaffProtectedTestsEnabled();
         RequirePatronCredentials();
 
         var response = await Papi.PatronAccountDepositCreditAsync(Settings.PatronBarcode, .01, WorkstationIdOrConfigured, UserIdOrConfigured, "integration testing");

--- a/src/polaris-api-csharpTests/Integration/PatronMutationIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronMutationIntegrationTests.cs
@@ -12,6 +12,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     public async Task CreatePatronBlocksAsync_FreeText_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
         RequireMutatingTestsEnabled();
+        RequireStaffProtectedTestsEnabled();
         RequirePatronCredentials();
         if (string.IsNullOrWhiteSpace(Settings.FreeTextBlock))
         {
@@ -28,6 +29,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     public async Task CreatePatronBlocksAsync_SystemBlock_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
         RequireMutatingTestsEnabled();
+        RequireStaffProtectedTestsEnabled();
         RequirePatronCredentials();
 
         var response = await Papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.System, "128", UserIdOrConfigured, WorkstationIdOrConfigured);
@@ -40,6 +42,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     public async Task CreatePatronBlocksAsync_LibraryAssignedBlock_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
         RequireMutatingTestsEnabled();
+        RequireStaffProtectedTestsEnabled();
         RequirePatronCredentials();
 
         var response = await Papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.LibraryAssigned, "1", UserIdOrConfigured, WorkstationIdOrConfigured);
@@ -135,6 +138,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     public async Task UpdatePatronNotesDataAsync_WhenMutatingTestsEnabled_UpdatesConfiguredPatronNotes()
     {
         RequireMutatingTestsEnabled();
+        RequireStaffProtectedTestsEnabled();
         RequirePatronCredentials();
 
         var response = await Papi.UpdatePatronNotesDataAsync(Settings.PatronBarcode, nonBlockingNote: "PAPI integration test note", updateMode: UpdateNoteMode.Prepend, workstationId: WorkstationIdOrConfigured);

--- a/src/polaris-api-csharpTests/Integration/PatronReadIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronReadIntegrationTests.cs
@@ -22,6 +22,7 @@ public sealed class PatronReadIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task Patron_GetBarcodeFromIdAsync_WithConfiguredPatron_ReturnsBarcode()
     {
+        RequireStaffProtectedTestsEnabled();
         RequirePatronId();
         RequirePatronCredentials();
 
@@ -124,6 +125,7 @@ public sealed class PatronReadIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task PatronRenewBlocksGetAsync_WithConfiguredPatron_ReturnsSuccessShape()
     {
+        RequireStaffProtectedTestsEnabled();
         RequirePatronId();
 
         var response = await Papi.PatronRenewBlocksGetAsync(Settings.PatronId, BranchIdOrConfiguredOrganizationId);
@@ -142,6 +144,7 @@ public sealed class PatronReadIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task PatronSearchAsync_WithConfiguredPatronId_ReturnsMatchingRows()
     {
+        RequireStaffProtectedTestsEnabled();
         RequirePatronId();
 
         var response = await Papi.PatronSearchAsync($"PRID={Settings.PatronId}", orgId: OrganizationIdOrConfigured);

--- a/src/polaris-api-csharpTests/Integration/SynchIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/SynchIntegrationTests.cs
@@ -9,6 +9,7 @@ public sealed class SynchIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task Synch_BibsByIdGetAsync_WithConfiguredBib_ReturnsSynchronisationPayload()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireBibScenario();
 
         var response = await Papi.Synch_BibsByIdGetAsync(Settings.BibId);

--- a/src/polaris-api-csharpTests/README.md
+++ b/src/polaris-api-csharpTests/README.md
@@ -32,7 +32,7 @@ Copy the example file and replace placeholders with values for a disposable/safe
 cp src/polaris-api-csharpTests/appsettings.Test.example.json src/polaris-api-csharpTests/appsettings.Test.json
 ```
 
-`appsettings.Test.json` is intentionally not committed. The test project copies it to the output directory only when the file exists. Integration-only fixture values are bound to `IntegrationScenarioSettings` from the existing `TestSettings` section so older local configuration files and environment-variable names continue to work.
+`appsettings.Test.json` is intentionally not committed. The test project copies it to the output directory only when the file exists. Integration-only fixture values prefer the current nested `TestSettings` section shown in `appsettings.Test.example.json`. If that section is absent, the fixture falls back to the legacy root-level shape (`PatronId`, `PatronBarcode`, `PatronPin`, `FreeTextBlock`, `PatronListName`, `OrgEmail`, and the other scenario fields at the JSON root), so older local configuration files and legacy root-level environment-variable names continue to work.
 
 ## Environment variables
 
@@ -71,6 +71,8 @@ The integration fixture also loads environment variables using standard .NET con
 - `IntegrationTestOptions__EnableScenarioDependentTests`
 - `IntegrationTestOptions__EnableAuthenticationFailureTests`
 
+When configuring GitHub Actions or local shells, omit optional numeric settings when you do not have a value. Do not set numeric variables such as `TestSettings__PatronId`, `TestSettings__BibId`, `TestSettings__BranchId`, `TestSettings__RecordSetId`, `TestSettings__ItemRecordId`, `TestSettings__PatronAccountTransactionId`, or `TestSettings__HoldRequestId` to an empty string; unset values bind as their default `0` and allow the integration gates to mark tests inconclusive cleanly.
+
 ## Fixture data required
 
 Minimum live read-only configuration:
@@ -83,7 +85,7 @@ Additional success-path scenarios require:
 - Patron read tests: `TestSettings:PatronId`, `PatronBarcode`, and `PatronPin`
 - Catalog success tests: `TestSettings:BibId`
 - Branch-specific lookups: `TestSettings:BranchId`
-- Staff/protected endpoints: `PapiSettings:PolarisOverrideAccount:*` plus `IntegrationTestOptions:EnableStaffProtectedTests=true`
+- Staff/protected endpoints, including protected read routes such as patron barcode lookup, patron renew-block lookup, patron search, synchronization bib lookup, record-set reads, notification queue, hold request list, remote storage, and system-administration value reads: `PapiSettings:PolarisOverrideAccount:*` plus `IntegrationTestOptions:EnableStaffProtectedTests=true`
 - `SA_GetValueByOrgAsync`: `TestSettings:OrgEmail` matching the configured organization
 - Remote storage: `TestSettings:RemoteStorageBranchId`, `RemoteStorageStartDate`, and `RemoteStorageEndDate`, plus scenario-dependent tests enabled
 - Optional scenario fixtures for local extensions: `TestSettings:RecordSetId`, `ItemRecordId`, `ItemBarcode`, `PatronAccountTransactionId`, and `HoldRequestId`
@@ -102,7 +104,7 @@ The mutating gate checks live PAPI configuration and the explicit option only. P
 
 ## Staff-protected tests
 
-Protected/staff tests are disabled by default because they require a staff override account and may access protected PAPI routes. To run them, provide `PapiSettings:PolarisOverrideAccount` credentials and set:
+Protected/staff tests are disabled by default because they require a staff override account and may access protected PAPI routes. Some read-only client methods use protected-token URLs even though they do not mutate data, so they are gated here as well; a run with public PAPI credentials but no staff override credentials should report these tests as inconclusive instead of attempting live protected calls. To run them, provide `PapiSettings:PolarisOverrideAccount` credentials and set:
 
 ```bash
 IntegrationTestOptions__EnableStaffProtectedTests=true
@@ -145,9 +147,9 @@ The guide was used selectively to confirm endpoint routes, response shapes, row-
 | API/version/authentication | API key validation, API version, patron auth, staff auth when enabled | None by default | None | Failed-auth testing is a placeholder because account lockout is a risk |
 | Bibliographic/catalog lookup | Bib get, branch-specific bib get, keyword/boolean search, holdings | None | None | `HeadingsSearchAsync` remains a client `NotImplementedException` check |
 | Reference data lookup | Collections, dates closed, item statuses, limit filters, MARC types, material types, organizations, patron codes, pickup branches, shelf locations | None | None | None |
-| Synch | synch bibs by ID | None | None | None |
-| Patron reads | validate, barcode-from-id, basic data, blocks, hold/ILL/items out, messages, preferences, reading history, renew blocks, saved searches, patron search | None | None | None |
-| Patron account/title lists | account get, title lists get | None by default for payment/refund/void/title-list mutations | unique create/delete title list, create credit, deposit credit | payment/refund/void and hard-coded title-list mutation reachability require disposable account/list fixtures |
+| Synch | synch bibs by ID (staff/protected-gated) | None | None | None |
+| Patron reads | validate, basic data, blocks, hold/ILL/items out, messages, preferences, reading history, saved searches; barcode-from-id, renew blocks, and patron search are staff/protected-gated | None | None | None |
+| Patron account/title lists | account get, title lists get | None by default for payment/refund/void/title-list mutations | unique create/delete title list, create credit and deposit credit (credit calls are staff/protected-gated) | payment/refund/void and hard-coded title-list mutation reachability require disposable account/list fixtures |
 | Hold requests/circulation | hold request list (staff/protected-gated) | None by default for hold/item mutations | None without disposable fixtures | hold create/cancel/reactivate/suspend/reply/pickup updates, item renew, renew-all, and item barcode update require disposable fixtures |
-| Patron mutations/messages | None by default | None by default for patron message/reading-history/notification mutations | patron blocks, no-op patron update, username unauthorized check, notes update | patron message, reading-history, notification update, and registration v1/v2 require disposable fixtures |
+| Patron mutations/messages | None by default | None by default for patron message/reading-history/notification mutations | patron blocks and notes update are staff/protected-gated; no-op patron update and username unauthorized check use patron credentials | patron message, reading-history, notification update, and registration v1/v2 require disposable fixtures |
 | Staff/protected/record sets | hold request list, SA value lookup, notification queue when staff tests are enabled | read-only record-set get with a known-invalid sentinel ID | None without disposable fixtures | record-set add/remove/put mutations and remote storage require explicit scenario data |


### PR DESCRIPTION
### Motivation
- Preserve backward compatibility for existing local `appsettings.Test.json` files that used the pre-refactor root-level fixture shape while continuing to prefer the nested `TestSettings` section when present.
- Ensure tests that call protected/token-based endpoints are gated on staff override credentials so default/readonly runs mark them inconclusive instead of throwing.
- Make title-list create/delete tests robust so created disposable lists are cleaned up even when a post-create assertion or read fails.
- Prevent empty-string numeric secrets from being exported in the manual integration workflow so .NET configuration binding does not fail before test gates run.

### Description
- Added `LoadIntegrationScenarioSettings(IConfiguration)` helper in `IntegrationTestBase` to load root-level `IntegrationScenarioSettings` and then bind the nested `TestSettings` section over it when present, preserving `TestSettings__...` env-var behavior and leaving `IntegrationScenarioSettings.SectionName` as the single source of truth. (file: `src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs`)
- Gated protected-token read/mutating tests by calling `RequireStaffProtectedTestsEnabled()` where appropriate, including `Patron_GetBarcodeFromIdAsync`, `PatronRenewBlocksGetAsync`, `PatronSearchAsync`, `Synch_BibsByIdGetAsync`, `PatronAccountCreateCreditAsync`, `PatronAccountDepositCreditAsync`, `CreatePatronBlocksAsync` variants, and `UpdatePatronNotesDataAsync`, so runs without staff override credentials are inconclusive rather than erroring. (files: `src/polaris-api-csharpTests/Integration/*.cs`)
- Hardened `PatronAccountCreateAndDeleteTitleListAsync_WhenMutatingTestsEnabled_CleansUpList` to track whether creation succeeded, attempt to resolve the GUID-suffixed unique list name via a new `TryFindTitleListIdAsync(...)` helper, and perform best-effort cleanup in `finally`, surfacing cleanup failures without hiding original test failures. (file: `src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs`)
- Updated the manual workflow `.github/workflows/integration-tests.yaml` to stop exporting optional numeric secrets at job scope and instead run a pre-test shell step that appends only non-empty numeric values to `$GITHUB_ENV`, avoiding empty-string-to-int binding failures; preserved required string settings and `workflow_dispatch` behaviour. (file: `.github/workflows/integration-tests.yaml`)
- Documentation updates to `src/polaris-api-csharpTests/README.md` clarifying legacy root-level compatibility, that some read endpoints are staff/protected-gated, and that optional numeric workflow secrets should be omitted rather than set to empty strings.

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` which completed successfully. 
- Ran `dotnet build src/polaris-api-csharp.sln --configuration Release -warnaserror` which completed successfully with zero warnings or errors. 
- Ran the fast suite `dotnet test ... --filter "TestCategory!=Integration"` and observed all non-integration tests passed (99 passed). 
- Ran the integration-only filter `dotnet test ... --filter "TestCategory=Integration"` without live config and observed the run returned inconclusive/skipped cleanly (integration tests were skipped/inconclusive as expected with no null-reference or configuration-binding exceptions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1cee74e5dc8323800dea6816b417fe)