### PR TITLE
Integration tests: preserve legacy TestSettings, gate protected reads, harden title-list cleanup, and avoid empty numeric workflow exports

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -34,25 +34,14 @@ jobs:
       PapiSettings__PolarisOverrideAccount__Domain: ${{ secrets.PAPI_STAFF_DOMAIN }}
       PapiSettings__PolarisOverrideAccount__Username: ${{ secrets.PAPI_STAFF_USERNAME }}
       PapiSettings__PolarisOverrideAccount__Password: ${{ secrets.PAPI_STAFF_PASSWORD }}
-      TestSettings__PatronId: ${{ secrets.PAPI_TEST_PATRON_ID }}
       TestSettings__PatronBarcode: ${{ secrets.PAPI_TEST_PATRON_BARCODE }}
       TestSettings__PatronPin: ${{ secrets.PAPI_TEST_PATRON_PIN }}
-      TestSettings__BibId: ${{ secrets.PAPI_TEST_BIB_ID }}
-      TestSettings__BranchId: ${{ secrets.PAPI_TEST_BRANCH_ID }}
-      TestSettings__OrganizationId: ${{ secrets.PAPI_TEST_ORGANIZATION_ID }}
-      TestSettings__WorkstationId: ${{ secrets.PAPI_TEST_WORKSTATION_ID }}
-      TestSettings__UserId: ${{ secrets.PAPI_TEST_USER_ID }}
       TestSettings__OrgEmail: ${{ secrets.PAPI_TEST_ORG_EMAIL }}
       TestSettings__PatronListName: ${{ secrets.PAPI_TEST_PATRON_LIST_NAME }}
       TestSettings__FreeTextBlock: ${{ secrets.PAPI_TEST_FREE_TEXT_BLOCK }}
-      TestSettings__RemoteStorageBranchId: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_BRANCH_ID }}
       TestSettings__RemoteStorageStartDate: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_START_DATE }}
       TestSettings__RemoteStorageEndDate: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_END_DATE }}
-      TestSettings__RecordSetId: ${{ secrets.PAPI_TEST_RECORD_SET_ID }}
-      TestSettings__ItemRecordId: ${{ secrets.PAPI_TEST_ITEM_RECORD_ID }}
       TestSettings__ItemBarcode: ${{ secrets.PAPI_TEST_ITEM_BARCODE }}
-      TestSettings__PatronAccountTransactionId: ${{ secrets.PAPI_TEST_PATRON_ACCOUNT_TRANSACTION_ID }}
-      TestSettings__HoldRequestId: ${{ secrets.PAPI_TEST_HOLD_REQUEST_ID }}
       IntegrationTestOptions__EnableMutatingIntegrationTests: ${{ inputs.enable_mutating_tests }}
       IntegrationTestOptions__EnableStaffProtectedTests: ${{ inputs.enable_staff_protected_tests }}
       IntegrationTestOptions__EnableScenarioDependentTests: ${{ inputs.enable_scenario_dependent_tests }}
@@ -71,6 +60,60 @@ jobs:
 
       - name: Build
         run: dotnet build src/polaris-api-csharp.sln --configuration Release --no-restore -warnaserror
