### PR TITLE
🧪 Add unit tests for ShelfLocationsGet

### DIFF
--- a/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
@@ -190,5 +190,32 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(handler.LastRequest);
             Assert.AreEqual(expectedPath, handler.LastRequest!.RequestUri!.AbsolutePath);
         }
+
+        [TestMethod]
+        public void ShelfLocationsGet_WithBranchId_UsesBranchIdInUrl()
+        {
+            var handler = new CaptureHttpMessageHandler();
+            var client = CreateClient(handler);
+            int branchId = 789;
+
+            client.ShelfLocationsGet(branchId);
+
+            var expectedPath = $"/PAPIService/REST/public/v1/1033/100/{branchId}/shelflocations";
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(expectedPath, handler.LastRequest!.RequestUri!.AbsolutePath);
+        }
+
+        [TestMethod]
+        public void ShelfLocationsGet_WithoutBranchId_DefaultsToOrganizationId()
+        {
+            var handler = new CaptureHttpMessageHandler();
+            var client = CreateClient(handler);
+
+            client.ShelfLocationsGet();
+
+            var expectedPath = $"/PAPIService/REST/public/v1/1033/100/1/shelflocations"; // OrganizationId from CreateClient is 1
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(expectedPath, handler.LastRequest!.RequestUri!.AbsolutePath);
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** Missing unit tests for the `ShelfLocationsGet` method in `PapiClientUrlEncodingTests`.
📊 **Coverage:** Two scenarios are now tested:
1. `ShelfLocationsGet_WithBranchId_UsesBranchIdInUrl`: verifies the generated path incorporates the provided `branchId`.
2. `ShelfLocationsGet_WithoutBranchId_DefaultsToOrganizationId`: verifies that the generated path defaults to the client's `OrganizationId` when no `branchId` is passed.
✨ **Result:** Improved test coverage and reliability for `ShelfLocationsGet` method's URL generation.

---
*PR created automatically by Jules for task [10462562172941853185](https://jules.google.com/task/10462562172941853185) started by @wesochuck*