### PR TITLE
Document disposable integration test usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ Integration tests require live Polaris dev credentials and local test data in `s
 Run read-only integration tests only when you have local Polaris dev settings configured:
 
 ```bash
-dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Integration&TestCategory!=DisposableIntegration"
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Integration&TestCategory!=MutatingIntegration"
 ```
 
-Run disposable/destructive integration tests only against a disposable Polaris dev environment that is refreshed nightly or otherwise safe to dirty:
+Run mutating/destructive integration tests only against a disposable Polaris dev environment that is refreshed nightly or otherwise safe to dirty:
 
 ```bash
-dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=DisposableIntegration"
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=MutatingIntegration"
 ```
 
-`DisposableIntegration` tests may create patron blocks, title lists, account entries, record-set entries, notes, or similar artifacts in Polaris. These artifacts may be left behind; cleanup is not guaranteed. Same-day collision avoidance is handled by unique test names and notes, not by assuming prior artifacts were removed. Protected or destructive tests require staff override credentials in `PapiSettings.PolarisOverrideAccount`.
+`MutatingIntegration` tests may create or modify patron blocks, title lists, account entries, record-set entries, notes, or similar artifacts in Polaris. These artifacts may be left behind; cleanup is not guaranteed. Same-day collision avoidance is handled by unique test names and notes, not by assuming prior artifacts were removed. Protected or destructive tests require staff override credentials in `PapiSettings.PolarisOverrideAccount`.
 
 A local `appsettings.Test.json` follows this shape:
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,21 @@ Run non-integration tests from the repository root:
 dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"
 ```
 
-Run integration tests only when you have local Polaris settings configured:
+Integration tests require live Polaris dev credentials and local test data in `src/polaris-api-csharpTests/appsettings.Test.json`, so they are not run by default in CI. Keep this file local only: do not commit real secrets, and remember that `appsettings.Test.json` is ignored by git.
+
+Run read-only integration tests only when you have local Polaris dev settings configured:
 
 ```bash
-dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Integration"
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Integration&TestCategory!=DisposableIntegration"
 ```
 
-Integration tests require local Polaris credentials and test data in `src/polaris-api-csharpTests/appsettings.Test.json`, so they are not run by default in CI. Do not commit real secrets; `appsettings.Test.json` is ignored by git.
+Run disposable/destructive integration tests only against a disposable Polaris dev environment that is refreshed nightly or otherwise safe to dirty:
+
+```bash
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=DisposableIntegration"
+```
+
+`DisposableIntegration` tests may create patron blocks, title lists, account entries, record-set entries, notes, or similar artifacts in Polaris. These artifacts may be left behind; cleanup is not guaranteed. Same-day collision avoidance is handled by unique test names and notes, not by assuming prior artifacts were removed. Protected or destructive tests require staff override credentials in `PapiSettings.PolarisOverrideAccount`.
 
 A local `appsettings.Test.json` follows this shape:
 


### PR DESCRIPTION
### Motivation

- Clarify the intended test model distinguishing read-only integration tests from disposable/destructive tests that may modify Polaris data.
- Warn contributors that disposable tests require a refreshable/dev environment and that cleanup is not guaranteed.
- Reinforce that local secrets in `appsettings.Test.json` must remain local and must not be committed.

### Description

- Update `README.md` Local tests section to require live Polaris dev credentials and local test data in `src/polaris-api-csharpTests/appsettings.Test.json` and to state that the file is ignored by git.
- Split the documented test commands so maintainers can run non-integration, read-only integration, and disposable integration tests separately using `dotnet test` with filters `"TestCategory!=Integration"`, `"TestCategory=Integration&TestCategory!=DisposableIntegration"`, and `"TestCategory=DisposableIntegration"` respectively.
- Add clear warnings that `DisposableIntegration` tests may create patron blocks, title lists, account entries, record-set entries, notes, or similar artifacts and that these artifacts may be left behind.
- Note that same-day collision avoidance is handled by unique test names/notes and that protected/destructive tests require staff override credentials in `PapiSettings.PolarisOverrideAccount`.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a232b6a352883239db5ca4480dc0677)