+
+      - name: Validate required integration settings
+        run: |
+          missing=()
+          for name in \
+            PapiSettings__Hostname \
+            PapiSettings__AccessId \
+            PapiSettings__AccessKey \
+            PapiSettings__OrganizationId \
+            PapiSettings__UserId \
+            PapiSettings__WorkstationId
+          do
+            if [ -z "${!name}" ]; then
+              missing+=("$name")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf '::error::Missing required integration setting(s): %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+      - name: Export optional numeric test fixtures
+        env:
+          TestSettings__PatronId: ${{ secrets.PAPI_TEST_PATRON_ID }}
+          TestSettings__BibId: ${{ secrets.PAPI_TEST_BIB_ID }}
+          TestSettings__BranchId: ${{ secrets.PAPI_TEST_BRANCH_ID }}
+          TestSettings__OrganizationId: ${{ secrets.PAPI_TEST_ORGANIZATION_ID }}
+          TestSettings__WorkstationId: ${{ secrets.PAPI_TEST_WORKSTATION_ID }}
+          TestSettings__UserId: ${{ secrets.PAPI_TEST_USER_ID }}
+          TestSettings__RemoteStorageBranchId: ${{ secrets.PAPI_TEST_REMOTE_STORAGE_BRANCH_ID }}
+          TestSettings__RecordSetId: ${{ secrets.PAPI_TEST_RECORD_SET_ID }}
+          TestSettings__ItemRecordId: ${{ secrets.PAPI_TEST_ITEM_RECORD_ID }}
+          TestSettings__PatronAccountTransactionId: ${{ secrets.PAPI_TEST_PATRON_ACCOUNT_TRANSACTION_ID }}
+          TestSettings__HoldRequestId: ${{ secrets.PAPI_TEST_HOLD_REQUEST_ID }}
+        run: |
+          for name in \
+            TestSettings__PatronId \
+            TestSettings__BibId \
+            TestSettings__BranchId \
+            TestSettings__OrganizationId \
+            TestSettings__WorkstationId \
+            TestSettings__UserId \
+            TestSettings__RemoteStorageBranchId \
+            TestSettings__RecordSetId \
+            TestSettings__ItemRecordId \
+            TestSettings__PatronAccountTransactionId \
+            TestSettings__HoldRequestId
+          do
+            value="${!name}"
+            if [ -n "$value" ]; then
+              printf '%s=%s\n' "$name" "$value" >> "$GITHUB_ENV"
+            fi
+          done
 
       - name: Run integration tests
         run: >-

--- a/src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs
+++ b/src/polaris-api-csharpTests/Integration/IntegrationTestBase.cs
@@ -30,10 +30,23 @@ public abstract class IntegrationTestBase
             .Build();
 
         PapiSettings = config.GetSection(PapiSettings.SECTION_NAME).Get<PapiSettings>() ?? new PapiSettings();
-        Settings = config.GetSection(IntegrationScenarioSettings.SectionName).Get<IntegrationScenarioSettings>() ?? new IntegrationScenarioSettings();
+        Settings = LoadIntegrationScenarioSettings(config);
         Options = config.GetSection(nameof(IntegrationTestOptions)).Get<IntegrationTestOptions>() ?? new IntegrationTestOptions();
 
         Papi = new PapiClient(PapiSettings);
+    }
+
+    internal static IntegrationScenarioSettings LoadIntegrationScenarioSettings(IConfiguration config)
+    {
+        var settings = config.Get<IntegrationScenarioSettings>() ?? new IntegrationScenarioSettings();
+        var testSettingsSection = config.GetSection(IntegrationScenarioSettings.SectionName);
+
+        if (testSettingsSection.Exists())
+        {
+            testSettingsSection.Bind(settings);
+        }
+
+        return settings;
     }
 
     protected void RequirePapiConfiguration()

--- a/src/polaris-api-csharpTests/Integration/IntegrationTestBaseSettingsTests.cs
+++ b/src/polaris-api-csharpTests/Integration/IntegrationTestBaseSettingsTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Clc.Polaris.Api.Tests.Integration;
+
+[TestClass]
+public sealed class IntegrationTestBaseSettingsTests
+{
+    [TestMethod]
+    public void LoadIntegrationScenarioSettings_WhenTestSettingsSectionMissing_BindsLegacyRootValues()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [nameof(IntegrationScenarioSettings.PatronId)] = "123",
+                [nameof(IntegrationScenarioSettings.PatronBarcode)] = "legacy-barcode",
+                [nameof(IntegrationScenarioSettings.PatronPin)] = "legacy-pin",
+                [nameof(IntegrationScenarioSettings.FreeTextBlock)] = "legacy block",
+                [nameof(IntegrationScenarioSettings.PatronListName)] = "legacy-list",
+                [nameof(IntegrationScenarioSettings.OrgEmail)] = "legacy@example.org"
+            })
+            .Build();
+
+        var settings = IntegrationTestBase.LoadIntegrationScenarioSettings(config);
+
+        Assert.AreEqual(123, settings.PatronId);
+        Assert.AreEqual("legacy-barcode", settings.PatronBarcode);
+        Assert.AreEqual("legacy-pin", settings.PatronPin);
+        Assert.AreEqual("legacy block", settings.FreeTextBlock);
+        Assert.AreEqual("legacy-list", settings.PatronListName);
+        Assert.AreEqual("legacy@example.org", settings.OrgEmail);
+    }
+
+    [TestMethod]
+    public void LoadIntegrationScenarioSettings_WhenTestSettingsSectionExists_PrefersNestedValues()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [nameof(IntegrationScenarioSettings.PatronId)] = "123",
+                [nameof(IntegrationScenarioSettings.PatronBarcode)] = "legacy-barcode",
+                [$"{IntegrationScenarioSettings.SectionName}:{nameof(IntegrationScenarioSettings.PatronId)}"] = "456",
+                [$"{IntegrationScenarioSettings.SectionName}:{nameof(IntegrationScenarioSettings.PatronBarcode)}"] = "nested-barcode"
+            })
+            .Build();
+
+        var settings = IntegrationTestBase.LoadIntegrationScenarioSettings(config);
+
+        Assert.AreEqual(456, settings.PatronId);
+        Assert.AreEqual("nested-barcode", settings.PatronBarcode);
+    }
+}

