### PR TITLE
Require staff override credentials for protected integration tests

### DIFF
--- a/src/polaris-api-csharpTests/IntegrationTestRequirements.cs
+++ b/src/polaris-api-csharpTests/IntegrationTestRequirements.cs
@@ -1,0 +1,47 @@
+using Clc.Polaris.Api.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Clc.Polaris.Api.Tests
+{
+    internal static class IntegrationTestRequirements
+    {
+        public const string MissingIntegrationConfigurationMessage = "Integration test configuration is missing. Provide appsettings.Test.json or environment variables to run integration tests.";
+        public const string MissingStaffOverrideAccountMessage = "Integration test requires staff override credentials. Configure PapiSettings:PolarisOverrideAccount with non-empty Domain, Username, and Password to run protected or destructive live tests.";
+
+        public static bool HasRequiredPapiSettings(PapiSettings? settings)
+        {
+            return settings != null
+                && !string.IsNullOrWhiteSpace(settings.AccessId)
+                && !string.IsNullOrWhiteSpace(settings.AccessKey)
+                && !string.IsNullOrWhiteSpace(settings.Hostname);
+        }
+
+        public static bool HasRequiredTestSettings(TestSettings? settings)
+        {
+            return settings != null
+                && settings.PatronId > 0
+                && !string.IsNullOrWhiteSpace(settings.PatronBarcode)
+                && !string.IsNullOrWhiteSpace(settings.PatronPin)
+                && !string.IsNullOrWhiteSpace(settings.FreeTextBlock)
+                && !string.IsNullOrWhiteSpace(settings.OrgEmail);
+        }
+
+        public static bool HasRequiredStaffOverrideAccount(PapiSettings? settings)
+        {
+            var staffOverrideAccount = settings?.PolarisOverrideAccount;
+
+            return staffOverrideAccount != null
+                && !string.IsNullOrWhiteSpace(staffOverrideAccount.Domain)
+                && !string.IsNullOrWhiteSpace(staffOverrideAccount.Username)
+                && !string.IsNullOrWhiteSpace(staffOverrideAccount.Password);
+        }
+
+        public static void RequireStaffOverrideAccount(PapiSettings? settings)
+        {
+            if (!HasRequiredStaffOverrideAccount(settings))
+            {
+                Assert.Inconclusive(MissingStaffOverrideAccountMessage);
+            }
+        }
+    }
+}

