### PR TITLE
🔒 Fix insecure default for AllowStaffOverrideRequests

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -32,7 +32,7 @@ namespace Clc.Polaris.Api
         public int WorkstationId { get; set; } = 1;
         public int OrganizationId { get; set; } = 1;
 
-        public bool AllowStaffOverrideRequests { get; set; } = true;
+        public bool AllowStaffOverrideRequests { get; set; } = false;
 
         /// <summary>
         /// The staff credentials used for protected methods and public method overrides


### PR DESCRIPTION
🎯 **What:** Changed the default value of `AllowStaffOverrideRequests` from `true` to `false` in `PapiClient`.
⚠️ **Risk:** If left `true` by default, consumers might unknowingly authorize staff-level overrides by providing staff credentials to `PapiClient` without explicitly opting into override behaviors, which violates the principle of least privilege.
🛡️ **Solution:** Defaulted it to `false` to require explicit opt-in for elevated access, ensuring consumers explicitly authorize staff overrides.

---
*PR created automatically by Jules for task [4606114140168299251](https://jules.google.com/task/4606114140168299251) started by @wesochuck*