### PR TITLE
Document disposable integration test model

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,21 @@ Run non-integration tests from the repository root:
 dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"
 ```
 
-Run integration tests only when you have local Polaris settings configured:
+Run read-only integration tests only when you have live Polaris dev credentials and local Polaris settings configured:
 
 ```bash
-dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Integration"
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Integration&TestCategory!=DisposableIntegration"
 ```
 
-Integration tests require local Polaris credentials and test data in `src/polaris-api-csharpTests/appsettings.Test.json`, so they are not run by default in CI. Do not commit real secrets; `appsettings.Test.json` is ignored by git.
+Integration tests require live Polaris dev credentials and test data in `src/polaris-api-csharpTests/appsettings.Test.json`, so they are not run by default in CI. Keep `appsettings.Test.json` local only: do not commit real secrets or environment-specific test settings. The file is ignored by git.
+
+Run disposable/destructive integration tests separately, and only against a disposable or nightly-refreshed Polaris dev environment:
+
+```bash
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=DisposableIntegration"
+```
+
+`DisposableIntegration` tests may create or modify patron blocks, title lists, account entries, record-set entries, notes, or similar Polaris artifacts. These tests are intended for disposable dev data only, artifacts may be left behind, and cleanup is not guaranteed. Same-day collision avoidance is handled by unique test names and notes rather than by assuming that prior artifacts were removed. Staff override credentials in `PapiSettings.PolarisOverrideAccount` are required for protected or destructive tests.
 
 A local `appsettings.Test.json` follows this shape:
 


### PR DESCRIPTION
### Motivation
- Clarify the intended test model by distinguishing read-only integration tests from disposable/destructive integration tests. 
- Warn maintainers that some integration tests require live Polaris dev credentials and may create persistent artifacts in dev environments. 
- Reinforce that local test secrets and environment-specific settings must not be committed.

### Description
- Updated the README `Local tests` section to introduce separate commands for non-integration, read-only integration, and disposable integration tests. 
- Changed the integration test command to run read-only tests with `--filter "TestCategory=Integration&TestCategory!=DisposableIntegration"` and added a separate command for `DisposableIntegration` tests. 
- Added a clear warning that `DisposableIntegration` tests may create or modify patron blocks, title lists, account entries, record-set entries, notes, or similar Polaris artifacts and that cleanup is not guaranteed. 
- Documented that same-day collision avoidance relies on unique test names/notes and that staff override credentials in `PapiSettings.PolarisOverrideAccount` are required for protected/destructive tests.

### Testing
- Ran `git diff --check` to validate working tree changes with no whitespace or diff issues and it completed successfully. 
- Executed `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"` and the test run passed (`Passed: 109, Failed: 0`).
- No CI-facing changes were made; integration tests remain excluded from default CI runs as documented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a232b6a352883239db5ca4480dc0677)