### PR TITLE
Make disposable integration artifacts unique

### DIFF
--- a/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
@@ -21,6 +21,7 @@ namespace Clc.Polaris.Api.Tests
     public class PapiClientTests
     {
         private const string MissingIntegrationConfigurationMessage = "Integration test configuration is missing. Provide appsettings.Test.json or environment variables to run integration tests.";
+        private const string TestArtifactPrefix = "PAPI_TEST_";
 
         TestSettings Settings = null!;
 
@@ -74,8 +75,45 @@ namespace Clc.Polaris.Api.Tests
                 && !string.IsNullOrWhiteSpace(settings.PatronBarcode)
                 && !string.IsNullOrWhiteSpace(settings.PatronPin)
                 && !string.IsNullOrWhiteSpace(settings.FreeTextBlock)
-                && !string.IsNullOrWhiteSpace(settings.PatronListName)
                 && !string.IsNullOrWhiteSpace(settings.OrgEmail);
+        }
+
+        private static string CreateUniqueTestArtifactText(string? baseName = null, int maxLength = 80)
+        {
+            var sanitizedBaseName = SanitizeArtifactBaseName(baseName);
+            var uniqueSuffix = $"{DateTime.UtcNow:yyyyMMddHHmmss}_{Guid.NewGuid():N}";
+            var suffixWithPrefix = $"{TestArtifactPrefix}{uniqueSuffix}";
+
+            if (string.IsNullOrWhiteSpace(sanitizedBaseName))
+            {
+                return suffixWithPrefix;
+            }
+
+            var baseNameBudget = maxLength - suffixWithPrefix.Length - 1;
+            if (baseNameBudget <= 0)
+            {
+                return suffixWithPrefix;
+            }
+
+            var trimmedBaseName = sanitizedBaseName.Length <= baseNameBudget
+                ? sanitizedBaseName
+                : sanitizedBaseName[..baseNameBudget];
+
+            return $"{TestArtifactPrefix}{trimmedBaseName}_{uniqueSuffix}";
+        }
+
+        private static string SanitizeArtifactBaseName(string? baseName)
+        {
+            if (string.IsNullOrWhiteSpace(baseName))
+            {
+                return string.Empty;
+            }
+
+            var sanitized = new string(baseName
+                .Where(c => char.IsLetterOrDigit(c) || c == '-' || c == '_')
+                .ToArray());
+
+            return sanitized.Trim('_', '-');
         }
 
         [TestMethod()]
@@ -282,7 +320,7 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task NotificationUpdateTest()
         {
-            var response = (await papi.NotificationUpdateAsync(new NotificationUpdateParams { PatronId = Settings.PatronId, DeliveryString = "test@test.test", ReportingOrgID = 7, NotificationDeliveryDate = DateTime.Now, DeliveryOptionId = 2, Details = "test", NotificationStatusId = NotificationStatus.EmailCompleted, NotificationTypeId = 1 })).Data;
+            var response = (await papi.NotificationUpdateAsync(new NotificationUpdateParams { PatronId = Settings.PatronId, DeliveryString = "test@test.test", ReportingOrgID = 7, NotificationDeliveryDate = DateTime.Now, DeliveryOptionId = 2, Details = CreateUniqueTestArtifactText(maxLength: 80), NotificationStatusId = NotificationStatus.EmailCompleted, NotificationTypeId = 1 })).Data;
             Assert.IsTrue(response.PAPIErrorCode == -1);
         }
 
@@ -305,7 +343,7 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronAccountCreateCreditTest()
         {
-            var response = await papi.PatronAccountCreateCreditAsync(Settings.PatronBarcode, .01, PaymentMethod.Cash);
+            var response = await papi.PatronAccountCreateCreditAsync(Settings.PatronBarcode, .01, PaymentMethod.Cash, note: CreateUniqueTestArtifactText(maxLength: 80));
             Assert.IsTrue(response.Data.PAPIErrorCode == 0);
         }
 
@@ -314,11 +352,16 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task TestTitleListCreate_Get_Delete()
         {
-            var createResponse = await papi.PatronAccountCreateTitleListAsync(Settings.PatronBarcode, Settings.PatronListName, Settings.PatronPin);
-            Assert.IsTrue(createResponse.Data.PAPIErrorCode == 0 || createResponse.Data.PAPIErrorCode == -1);
+            var listName = CreateUniqueTestArtifactText(Settings.PatronListName);
+
+            var createResponse = await papi.PatronAccountCreateTitleListAsync(Settings.PatronBarcode, listName, Settings.PatronPin);
+            Assert.AreEqual(0, createResponse.Data.PAPIErrorCode);
 
             var getResponse = await papi.PatronAccountGetTitleListsAsync(Settings.PatronBarcode, Settings.PatronPin);
-            var list = getResponse.Data.PatronAccountTitleListsRows.Single(l => l.RecordStoreName == Settings.PatronListName);
+            var list = getResponse.Data.PatronAccountTitleListsRows.FirstOrDefault(l => l.RecordStoreName == listName);
+
+            Assert.IsNotNull(list, $"Expected to find uniquely named title list '{listName}'.");
+
             var deleteResponse = await papi.PatronAccountDeleteTitleListAsync(Settings.PatronBarcode, list.RecordStoreId, Settings.PatronPin);
             Assert.IsTrue(deleteResponse.Data.PAPIErrorCode == 0);
         }
