### PR TITLE
🧪 [testing improvement] Add unit test for HoldRequestReply method

### DIFF
--- a/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
@@ -190,5 +190,39 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(handler.LastRequest);
             Assert.AreEqual(expectedPath, handler.LastRequest!.RequestUri!.AbsolutePath);
         }
+
+        [TestMethod]
+        public async Task HoldRequestReply_ConstructsCorrectUrlAndBody()
+        {
+            var handler = new CaptureHttpMessageHandler();
+            var client = CreateClient(handler);
+            var holdCreateResult = new HoldRequestCreateResult
+            {
+                RequestGuid = Guid.NewGuid(),
+                TxnGroupQualifier = "group-qual",
+                TxnQualifier = "txn-qual"
+            };
+            var requestingOrgId = 42;
+            var answer = HoldRequestReplyAnswer.Yes;
+            var state = HoldRequestReplyState.AcceptILLPolicy;
+
+            client.HoldRequestReply(holdCreateResult, requestingOrgId, answer, state);
+
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(HttpMethod.Put, handler.LastRequest!.Method);
+
+            var expectedPath = $"/PAPIService/REST/public/v1/1033/100/1/holdrequest/{holdCreateResult.RequestGuid}";
+            Assert.AreEqual(expectedPath, handler.LastRequest.RequestUri!.AbsolutePath);
+
+            var content = handler.LastRequest.Content;
+            Assert.IsNotNull(content);
+            var contentString = await content.ReadAsStringAsync();
+
+            Assert.IsTrue(contentString.Contains("\"TxnGroupQualifier\":\"group-qual\""));
+            Assert.IsTrue(contentString.Contains("\"TxnQualifier\":\"txn-qual\""));
+            Assert.IsTrue(contentString.Contains($"\"RequestingOrgID\":{requestingOrgId}"));
+            Assert.IsTrue(contentString.Contains($"\"Answer\":{(int)answer}"));
+            Assert.IsTrue(contentString.Contains($"\"State\":{(int)state}"));
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the `HoldRequestReply` method.
📊 **Coverage:** The new test verifies that `HoldRequestReply` properly serializes the correct JSON request body, utilizes the HTTP PUT method, and generates the expected URL path for the REST API endpoint. 
✨ **Result:** Test coverage for this method is now complete, acting as a regression safety net for future maintenance.

---
*PR created automatically by Jules for task [3753248579918426236](https://jules.google.com/task/3753248579918426236) started by @wesochuck*