### PR TITLE
Ignore local integration test settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -403,5 +403,11 @@ FodyWeavers.xsd
 ##################
 # CLC CUSTOM
 ##################
-[Aa]pp[Ss]ettings.[Tt]est.json
+# Local integration test settings may contain real Polaris credentials.
+src/polaris-api-csharpTests/appsettings.Test.json
+**/appsettings.Test.json
+# Keep shareable example/template configuration files trackable.
+!**/appsettings*.example.json
+!**/appsettings*.template.json
+
 [Aa]pp[Ss]ettings.[Dd]evelopment.json


### PR DESCRIPTION
### Motivation
- Prevent accidental commits of local Polaris integration credentials by explicitly protecting the local `appsettings.Test.json` file. 
- Preserve the README's guidance that `appsettings.Test.json` is ignored while allowing shareable example/template config files to remain trackable.

### Description
- Update `.gitignore` to explicitly ignore `src/polaris-api-csharpTests/appsettings.Test.json` and a broader `**/appsettings.Test.json` pattern. 
- Add negated patterns `!**/appsettings*.example.json` and `!**/appsettings*.template.json` so example/template config files are not ignored. 
- Leave other existing ignore entries (including `[Aa]pp[Ss]ettings.[Dd]evelopment.json`) unchanged and do not modify package versions.

### Testing
- Ran `git check-ignore -v src/polaris-api-csharpTests/appsettings.Test.json` which matched the new `**/appsettings.Test.json` ignore pattern and succeeded. 
- Ran `git check-ignore -v src/polaris-api-csharpTests/appsettings.template.json` which returned no match (exit code 1) confirming templates remain trackable. 
- Ran `git diff --check` with no problems reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a22e5dd6f74832387d416e2dbc45719)