### PR TITLE
🔒 Fix explicit TLS 1.2 downgrade

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -70,7 +70,7 @@ namespace Clc.Polaris.Api
 
         public PapiClient(HttpClient client, IPapiSettings settings) : base(null, client)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12 | (SecurityProtocolType)12288;
 
             if (settings != null)
             {


### PR DESCRIPTION
🎯 **What:**
Fixed a security vulnerability in `PapiClient.cs` where the application explicitly downgraded and restricted its outbound connection security protocol to only TLS 1.2, preventing the use of the newer and more secure TLS 1.3 protocol or newer default protocols.

⚠️ **Risk:**
Explicitly restricting to TLS 1.2 prevents the client from utilizing TLS 1.3 when connecting to servers that support it. This leads to weaker cryptography, higher latency during handshakes, and prevents forward compatibility. By overriding existing secure system defaults using the `=` assignment operator, the code was explicitly turning off modern security defaults.

🛡️ **Solution:**
Modified the `ServicePointManager.SecurityProtocol` assignment from an overwrite (`=`) to an append (`|=`) operation using bitwise OR. Additionally, explicitly included TLS 1.3 (value 12288) to ensure modern frameworks can negotiate TLS 1.3 while still supporting TLS 1.2 for legacy systems. Since the project targets `.NET Standard 2.0`, TLS 1.3 was safely implemented by casting the integer `12288` to `SecurityProtocolType`.

---
*PR created automatically by Jules for task [10779083072559061083](https://jules.google.com/task/10779083072559061083) started by @wesochuck*