### PR TITLE
Fix protected-token cache isolation by including AccessID in cache key

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -219,13 +219,14 @@ namespace Clc.Polaris.Api
         {
             if (StaffOverrideAccount == null ||
                 string.IsNullOrWhiteSpace(Hostname) ||
+                string.IsNullOrWhiteSpace(AccessID) ||
                 string.IsNullOrWhiteSpace(StaffOverrideAccount.Domain) ||
                 string.IsNullOrWhiteSpace(StaffOverrideAccount.Username))
             {
                 return null;
             }
 
-            return $"{Hostname}|{StaffOverrideAccount.Domain}|{StaffOverrideAccount.Username}";
+            return $"{Hostname.Trim()}|{AccessID.Trim()}|{StaffOverrideAccount.Domain.Trim()}|{StaffOverrideAccount.Username.Trim()}";
         }
 
         private static bool IsProtectedTokenMissingOrExpired(ProtectedToken? token)

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -46,7 +46,7 @@ namespace Clc.Polaris.Api.Tests
             var staff = CreateStaffUser();
             client.StaffOverrideAccount = staff;
             client.UseProtectedTokenCache = true;
-            SetCachedToken(client.Hostname, staff, new ProtectedToken
+            SetCachedToken(client.Hostname, client.AccessID, staff, new ProtectedToken
             {
                 AccessToken = "cached-token",
                 AccessSecret = "cached-secret",
@@ -93,7 +93,7 @@ namespace Clc.Polaris.Api.Tests
                 AccessSecret = "expired-secret",
                 ExpirationDate = DateTime.Now.AddHours(-1)
             };
-            SetCachedToken(client.Hostname, staff, new ProtectedToken
+            SetCachedToken(client.Hostname, client.AccessID, staff, new ProtectedToken
             {
                 AccessToken = "cached-token",
                 AccessSecret = "cached-secret",
@@ -224,7 +224,7 @@ namespace Clc.Polaris.Api.Tests
         {
             var handler = new ProtectedTokenHttpMessageHandler();
             var client = CreateProtectedClient(handler);
-            SetCachedToken(client.Hostname, client.StaffOverrideAccount, new ProtectedToken
+            SetCachedToken(client.Hostname, client.AccessID, client.StaffOverrideAccount, new ProtectedToken
             {
                 AccessToken = "cached-token",
                 AccessSecret = "cached-secret",
@@ -254,10 +254,50 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual(2, paths.Length);
             StringAssert.Contains(paths[0], "/protected/v1/1033/100/1/authenticator/staff");
             StringAssert.Contains(paths[1], "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
-            Assert.IsTrue(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out var cachedToken));
+            Assert.IsTrue(TryGetCachedToken(client.Hostname, client.AccessID, client.StaffOverrideAccount, out var cachedToken));
             Assert.IsNotNull(cachedToken);
             Assert.AreEqual("protected-token", cachedToken.AccessToken);
             Assert.AreNotSame(client.Token, cachedToken);
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_SameHostAndStaffWithDifferentAccessIds_AuthenticatesAndCachesSeparately()
+        {
+            var hostname = $"https://example-{Guid.NewGuid():N}.test";
+            var staffUser = CreateStaffUser();
+            var handlerA = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("protected-token-a", "protected-secret-a", DateTime.Now.AddHours(1)));
+            var handlerB = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("protected-token-b", "protected-secret-b", DateTime.Now.AddHours(1)));
+            var clientA = CreateProtectedClient(handlerA);
+            clientA.Hostname = hostname;
+            clientA.AccessID = "access-a";
+            clientA.AccessKey = "access-key-a";
+            clientA.StaffOverrideAccount = staffUser;
+            var clientB = CreateProtectedClient(handlerB);
+            clientB.Hostname = hostname;
+            clientB.AccessID = "access-b";
+            clientB.AccessKey = "access-key-b";
+            clientB.StaffOverrideAccount = CreateStaffUser();
+
+            await clientA.PatronSearchAsync("name=Smith");
+            await clientB.PatronSearchAsync("name=Smith");
+
+            Assert.AreEqual(1, handlerA.AuthenticationRequestCount);
+            Assert.AreEqual(1, handlerA.ProtectedRequestCount);
+            Assert.AreEqual("protected-token-a", clientA.Token?.AccessToken);
+            Assert.AreEqual(1, handlerB.AuthenticationRequestCount);
+            Assert.AreEqual(1, handlerB.ProtectedRequestCount);
+            Assert.AreEqual("protected-token-b", clientB.Token?.AccessToken);
+            Assert.IsTrue(TryGetCachedToken(hostname, "access-a", clientA.StaffOverrideAccount, out var cachedTokenA));
+            Assert.IsTrue(TryGetCachedToken(hostname, "access-b", clientB.StaffOverrideAccount, out var cachedTokenB));
+            Assert.IsNotNull(cachedTokenA);
+            Assert.IsNotNull(cachedTokenB);
+            Assert.AreEqual("protected-token-a", cachedTokenA.AccessToken);
+            Assert.AreEqual("protected-token-b", cachedTokenB.AccessToken);
+            Assert.AreNotSame(cachedTokenA, cachedTokenB);
         }
 
         [TestMethod]
@@ -271,7 +311,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
-            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.StaffOverrideAccount, out _));
         }
 
         [TestMethod]
@@ -285,7 +325,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
-            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.StaffOverrideAccount, out _));
         }
 
         [TestMethod]
@@ -305,7 +345,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
-            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.StaffOverrideAccount, out _));
         }
 
         [TestMethod]
