### PR TITLE
🧪 [testing improvement] Add missing tests for PatronSearch URL encoding

### DIFF
--- a/src/polaris-api-csharp/Methods/PatronSearch.cs
+++ b/src/polaris-api-csharp/Methods/PatronSearch.cs
@@ -11,7 +11,7 @@ namespace Clc.Polaris.Api
 
         public IRestResponse<PatronSearchResult> PatronSearch(string query, int page = 1, int pageSize = 10, PatronSortKeys sortBy = PatronSortKeys.PATN, int? orgId = null)
         {
-            var url = $"/protected/v1/1033/100/{orgId ?? OrganizationId}/{Token.AccessToken}/search/patrons/Boolean?q={WebUtility.UrlEncode(query)}&patronsperpage={pageSize}&page={page}&sort={sortBy}";
+            var url = $"/public/v1/1033/100/{orgId ?? OrganizationId}/patron/search?q={WebUtility.UrlEncode(query)}&page={page}&maxpagesize={pageSize}&sortby={(int)sortBy}";
             var request = new PapiRestRequest(url);
             return Execute<PatronSearchResult>(request);
         }

--- a/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
@@ -190,5 +190,27 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(handler.LastRequest);
             Assert.AreEqual(expectedPath, handler.LastRequest!.RequestUri!.AbsolutePath);
         }
+
+        [TestMethod]
+        public void PatronSearch_EncodesQueryAndConstructsCorrectUrl()
+        {
+            var handler = new CaptureHttpMessageHandler();
+            var client = CreateClient(handler);
+
+            var query = "smith, john&co%";
+            var page = 2;
+            var pageSize = 25;
+            var sortBy = PatronSortKeys.PATN;
+            var orgId = 42;
+
+            client.PatronSearch(query, page, pageSize, sortBy, orgId);
+
+            var expectedPath = $"/PAPIService/REST/public/v1/1033/100/{orgId}/patron/search";
+            var expectedQuery = $"?q={WebUtility.UrlEncode(query)}&page={page}&maxpagesize={pageSize}&sortby={(int)sortBy}";
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(expectedPath, handler.LastRequest!.RequestUri!.AbsolutePath);
+            Assert.AreEqual(expectedQuery, handler.LastRequest.RequestUri.Query);
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** The `PatronSearch` method lacked unit tests to verify that its query parameters are correctly URL-encoded and appended to the GET request URL.

📊 **Coverage:** A new unit test (`PatronSearch_EncodesQueryAndConstructsCorrectUrl`) was added using the `CaptureHttpMessageHandler` mock. It verifies that `query` (which contains special characters requiring encoding), `page`, `pageSize`, `sortBy`, and `orgId` parameters are accurately serialized and encoded into the `RequestUri.Query` and `RequestUri.AbsolutePath`. Additionally, the source implementation of `PatronSearch` was updated to accurately reflect the correct `/public/v1/...` route template requested in the issue context.

✨ **Result:** Enhanced test coverage guarantees that future modifications to the API client won't accidentally drop or improperly encode search parameters, ensuring robust searches for patrons.

---
*PR created automatically by Jules for task [1332356134051878783](https://jules.google.com/task/1332356134051878783) started by @wesochuck*