### PR TITLE
🧹 Remove dead code from PatronCirculateBlocksResult

### DIFF
--- a/src/polaris-api-csharp/Models/PatronCirculateBlocksResult.cs
+++ b/src/polaris-api-csharp/Models/PatronCirculateBlocksResult.cs
@@ -60,8 +60,6 @@ namespace Clc.Polaris.Api.Models
         /// <summary>
         /// List of blocks on the patron's account
         /// </summary>
-        ////public Blocks Blocks { get; set; }
-
         public List<Block> Blocks { get; set; }
 
         /// <summary>


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code (`////public Blocks Blocks { get; set; }`) from `src/polaris-api-csharp/Models/PatronCirculateBlocksResult.cs`.
💡 **Why:** Dead commented-out code degrades readability, causes confusion about the intended structure of the class, and provides no functional value. Removing it cleans up the file.
✅ **Verification:** Verified the code compiles successfully without warnings. Ran the test suite to ensure no syntactic regressions were introduced.
✨ **Result:** A cleaner, more readable `PatronCirculateBlocksResult` class with no functional changes.

---
*PR created automatically by Jules for task [5386484485286861656](https://jules.google.com/task/5386484485286861656) started by @wesochuck*