### PR TITLE
🧹 [remove commented-out URL in NotificationQueueGet]

### DIFF
--- a/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
+++ b/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
@@ -11,7 +11,6 @@ namespace Clc.Polaris.Api
     {
         public IRestResponse<PapiResponseCommon> NotificationQueueGet(int orgId = 1)
         {
-            //"protected/{Version}/{LangID}/{AppID}/{OrgID}/{AccessToken}/notification
             var url = $"/protected/v1/1033/24/{orgId}/{Token.AccessToken}/notification/";
             var request = new PapiRestRequest(url);
             return Execute<PapiResponseCommon>(request);


### PR DESCRIPTION
🎯 **What:** Removed a commented-out string representing an endpoint format (`//"protected/{Version}/{LangID}/{AppID}/{OrgID}/{AccessToken}/notification`) in `src/polaris-api-csharp/Methods/NotificationQueueGet.cs`.

💡 **Why:** The commented-out URL string is redundant, as it immediately precedes the active string interpolation for the same URL path. Removing this dead code improves readability and maintainability.

✅ **Verification:** Verified the code compiles successfully and the targeted `NotificationQueueGet` test continues to pass with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "FullyQualifiedName~NotificationQueueGet"`. The change is strictly a comment removal, ensuring no behavior regressions.

✨ **Result:** Cleaner code without unnecessary comment clutter in `NotificationQueueGet`.

---
*PR created automatically by Jules for task [16319161046530635608](https://jules.google.com/task/16319161046530635608) started by @wesochuck*