@@ -325,7 +365,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
-            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.StaffOverrideAccount, out _));
         }
 
 
@@ -348,7 +388,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
-            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.StaffOverrideAccount, out _));
         }
 
         [TestMethod]
@@ -580,17 +620,17 @@ namespace Clc.Polaris.Api.Tests
             locks?.Clear();
         }
 
-        private static void SetCachedToken(string hostname, PolarisUser? staffUser, ProtectedToken token)
+        private static void SetCachedToken(string hostname, string accessId, PolarisUser? staffUser, ProtectedToken token)
         {
             var cache = GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache");
-            cache?.TryAdd(BuildCacheKey(hostname, staffUser), token);
+            cache?.TryAdd(BuildCacheKey(hostname, accessId, staffUser), token);
         }
 
-        private static bool TryGetCachedToken(string hostname, PolarisUser? staffUser, out ProtectedToken? token)
+        private static bool TryGetCachedToken(string hostname, string accessId, PolarisUser? staffUser, out ProtectedToken? token)
         {
             token = null;
             var cache = GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache");
-            return staffUser != null && cache?.TryGetValue(BuildCacheKey(hostname, staffUser), out token) == true;
+            return staffUser != null && cache?.TryGetValue(BuildCacheKey(hostname, accessId, staffUser), out token) == true;
         }
 
         private static T? GetPrivateStaticProperty<T>(string propertyName) where T : class
@@ -599,10 +639,10 @@ namespace Clc.Polaris.Api.Tests
             return cacheProperty?.GetValue(null) as T;
         }
 
-        private static string BuildCacheKey(string hostname, PolarisUser? staffUser)
+        private static string BuildCacheKey(string hostname, string accessId, PolarisUser? staffUser)
         {
             if (staffUser == null) { throw new ArgumentNullException(nameof(staffUser)); }
-            return $"{hostname}|{staffUser.Domain}|{staffUser.Username}";
+            return $"{hostname.Trim()}|{accessId.Trim()}|{staffUser.Domain.Trim()}|{staffUser.Username.Trim()}";
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Prevent reuse of a protected-token across `PapiClient` instances that share host and staff account but use different PAPI credentials. 
- Ensure cache keys are stable and normalized while avoiding storing the raw `AccessKey`.

### Description

- Updated `BuildProtectedTokenCacheKey()` in `src/polaris-api-csharp/PapiClient.cs` to require `AccessID` and return a normalized trimmed key of the form `hostname|accessId|staffDomain|staffUsername` while keeping existing null/empty guards and not including `AccessKey`.
- Updated test helper signatures and implementations in `src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs` to include `accessId` in `SetCachedToken`, `TryGetCachedToken`, and `BuildCacheKey` and to use trimmed components.
- Reworked existing test assertions to use the new cache key shape and added a regression test `PatronSearchAsync_SameHostAndStaffWithDifferentAccessIds_AuthenticatesAndCachesSeparately` proving two clients with the same host and staff but different `AccessID`s authenticate and cache tokens separately.

### Testing

- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"` and the test run passed with all tests succeeding (Passed: 100, Failed: 0, Skipped: 0). 
- The newly added regression test `PatronSearchAsync_SameHostAndStaffWithDifferentAccessIds_AuthenticatesAndCachesSeparately` executed as part of that test run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a22e1d1cf648323a6b804489459bdfc)