--- a/src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs
@@ -90,31 +90,65 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
         }
 
         var uniqueListName = $"{Settings.PatronListName}-{Guid.NewGuid():N}";
+        var createSucceeded = false;
         int? createdListId = null;
+        Exception? testFailure = null;
+
         try
         {
             var createResponse = await Papi.PatronAccountCreateTitleListAsync(Settings.PatronBarcode, uniqueListName, Settings.PatronPin);
             PapiIntegrationAssert.ExactZeroSuccess(createResponse);
+            createSucceeded = true;
 
-            var getResponse = await Papi.PatronAccountGetTitleListsAsync(Settings.PatronBarcode, Settings.PatronPin);
-            var getData = PapiIntegrationAssert.Success(getResponse);
-            var list = getData.PatronAccountTitleListsRows.SingleOrDefault(l => l.RecordStoreName == uniqueListName);
-            Assert.IsNotNull(list, "The title list created by this test should be visible before cleanup.");
-            createdListId = list.RecordStoreId;
+            createdListId = await TryFindTitleListIdAsync(uniqueListName);
+            Assert.IsTrue(createdListId.HasValue, "The title list created by this test should be visible before cleanup.");
+        }
+        catch (Exception ex)
+        {
+            testFailure = ex;
+            throw;
         }
         finally
         {
-            if (createdListId.HasValue)
+            if (createSucceeded)
             {
-                var deleteResponse = await Papi.PatronAccountDeleteTitleListAsync(Settings.PatronBarcode, createdListId.Value, Settings.PatronPin);
-                PapiIntegrationAssert.Success(deleteResponse);
+                try
+                {
+                    createdListId ??= await TryFindTitleListIdAsync(uniqueListName);
+
+                    if (createdListId.HasValue)
+                    {
+                        var deleteResponse = await Papi.PatronAccountDeleteTitleListAsync(Settings.PatronBarcode, createdListId.Value, Settings.PatronPin);
+                        PapiIntegrationAssert.Success(deleteResponse);
+                    }
+                    else
+                    {
+                        Assert.Fail($"Cleanup could not find title list '{uniqueListName}' created by this test.");
+                    }
+                }
+                catch (Exception cleanupFailure) when (testFailure != null)
+                {
+                    Console.Error.WriteLine($"Cleanup failed for title list '{uniqueListName}' after the test had already failed: {cleanupFailure}");
+                }
             }
         }
+    }
+
+    private async Task<int?> TryFindTitleListIdAsync(string uniqueListName)
+    {
+        var getResponse = await Papi.PatronAccountGetTitleListsAsync(Settings.PatronBarcode, Settings.PatronPin);
+        var getData = PapiIntegrationAssert.Success(getResponse);
+        var matchingLists = getData.PatronAccountTitleListsRows
+            .Where(l => string.Equals(l.RecordStoreName, uniqueListName, StringComparison.Ordinal))
+            .ToList();
+
+        return matchingLists.Count == 1 ? matchingLists[0].RecordStoreId : null;
     }
 
     [TestMethod]
     public async Task PatronAccountCreateCreditAsync_WhenMutatingTestsEnabled_CreatesCredit()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireMutatingTestsEnabled();
         RequirePatronCredentials();
 