--- a/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
@@ -346,8 +346,6 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task TestTitleListCreate_Get_Delete()
         {
-            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
-
             var listName = CreateUniqueTestArtifactText(Settings.PatronListName);
 
             var createResponse = await papi.PatronAccountCreateTitleListAsync(Settings.PatronBarcode, listName, Settings.PatronPin);
@@ -478,8 +476,6 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronMessageDeleteTest()
         {
-            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
-
             var response = await papi.PatronMessageDeleteAsync(Settings.PatronBarcode, PatronMessageType.freetext, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -496,8 +492,6 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronMessageUpdateStatusTest()
         {
-            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
-
             var response = await papi.PatronMessageUpdateStatusAsync(Settings.PatronBarcode, PatronMessageType.freetext, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -514,8 +508,6 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronReadingHistoryClearTest()
         {
-            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
-
             var response = await papi.PatronReadingHistoryClearAsync(Settings.PatronBarcode, new[] { 1234 });
             Assert.IsTrue(response.Data.PAPIErrorCode == -10);
         }
@@ -564,8 +556,6 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListAddTitleTest()
         {
-            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
-
             var response = await papi.PatronTitleListAddTitleAsync(Settings.PatronBarcode, 1234, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -575,8 +565,6 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListCopyAllTitlesTest()
         {
-            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
-
             var response = await papi.PatronTitleListCopyAllTitlesAsync(Settings.PatronBarcode, 1234, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -586,8 +574,6 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListCopyTitleTest()
         {
-            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
-
             var response = await papi.PatronTitleListCopyTitleAsync(Settings.PatronBarcode, 1234, 1234, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -597,8 +583,6 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListDeleteAllTitlesTest()
         {
-            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
-
             var response = await papi.PatronTitleListDeleteAllTitlesAsync(Settings.PatronBarcode, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -608,8 +592,6 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListDeleteTitleTest()
         {
-            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
-
             var response = await papi.PatronTitleListDeleteTitleAsync(Settings.PatronBarcode, 1234, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -626,8 +608,6 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListMoveTitleTest()
         {
-            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
-
             var response = await papi.PatronTitleListMoveTitleAsync(Settings.PatronBarcode, 1234, 1234, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -637,8 +617,6 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronUpdateTest()
         {
-            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
-
             var response = await papi.PatronUpdateAsync(Settings.PatronBarcode, new PatronUpdateParams(), Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == 0);
         }

--- a/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
@@ -20,10 +20,10 @@ namespace Clc.Polaris.Api.Tests
     [TestCategory("Integration")]
     public class PapiClientTests
     {
-        private const string MissingIntegrationConfigurationMessage = "Integration test configuration is missing. Provide appsettings.Test.json or environment variables to run integration tests.";
         private const string TestArtifactPrefix = "PAPI_TEST_";
 
         TestSettings Settings = null!;
+        PapiSettings PapiSettings = null!;
 
         protected static IConfiguration InitConfiguration()
         {
@@ -51,31 +51,14 @@ namespace Clc.Polaris.Api.Tests
             var papiSettings = config.GetSection(PapiSettings.SECTION_NAME).Get<PapiSettings>();
             var testSettings = config.Get<TestSettings>();
 
-            if (!HasRequiredPapiSettings(papiSettings) || !HasRequiredTestSettings(testSettings))
+            if (!IntegrationTestRequirements.HasRequiredPapiSettings(papiSettings) || !IntegrationTestRequirements.HasRequiredTestSettings(testSettings))
             {
-                Assert.Inconclusive(MissingIntegrationConfigurationMessage);
+                Assert.Inconclusive(IntegrationTestRequirements.MissingIntegrationConfigurationMessage);
             }
 
             papi = new PapiClient(papiSettings!);
+            PapiSettings = papiSettings!;
             Settings = testSettings!;
-        }
-
-        private static bool HasRequiredPapiSettings(PapiSettings? settings)
-        {
-            return settings != null
-                && !string.IsNullOrWhiteSpace(settings.AccessId)
-                && !string.IsNullOrWhiteSpace(settings.AccessKey)
-                && !string.IsNullOrWhiteSpace(settings.Hostname);
-        }
-
-        private static bool HasRequiredTestSettings(TestSettings? settings)
-        {
-            return settings != null
-                && settings.PatronId > 0
-                && !string.IsNullOrWhiteSpace(settings.PatronBarcode)
-                && !string.IsNullOrWhiteSpace(settings.PatronPin)
-                && !string.IsNullOrWhiteSpace(settings.FreeTextBlock)
-                && !string.IsNullOrWhiteSpace(settings.OrgEmail);
         }
 
         private static string CreateUniqueTestArtifactText(string? baseName = null, int maxLength = 80)
@@ -135,10 +118,7 @@ namespace Clc.Polaris.Api.Tests
         public async Task AuthenticateStaffUserTest()
         {
             var staffOverrideAccount = papi.StaffOverrideAccount;
-            if (staffOverrideAccount == null)
-            {
-                Assert.Inconclusive(MissingIntegrationConfigurationMessage);
-            }
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
             var response = await papi.AuthenticateStaffUserAsync(staffOverrideAccount!);
             Assert.AreEqual(response.Data.PAPIErrorCode, 0);
@@ -188,6 +168,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task CreatePatronBlocksTest_FreeTextBlock()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.FreeText, Settings.FreeTextBlock);
             Assert.IsTrue(new[] { 0, -3507 }.Contains(response.Data.PAPIErrorCode));
         }
@@ -197,6 +179,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task CreatePatronBlocksTest_SystemBlock()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.System, "128");
             Assert.IsTrue(new[] { 0, -3507 }.Contains(response.Data.PAPIErrorCode));
         }
@@ -206,6 +190,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task CreatePatronBlocksTest_LibraryAssignedBlock()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.LibraryAssigned, "1");
             Assert.IsTrue(new[] { 0, -3507 }.Contains(response.Data.PAPIErrorCode));
         }
@@ -254,6 +240,8 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod()]
         public async Task HoldRequestGetListTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.HoldRequestGetListAsync(7);
             Assert.IsTrue(response.Data.PAPIErrorCode == 0);
         }
@@ -320,6 +308,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task NotificationUpdateTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = (await papi.NotificationUpdateAsync(new NotificationUpdateParams { PatronId = Settings.PatronId, DeliveryString = "test@test.test", ReportingOrgID = 7, NotificationDeliveryDate = DateTime.Now, DeliveryOptionId = 2, Details = CreateUniqueTestArtifactText(maxLength: 80), NotificationStatusId = NotificationStatus.EmailCompleted, NotificationTypeId = 1 })).Data;
             Assert.IsTrue(response.PAPIErrorCode == -1);
         }
@@ -334,6 +324,8 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod()]
         public async Task Patron_GetBarcodeFromIdTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.Patron_GetBarcodeFromIdAsync(Settings.PatronId);
             Assert.IsTrue(response.Data.Barcode == Settings.PatronBarcode);
         }
@@ -343,6 +335,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronAccountCreateCreditTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronAccountCreateCreditAsync(Settings.PatronBarcode, .01, PaymentMethod.Cash, note: CreateUniqueTestArtifactText(maxLength: 80));
             Assert.IsTrue(response.Data.PAPIErrorCode == 0);
         }
@@ -352,6 +346,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task TestTitleListCreate_Get_Delete()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var listName = CreateUniqueTestArtifactText(Settings.PatronListName);
 
             var createResponse = await papi.PatronAccountCreateTitleListAsync(Settings.PatronBarcode, listName, Settings.PatronPin);
@@ -371,6 +367,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronAccountDepositCreditTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronAccountDepositCreditAsync(Settings.PatronBarcode, .01, note: CreateUniqueTestArtifactText(maxLength: 80));
             Assert.IsTrue(response.Data.PAPIErrorCode == 0);
         }
@@ -388,6 +386,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronAccountPayTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = (await papi.PatronAccountPayAsync(Settings.PatronBarcode, 1234, .01, PaymentMethod.Cash, note: CreateUniqueTestArtifactText(maxLength: 80))).Data;
             Assert.IsTrue(response.PAPIErrorCode == -3600);
         }
@@ -397,6 +397,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronAccountPayAllTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronAccountPayAllAsync(Settings.PatronBarcode, 999999.99, PaymentMethod.Cash, note: CreateUniqueTestArtifactText(maxLength: 80));
             Assert.IsTrue(response.Data.PAPIErrorCode == -3610);
         }
@@ -406,6 +408,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronAccountRefundCreditTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronAccountRefundCreditAsync(Settings.PatronBarcode, 999999.99, note: CreateUniqueTestArtifactText(maxLength: 80));
             Assert.IsTrue(response.Data.PAPIErrorCode == -3606);
         }
@@ -415,6 +419,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronAccountVoidTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronAccountVoidAsync(Settings.PatronBarcode, 1234, note: CreateUniqueTestArtifactText(maxLength: 80));
             Assert.IsTrue(response.Data.PAPIErrorCode == -3606);
         }
@@ -472,6 +478,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronMessageDeleteTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronMessageDeleteAsync(Settings.PatronBarcode, PatronMessageType.freetext, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -488,6 +496,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronMessageUpdateStatusTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronMessageUpdateStatusAsync(Settings.PatronBarcode, PatronMessageType.freetext, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -504,6 +514,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronReadingHistoryClearTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronReadingHistoryClearAsync(Settings.PatronBarcode, new[] { 1234 });
             Assert.IsTrue(response.Data.PAPIErrorCode == -10);
         }
@@ -525,6 +537,8 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod()]
         public async Task PatronRenewBlocksGetTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronRenewBlocksGetAsync(Settings.PatronId);
             Assert.IsTrue(response.Data.PAPIErrorCode == 0);
         }
@@ -539,6 +553,8 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod()]
         public async Task PatronSearchTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronSearchAsync($"PRID={Settings.PatronId}");
             Assert.IsTrue(response.Data.PAPIErrorCode == response.Data.PatronSearchRows.Count);
         }
