### PR TITLE
Fix protected token cache key isolation (include AccessID)

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -219,13 +219,14 @@ namespace Clc.Polaris.Api
         {
             if (StaffOverrideAccount == null ||
                 string.IsNullOrWhiteSpace(Hostname) ||
+                string.IsNullOrWhiteSpace(AccessID) ||
                 string.IsNullOrWhiteSpace(StaffOverrideAccount.Domain) ||
                 string.IsNullOrWhiteSpace(StaffOverrideAccount.Username))
             {
                 return null;
             }
 
-            return $"{Hostname}|{StaffOverrideAccount.Domain}|{StaffOverrideAccount.Username}";
+            return $"{Hostname.Trim()}|{AccessID.Trim()}|{StaffOverrideAccount.Domain.Trim()}|{StaffOverrideAccount.Username.Trim()}";
         }
 
         private static bool IsProtectedTokenMissingOrExpired(ProtectedToken? token)

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -46,7 +46,7 @@ namespace Clc.Polaris.Api.Tests
             var staff = CreateStaffUser();
             client.StaffOverrideAccount = staff;
             client.UseProtectedTokenCache = true;
-            SetCachedToken(client.Hostname, staff, new ProtectedToken
+            SetCachedToken(client.Hostname, client.AccessID, staff, new ProtectedToken
             {
                 AccessToken = "cached-token",
                 AccessSecret = "cached-secret",
@@ -93,7 +93,7 @@ namespace Clc.Polaris.Api.Tests
                 AccessSecret = "expired-secret",
                 ExpirationDate = DateTime.Now.AddHours(-1)
             };
-            SetCachedToken(client.Hostname, staff, new ProtectedToken
+            SetCachedToken(client.Hostname, client.AccessID, staff, new ProtectedToken
             {
                 AccessToken = "cached-token",
                 AccessSecret = "cached-secret",
@@ -224,7 +224,7 @@ namespace Clc.Polaris.Api.Tests
         {
             var handler = new ProtectedTokenHttpMessageHandler();
             var client = CreateProtectedClient(handler);
-            SetCachedToken(client.Hostname, client.StaffOverrideAccount, new ProtectedToken
+            SetCachedToken(client.Hostname, client.AccessID, client.StaffOverrideAccount, new ProtectedToken
             {
                 AccessToken = "cached-token",
                 AccessSecret = "cached-secret",
@@ -236,6 +236,51 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.ProtectedRequestCount);
             Assert.AreEqual("cached-token", client.Token?.AccessToken);
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_SameHostAndStaffWithDifferentAccessIds_AuthenticatesAndCachesSeparateTokens()
+        {
+            var hostname = $"https://example-{Guid.NewGuid():N}.test";
+            var staff = CreateStaffUser();
+
+            var handlerA = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("token-a", "secret-a", DateTime.Now.AddHours(1)));
+            var clientA = CreateProtectedClient(handlerA);
+            clientA.Hostname = hostname;
+            clientA.AccessID = "access-a";
+            clientA.StaffOverrideAccount = staff;
+
+            await clientA.PatronSearchAsync("name=Smith");
+
+            Assert.AreEqual(1, handlerA.AuthenticationRequestCount);
+            Assert.AreEqual(1, handlerA.ProtectedRequestCount);
+            Assert.AreEqual("token-a", clientA.Token?.AccessToken);
+            Assert.IsTrue(TryGetCachedToken(hostname, "access-a", staff, out var cachedTokenA));
+            Assert.IsNotNull(cachedTokenA);
+            Assert.AreEqual("token-a", cachedTokenA.AccessToken);
+
+            var handlerB = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("token-b", "secret-b", DateTime.Now.AddHours(1)));
+            var clientB = CreateProtectedClient(handlerB);
+            clientB.Hostname = hostname;
+            clientB.AccessID = "access-b";
+            clientB.StaffOverrideAccount = staff;
+
+            await clientB.PatronSearchAsync("name=Jones");
+
+            Assert.AreEqual(1, handlerB.AuthenticationRequestCount);
+            Assert.AreEqual(1, handlerB.ProtectedRequestCount);
+            Assert.AreEqual("token-b", clientB.Token?.AccessToken);
+            Assert.IsTrue(TryGetCachedToken(hostname, "access-b", staff, out var cachedTokenB));
+            Assert.IsNotNull(cachedTokenB);
+            Assert.AreEqual("token-b", cachedTokenB.AccessToken);
+            Assert.AreNotEqual(cachedTokenA.AccessToken, cachedTokenB.AccessToken);
+            Assert.IsTrue(TryGetCachedToken(hostname, "access-a", staff, out var cachedTokenAAfterClientB));
+            Assert.IsNotNull(cachedTokenAAfterClientB);
+            Assert.AreEqual("token-a", cachedTokenAAfterClientB.AccessToken);
         }
 
         [TestMethod]
@@ -254,7 +299,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual(2, paths.Length);
             StringAssert.Contains(paths[0], "/protected/v1/1033/100/1/authenticator/staff");
             StringAssert.Contains(paths[1], "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
-            Assert.IsTrue(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out var cachedToken));
+            Assert.IsTrue(TryGetCachedToken(client.Hostname, client.AccessID, client.StaffOverrideAccount, out var cachedToken));
             Assert.IsNotNull(cachedToken);
             Assert.AreEqual("protected-token", cachedToken.AccessToken);
             Assert.AreNotSame(client.Token, cachedToken);
@@ -271,7 +316,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
-            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.StaffOverrideAccount, out _));
         }
 
         [TestMethod]
@@ -285,7 +330,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
-            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.StaffOverrideAccount, out _));
         }
 
         [TestMethod]
