### PR TITLE
Ignore local integration test settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -403,5 +403,8 @@ FodyWeavers.xsd
 ##################
 # CLC CUSTOM
 ##################
-[Aa]pp[Ss]ettings.[Tt]est.json
+# Local integration test settings can contain Polaris credentials.
+# Keep example/template config files trackable by only ignoring the real local file name.
+src/polaris-api-csharpTests/appsettings.Test.json
+**/appsettings.Test.json
 [Aa]pp[Ss]ettings.[Dd]evelopment.json


### PR DESCRIPTION
### Motivation
- Prevent accidental commits of local Polaris integration credentials by explicitly ignoring the real test settings file. 
- Keep the README statement accurate that `src/polaris-api-csharpTests/appsettings.Test.json` is ignored while allowing example/template files to remain trackable.

### Description
- Replace the previous broad ignore pattern with explicit entries for `src/polaris-api-csharpTests/appsettings.Test.json` and a recursive `**/appsettings.Test.json` in `.gitignore`.
- Add a short explanatory comment in `.gitignore` clarifying why the specific pattern is used so example/template files are not excluded.
- Leave other ignore rules (including `[Aa]pp[Ss]ettings.[Dd]evelopment.json`) unchanged.

### Testing
- Ran `git check-ignore -v src/polaris-api-csharpTests/appsettings.Test.json` which reported a matching ignore rule (success).
- Ran `git check-ignore -v src/polaris-api-csharpTests/appsettings.Test.example.json` which returned that the example file is not ignored (success).
- Ran `git diff --check` which reported no whitespace or merge conflict issues (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a22e5dd6f74832387d416e2dbc45719)