@@ -548,6 +564,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListAddTitleTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronTitleListAddTitleAsync(Settings.PatronBarcode, 1234, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -557,6 +575,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListCopyAllTitlesTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronTitleListCopyAllTitlesAsync(Settings.PatronBarcode, 1234, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -566,6 +586,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListCopyTitleTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronTitleListCopyTitleAsync(Settings.PatronBarcode, 1234, 1234, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -575,6 +597,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListDeleteAllTitlesTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronTitleListDeleteAllTitlesAsync(Settings.PatronBarcode, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -584,6 +608,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListDeleteTitleTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronTitleListDeleteTitleAsync(Settings.PatronBarcode, 1234, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -600,6 +626,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListMoveTitleTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronTitleListMoveTitleAsync(Settings.PatronBarcode, 1234, 1234, 1234, Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == -1);
         }
@@ -609,6 +637,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronUpdateTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.PatronUpdateAsync(Settings.PatronBarcode, new PatronUpdateParams(), Settings.PatronPin);
             Assert.IsTrue(response.Data.PAPIErrorCode == 0);
         }
@@ -639,6 +669,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task RecordSetContentAddTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.RecordSetContentAddAsync(1234, 1234);
             Assert.IsTrue(response.Data.PAPIErrorCode == -11001);
         }
@@ -648,6 +680,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task RecordSetContentAddTest_List()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.RecordSetContentAddAsync(1234, new[] { 1234 });
             Assert.IsTrue(response.Data.PAPIErrorCode == -11001);
         }
@@ -657,6 +691,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task RecordSetContentRemoveTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.RecordSetContentRemoveAsync(1234, 1234);
             Assert.IsTrue(response.Data.PAPIErrorCode == -11001);
         }