@@ -126,6 +160,7 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
     [TestMethod]
     public async Task PatronAccountDepositCreditAsync_WhenMutatingTestsEnabled_DepositsCredit()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireMutatingTestsEnabled();
         RequirePatronCredentials();
 

--- a/src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronAccountAndTitleListIntegrationTests.cs
@@ -128,7 +128,11 @@ public sealed class PatronAccountAndTitleListIntegrationTests : IntegrationTestB
                 }
                 catch (Exception cleanupFailure) when (testFailure != null)
                 {
-                    Console.Error.WriteLine($"Cleanup failed for title list '{uniqueListName}' after the test had already failed: {cleanupFailure}");
+                    var message = $"The title-list test failed and cleanup also failed for generated title list '{uniqueListName}'. "
+                        + "Manual cleanup may be required. "
+                        + $"Original test failure: {testFailure} "
+                        + $"Cleanup failure: {cleanupFailure}";
+                    throw new AssertFailedException(message, new AggregateException(testFailure, cleanupFailure));
                 }
             }
         }

--- a/src/polaris-api-csharpTests/Integration/PatronMutationIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronMutationIntegrationTests.cs
@@ -11,6 +11,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task CreatePatronBlocksAsync_FreeText_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireMutatingTestsEnabled();
         RequirePatronCredentials();
         if (string.IsNullOrWhiteSpace(Settings.FreeTextBlock))
@@ -27,6 +28,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task CreatePatronBlocksAsync_SystemBlock_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireMutatingTestsEnabled();
         RequirePatronCredentials();
 
@@ -39,6 +41,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task CreatePatronBlocksAsync_LibraryAssignedBlock_WhenMutatingTestsEnabled_ReturnsSuccessOrDuplicateBlock()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireMutatingTestsEnabled();
         RequirePatronCredentials();
 
@@ -134,6 +137,7 @@ public sealed class PatronMutationIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task UpdatePatronNotesDataAsync_WhenMutatingTestsEnabled_UpdatesConfiguredPatronNotes()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireMutatingTestsEnabled();
         RequirePatronCredentials();
 

