### PR TITLE
🧪 Add ItemStatusesGet tests

### DIFF
--- a/src/polaris-api-csharpTests/Methods/ItemStatusesGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ItemStatusesGetTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Clc.Polaris.Api.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Clc.Polaris.Api.Tests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class ItemStatusesGetTests
+    {
+        private sealed class CaptureHttpMessageHandler : HttpMessageHandler
+        {
+            public HttpRequestMessage? LastRequest { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastRequest = request;
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"PAPIErrorCode\":0, \"ItemStatusesRows\":[]}")
+                };
+                response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+                return Task.FromResult(response);
+            }
+        }
+
+        private static PapiClient CreateClient(CaptureHttpMessageHandler handler)
+        {
+            var settings = new PapiSettings
+            {
+                AccessId = "test-access-id",
+                AccessKey = "test-access-key",
+                Hostname = "https://example.test",
+                OrganizationId = 5,
+                UserId = 123,
+                WorkstationId = 456
+            };
+
+            var httpClient = new HttpClient(handler);
+            return new PapiClient(httpClient, settings);
+        }
+
+        [TestMethod]
+        public void ItemStatusesGet_NoBranchId_UsesOrganizationId()
+        {
+            var handler = new CaptureHttpMessageHandler();
+            var client = CreateClient(handler);
+
+            client.ItemStatusesGet();
+
+            var expectedPath = $"/PAPIService/REST/public/v1/1033/100/5/itemstatuses";
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(HttpMethod.Get, handler.LastRequest.Method);
+            Assert.AreEqual(expectedPath, handler.LastRequest.RequestUri!.AbsolutePath);
+        }
+
+        [TestMethod]
+        public void ItemStatusesGet_WithBranchId_UsesProvidedBranchId()
+        {
+            var handler = new CaptureHttpMessageHandler();
+            var client = CreateClient(handler);
+            var branchId = 7;
+
+            client.ItemStatusesGet(branchId);
+
+            var expectedPath = $"/PAPIService/REST/public/v1/1033/100/{branchId}/itemstatuses";
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(HttpMethod.Get, handler.LastRequest.Method);
+            Assert.AreEqual(expectedPath, handler.LastRequest.RequestUri!.AbsolutePath);
+        }
+    }
+}


### PR DESCRIPTION
### 🎯 What
Added missing unit tests for the `ItemStatusesGet` API method in the `PapiClient` using MSTest. The testing focuses on verifying that the client constructs the expected HTTP GET requests to the correct URLs.

### 📊 Coverage
The new `ItemStatusesGetTests` class covers the following scenarios for `ItemStatusesGet`:
* Calling the method without providing a `branchId` defaults to the configured `OrganizationId` in the URL path.
* Calling the method with an explicit `branchId` overrides the `OrganizationId` and correctly formats the URL path.
* The request uses the correct HTTP GET method.

### ✨ Result
Improved unit test coverage for the `PapiClient`. These tests rely on `CaptureHttpMessageHandler` to ensure they execute safely without requiring live network access or valid API credentials, guaranteeing they won't be flaky during CI.

---
*PR created automatically by Jules for task [16779999808112879031](https://jules.google.com/task/16779999808112879031) started by @wesochuck*