@@ -305,7 +350,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
-            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.StaffOverrideAccount, out _));
         }
 
         [TestMethod]
@@ -325,7 +370,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
-            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.StaffOverrideAccount, out _));
         }
 
 
@@ -348,7 +393,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsNull(client.Token);
-            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.StaffOverrideAccount, out _));
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.StaffOverrideAccount, out _));
         }
 
         [TestMethod]
@@ -580,17 +625,17 @@ namespace Clc.Polaris.Api.Tests
             locks?.Clear();
         }
 
-        private static void SetCachedToken(string hostname, PolarisUser? staffUser, ProtectedToken token)
+        private static void SetCachedToken(string hostname, string accessId, PolarisUser? staffUser, ProtectedToken token)
         {
             var cache = GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache");
-            cache?.TryAdd(BuildCacheKey(hostname, staffUser), token);
+            cache?.TryAdd(BuildCacheKey(hostname, accessId, staffUser), token);
         }
 
-        private static bool TryGetCachedToken(string hostname, PolarisUser? staffUser, out ProtectedToken? token)
+        private static bool TryGetCachedToken(string hostname, string accessId, PolarisUser? staffUser, out ProtectedToken? token)
         {
             token = null;
             var cache = GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache");
-            return staffUser != null && cache?.TryGetValue(BuildCacheKey(hostname, staffUser), out token) == true;
+            return staffUser != null && cache?.TryGetValue(BuildCacheKey(hostname, accessId, staffUser), out token) == true;
         }
 
         private static T? GetPrivateStaticProperty<T>(string propertyName) where T : class
@@ -599,10 +644,10 @@ namespace Clc.Polaris.Api.Tests
             return cacheProperty?.GetValue(null) as T;
         }
 
-        private static string BuildCacheKey(string hostname, PolarisUser? staffUser)
+        private static string BuildCacheKey(string hostname, string accessId, PolarisUser? staffUser)
         {
             if (staffUser == null) { throw new ArgumentNullException(nameof(staffUser)); }
-            return $"{hostname}|{staffUser.Domain}|{staffUser.Username}";
+            return $"{hostname.Trim()}|{accessId.Trim()}|{staffUser.Domain.Trim()}|{staffUser.Username.Trim()}";
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent protected-token reuse across different PAPI credentials when clients share the same host and staff account by improving cache key uniqueness.
- Ensure the cache key remains stable and normalized while continuing to avoid storing raw `AccessKey` material.
- Provide unit coverage proving that clients with identical host/staff but different `AccessID` values authenticate and cache tokens separately.

### Description
- Update `BuildProtectedTokenCacheKey()` in `src/polaris-api-csharp/PapiClient.cs` to require a non-empty `AccessID` and include the trimmed `AccessID` in the key while omitting the raw `AccessKey` and trimming all components (`Hostname`, `AccessID`, staff `Domain`, staff `Username`).
- Add a new unit test `PatronSearchAsync_SameHostAndStaffWithDifferentAccessIds_AuthenticatesAndCachesSeparateTokens()` in `src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs` to validate cache isolation between different `AccessID`s.
- Update existing test helpers and assertions in `PapiClientTokenTests.cs` to use the new normalized cache key shape (`hostname|accessId|domain|username`).

### Testing
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"` and all tests passed (100 passed, 0 failed) after the change.
- The new unit test demonstrates the bug would fail on the old implementation and succeeds with the updated cache key logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a22e1d1cf648323a6b804489459bdfc)