@@ -328,7 +371,7 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronAccountDepositCreditTest()
         {
-            var response = await papi.PatronAccountDepositCreditAsync(Settings.PatronBarcode, .01, note: "integration testing");
+            var response = await papi.PatronAccountDepositCreditAsync(Settings.PatronBarcode, .01, note: CreateUniqueTestArtifactText(maxLength: 80));
             Assert.IsTrue(response.Data.PAPIErrorCode == 0);
         }
 
@@ -345,7 +388,7 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronAccountPayTest()
         {
-            var response = (await papi.PatronAccountPayAsync(Settings.PatronBarcode, 1234, .01, PaymentMethod.Cash, note: "integration testing")).Data;
+            var response = (await papi.PatronAccountPayAsync(Settings.PatronBarcode, 1234, .01, PaymentMethod.Cash, note: CreateUniqueTestArtifactText(maxLength: 80))).Data;
             Assert.IsTrue(response.PAPIErrorCode == -3600);
         }
 
@@ -354,7 +397,7 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronAccountPayAllTest()
         {
-            var response = await papi.PatronAccountPayAllAsync(Settings.PatronBarcode, 999999.99, PaymentMethod.Cash, note: "integration testing");
+            var response = await papi.PatronAccountPayAllAsync(Settings.PatronBarcode, 999999.99, PaymentMethod.Cash, note: CreateUniqueTestArtifactText(maxLength: 80));
             Assert.IsTrue(response.Data.PAPIErrorCode == -3610);
         }
 
@@ -363,7 +406,7 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronAccountRefundCreditTest()
         {
-            var response = await papi.PatronAccountRefundCreditAsync(Settings.PatronBarcode, 999999.99, note: "integration testing");
+            var response = await papi.PatronAccountRefundCreditAsync(Settings.PatronBarcode, 999999.99, note: CreateUniqueTestArtifactText(maxLength: 80));
             Assert.IsTrue(response.Data.PAPIErrorCode == -3606);
         }
 
@@ -372,7 +415,7 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronAccountVoidTest()
         {
-            var response = await papi.PatronAccountVoidAsync(Settings.PatronBarcode, 1234, note: "integration testing");
+            var response = await papi.PatronAccountVoidAsync(Settings.PatronBarcode, 1234, note: CreateUniqueTestArtifactText(maxLength: 80));
             Assert.IsTrue(response.Data.PAPIErrorCode == -3606);
         }
 


### PR DESCRIPTION
### Motivation
- Prevent test failures caused by prior same-day artifacts when rerunning disposable mutating integration tests.
- Ensure title-list tests do not rely on a reusable configured name and can locate the exact list they created.
- Provide a consistent `PAPI_TEST_` prefix for easily-identifiable test artifacts while allowing an optional configured base name.

### Description
- Added a `TestArtifactPrefix` constant and helper `CreateUniqueTestArtifactText(...)` that builds `PAPI_TEST_` + `UTC timestamp` + `Guid`, and a `SanitizeArtifactBaseName(...)` helper to preserve a safe base name when space allows.
- Relaxed `HasRequiredTestSettings(...)` to stop requiring `Settings.PatronListName` so the configured value is optional and no longer required for test correctness.
- Rewrote `TestTitleListCreate_Get_Delete` to create a unique `listName`, create the list with that name, fetch lists and locate the created list using `FirstOrDefault(...)` by exact unique name, assert it is found, then delete it (removing the previous `.Single(...)` on the reusable name).
- Replaced static integration note/details text in mutating tests with `CreateUniqueTestArtifactText(...)` so any produced artifacts (notes/details) are unique per run.

### Testing
- Ran `dotnet format src/polaris-api-csharp.sln --include src/polaris-api-csharpTests/Methods/PapiClientTests.cs` which completed successfully.
- Ran `dotnet test src/polaris-api-csharp.sln --no-restore --filter "TestTitleListCreate_Get_Delete"` which built the test assembly successfully but the filtered integration test was skipped because integration configuration is not present in the execution environment.
- Ran `git diff --check` equivalent verification which reported no diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a22ef479d9c8323bf0df68e38e1bfdb)