@@ -666,6 +702,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task RecordSetContentRemoveTest_List()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.RecordSetContentRemoveAsync(1234, new[] { 1234 });
             Assert.IsTrue(response.Data.PAPIErrorCode == -11001);
         }
@@ -673,6 +711,8 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod()]
         public async Task RecordSetRecordsGetTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.RecordSetRecordsGetAsync(1234);
             Assert.IsTrue(response.Data.PAPIErrorCode == -11001);
         }
@@ -687,6 +727,8 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod()]
         public async Task SA_GetValueByOrgTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.SA_GetValueByOrgAsync("ORGEMAIL");
             Assert.IsTrue(response.Data.Value == Settings.OrgEmail);
         }
@@ -701,6 +743,8 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod()]
         public async Task Synch_BibsByIdGetTest()
         {
+            IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
+
             var response = await papi.Synch_BibsByIdGetAsync(bibId);
             Assert.IsTrue(response.Response.IsSuccessStatusCode);
         }

--- a/src/polaris-api-csharpTests/Validation/IntegrationTestRequirementsTests.cs
+++ b/src/polaris-api-csharpTests/Validation/IntegrationTestRequirementsTests.cs
@@ -1,0 +1,60 @@
+using Clc.Polaris.Api.Configuration;
+using Clc.Polaris.Api.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Clc.Polaris.Api.Tests.Validation
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class IntegrationTestRequirementsTests
+    {
+        [TestMethod]
+        public void HasRequiredStaffOverrideAccount_ReturnsFalseWhenSettingsAreNull()
+        {
+            Assert.IsFalse(IntegrationTestRequirements.HasRequiredStaffOverrideAccount(null));
+        }
+
+        [TestMethod]
+        public void HasRequiredStaffOverrideAccount_ReturnsFalseWhenOverrideAccountIsMissing()
+        {
+            var settings = new PapiSettings();
+
+            Assert.IsFalse(IntegrationTestRequirements.HasRequiredStaffOverrideAccount(settings));
+        }
+
+        [DataTestMethod]
+        [DataRow("", "user", "password")]
+        [DataRow("domain", "", "password")]
+        [DataRow("domain", "user", "")]
+        [DataRow("   ", "user", "password")]
+        [DataRow("domain", "   ", "password")]
+        [DataRow("domain", "user", "   ")]
+        public void HasRequiredStaffOverrideAccount_ReturnsFalseWhenAnyCredentialFieldIsBlank(string domain, string username, string password)
+        {
+            var settings = CreateSettings(domain, username, password);
+
+            Assert.IsFalse(IntegrationTestRequirements.HasRequiredStaffOverrideAccount(settings));
+        }
+
+        [TestMethod]
+        public void HasRequiredStaffOverrideAccount_ReturnsTrueWhenAllCredentialFieldsArePresent()
+        {
+            var settings = CreateSettings("domain", "user", "password");
+
+            Assert.IsTrue(IntegrationTestRequirements.HasRequiredStaffOverrideAccount(settings));
+        }
+
+        private static PapiSettings CreateSettings(string domain, string username, string password)
+        {
+            return new PapiSettings
+            {
+                PolarisOverrideAccount = new PolarisUser
+                {
+                    Domain = domain,
+                    Username = username,
+                    Password = password
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Protected PAPI integration tests can fail during protected-token placeholder replacement when staff override credentials are not configured.
- Public integration tests should continue to run with only the basic PAPI settings and patron test values.
- Public patron-authenticated tests should not be skipped solely because Polaris staff override credentials are unavailable.

### Description

- Added `IntegrationTestRequirements` to centralize integration configuration checks.
- Added `HasRequiredStaffOverrideAccount(PapiSettings?)` and `RequireStaffOverrideAccount(PapiSettings?)`.
- Staff override validation now checks that `PolarisOverrideAccount` is present and has non-empty `Domain`, `Username`, and `Password`.
- Updated `PapiClientTests` to store the loaded `PapiSettings` for per-test protected endpoint checks.
- Added `RequireStaffOverrideAccount(...)` only before tests that call protected PAPI endpoints or protected-token routes, including staff authentication, patron search/renew-block reads, record-set protected methods, protected patron-account methods, notification update, create patron blocks, sysadmin value lookup, and synch bib lookup.
- Left public read-only and public patron-authenticated tests runnable without staff override credentials.
- Added unit coverage for staff override validation with null settings, missing override account, blank credential fields, and complete credentials.

### Testing

- Ran unit tests with:

  `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter TestCategory=Unit`

- Ran non-integration tests with:

  `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"`

### Notes

- Staff override requirements now follow protected endpoint usage rather than the broader `MutatingIntegration` category.
- Public patron endpoints may still require patron barcode/password or `AccessSecret`, but they do not require `PolarisOverrideAccount` unless the client method uses a protected route.