--- a/src/polaris-api-csharpTests/Integration/PatronReadIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/PatronReadIntegrationTests.cs
@@ -22,6 +22,7 @@ public sealed class PatronReadIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task Patron_GetBarcodeFromIdAsync_WithConfiguredPatron_ReturnsBarcode()
     {
+        RequireStaffProtectedTestsEnabled();
         RequirePatronId();
         RequirePatronCredentials();
 
@@ -124,6 +125,7 @@ public sealed class PatronReadIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task PatronRenewBlocksGetAsync_WithConfiguredPatron_ReturnsSuccessShape()
     {
+        RequireStaffProtectedTestsEnabled();
         RequirePatronId();
 
         var response = await Papi.PatronRenewBlocksGetAsync(Settings.PatronId, BranchIdOrConfiguredOrganizationId);
@@ -142,6 +144,7 @@ public sealed class PatronReadIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task PatronSearchAsync_WithConfiguredPatronId_ReturnsMatchingRows()
     {
+        RequireStaffProtectedTestsEnabled();
         RequirePatronId();
 
         var response = await Papi.PatronSearchAsync($"PRID={Settings.PatronId}", orgId: OrganizationIdOrConfigured);

--- a/src/polaris-api-csharpTests/Integration/SynchIntegrationTests.cs
+++ b/src/polaris-api-csharpTests/Integration/SynchIntegrationTests.cs
@@ -9,6 +9,7 @@ public sealed class SynchIntegrationTests : IntegrationTestBase
     [TestMethod]
     public async Task Synch_BibsByIdGetAsync_WithConfiguredBib_ReturnsSynchronisationPayload()
     {
+        RequireStaffProtectedTestsEnabled();
         RequireBibScenario();
 
         var response = await Papi.Synch_BibsByIdGetAsync(Settings.BibId);

--- a/src/polaris-api-csharpTests/README.md
+++ b/src/polaris-api-csharpTests/README.md
@@ -32,7 +32,7 @@ Copy the example file and replace placeholders with values for a disposable/safe
 cp src/polaris-api-csharpTests/appsettings.Test.example.json src/polaris-api-csharpTests/appsettings.Test.json
 ```
 
-`appsettings.Test.json` is intentionally not committed. The test project copies it to the output directory only when the file exists. Integration-only fixture values are bound to `IntegrationScenarioSettings` from the existing `TestSettings` section so older local configuration files and environment-variable names continue to work.
+`appsettings.Test.json` is intentionally not committed. The test project copies it to the output directory only when the file exists. Integration-only fixture values are bound to `IntegrationScenarioSettings` from the `TestSettings` section when that section exists. Legacy local files that kept fixture fields such as `PatronId`, `PatronBarcode`, `PatronPin`, `FreeTextBlock`, `PatronListName`, and `OrgEmail` at the JSON root are still supported as a fallback, and `TestSettings__...` environment variables continue to override those root-level values.
 
 ## Environment variables
 
@@ -71,6 +71,9 @@ The integration fixture also loads environment variables using standard .NET con
 - `IntegrationTestOptions__EnableScenarioDependentTests`
 - `IntegrationTestOptions__EnableAuthenticationFailureTests`
 
+
+When configuring GitHub Actions secrets or local environment variables, omit optional numeric fixture values that are not configured instead of setting them to empty strings. Empty strings cannot be converted to integers by .NET configuration binding; omitted values remain at their safe default of `0` and the relevant integration tests call `Assert.Inconclusive(...)` when they need fixture data.
+
 ## Fixture data required
 
 Minimum live read-only configuration:
@@ -83,7 +86,7 @@ Additional success-path scenarios require:
 - Patron read tests: `TestSettings:PatronId`, `PatronBarcode`, and `PatronPin`
 - Catalog success tests: `TestSettings:BibId`
 - Branch-specific lookups: `TestSettings:BranchId`
-- Staff/protected endpoints: `PapiSettings:PolarisOverrideAccount:*` plus `IntegrationTestOptions:EnableStaffProtectedTests=true`
+- Staff/protected endpoints, including protected read routes such as patron barcode-from-ID, patron renew-blocks, patron search, synch bibs, hold request list, record-set reads, SA value lookup, notification queue, and remote storage: `PapiSettings:PolarisOverrideAccount:*` plus `IntegrationTestOptions:EnableStaffProtectedTests=true`
 - `SA_GetValueByOrgAsync`: `TestSettings:OrgEmail` matching the configured organization
 - Remote storage: `TestSettings:RemoteStorageBranchId`, `RemoteStorageStartDate`, and `RemoteStorageEndDate`, plus scenario-dependent tests enabled
 - Optional scenario fixtures for local extensions: `TestSettings:RecordSetId`, `ItemRecordId`, `ItemBarcode`, `PatronAccountTransactionId`, and `HoldRequestId`
@@ -108,7 +111,7 @@ Protected/staff tests are disabled by default because they require a staff overr
 IntegrationTestOptions__EnableStaffProtectedTests=true
 ```
 
-Read-only staff/protected reachability tests may use known-invalid sentinel IDs and assert documented negative `PAPIErrorCode` values. Record-set content add/remove/put tests are mutating and remain inconclusive placeholders until disposable record-set fixtures are configured and an executable cleanup strategy is implemented.
+Read-only staff/protected tests include protected patron, synch, circulation, record-set, SA, notification, and remote-storage routes; they must satisfy this gate even when they also require patron or scenario fixture settings. Read-only staff/protected reachability tests may use known-invalid sentinel IDs and assert documented negative `PAPIErrorCode` values. Record-set content add/remove/put tests are mutating and remain inconclusive placeholders until disposable record-set fixtures are configured and an executable cleanup strategy is implemented.
 
 ## Scenario-dependent placeholders
 
@@ -145,8 +148,8 @@ The guide was used selectively to confirm endpoint routes, response shapes, row-
 | API/version/authentication | API key validation, API version, patron auth, staff auth when enabled | None by default | None | Failed-auth testing is a placeholder because account lockout is a risk |
 | Bibliographic/catalog lookup | Bib get, branch-specific bib get, keyword/boolean search, holdings | None | None | `HeadingsSearchAsync` remains a client `NotImplementedException` check |
 | Reference data lookup | Collections, dates closed, item statuses, limit filters, MARC types, material types, organizations, patron codes, pickup branches, shelf locations | None | None | None |
-| Synch | synch bibs by ID | None | None | None |
-| Patron reads | validate, barcode-from-id, basic data, blocks, hold/ILL/items out, messages, preferences, reading history, renew blocks, saved searches, patron search | None | None | None |
+| Synch | synch bibs by ID (staff/protected-gated) | None | None | None |
+| Patron reads | validate, basic data, blocks, hold/ILL/items out, messages, preferences, reading history, saved searches; barcode-from-id, renew blocks, and patron search are staff/protected-gated | None | None | None |
 | Patron account/title lists | account get, title lists get | None by default for payment/refund/void/title-list mutations | unique create/delete title list, create credit, deposit credit | payment/refund/void and hard-coded title-list mutation reachability require disposable account/list fixtures |
 | Hold requests/circulation | hold request list (staff/protected-gated) | None by default for hold/item mutations | None without disposable fixtures | hold create/cancel/reactivate/suspend/reply/pickup updates, item renew, renew-all, and item barcode update require disposable fixtures |
 | Patron mutations/messages | None by default | None by default for patron message/reading-history/notification mutations | patron blocks, no-op patron update, username unauthorized check, notes update | patron message, reading-history, notification update, and registration v1/v2 require disposable fixtures |


### PR DESCRIPTION
### Motivation
- Preserve backward compatibility with older root-level integration fixture files while keeping the new `TestSettings` section as the preferred source. 
- Prevent protected-route integration tests from throwing when staff override credentials are absent by ensuring they are explicitly gated. 
- Make title-list creation tests clean up reliably even if post-create assertions fail. 
- Avoid .NET configuration binding failures caused by exporting unset numeric secrets as empty strings from the manual workflow. 

### Description
- Load legacy root-level `IntegrationScenarioSettings` first and then bind the `TestSettings` section (when present) by adding `LoadIntegrationScenarioSettings(IConfiguration)` and using it in `InitializeIntegrationTest`; this preserves `TestSettings__...` environment-variable behavior and prefers nested settings when present. 
- Add unit tests `IntegrationTestBaseSettingsTests` to validate both legacy root-level binding and nested `TestSettings` preference. 
- Gate protected/staff endpoints by calling `RequireStaffProtectedTestsEnabled()` where methods use protected-token routes; notable test methods now gated include `Patron_GetBarcodeFromIdAsync`, `PatronRenewBlocksGetAsync`, `PatronSearchAsync`, `Synch_BibsByIdGetAsync`, and protected mutating/account flows such as patron-block creation and patron-note/account-credit tests. 
- Harden title-list create/delete test by tracking whether creation succeeded, adding `TryFindTitleListIdAsync(uniqueName)` to resolve the GUID-suffixed list by name, and making a best-effort cleanup in `finally` that deletes only the uniquely-matched list and surfaces cleanup errors without hiding the original failure. 
- Update `.github/workflows/integration-tests.yaml` to remove optional numeric fixture secrets from the job-level `env`, add a validation step for required PAPI settings, and add a shell step that appends only non-empty optional numeric `TestSettings__...` values to `$GITHUB_ENV`. 
- Update `src/polaris-api-csharpTests/README.md` to document legacy root-level compatibility, explain that protected read endpoints require staff override credentials, and recommend omitting optional numeric secrets rather than setting them to empty strings. 

### Testing
- Ran `dotnet restore src/polaris-api-csharp.sln` and `dotnet build src/polaris-api-csharp.sln --configuration Release -warnaserror`, and the build succeeded with zero warnings or errors. 
- Ran non-integration tests: `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --configuration Release --filter "TestCategory!=Integration"` and received all unit/characterization tests passing (101 passed). 
- Ran integration-only tests: `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --configuration Release --filter "TestCategory=Integration"` and observed the suite run safely with integration tests marked skipped/inconclusive (78 skipped), with no configuration-binding exceptions, null-reference failures, or accidental live protected calls when staff credentials/options were not provided.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1cee74e5dc8323800dea6816b417fe)