### PR TITLE
PatronReadingHistoryClearTest: use patron PIN to ensure authenticated call

### DIFF
--- a/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
@@ -508,7 +508,7 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronReadingHistoryClearTest()
         {
-            var response = await papi.PatronReadingHistoryClearAsync(Settings.PatronBarcode, new[] { 1234 });
+            var response = await papi.PatronReadingHistoryClearAsync(Settings.PatronBarcode, Settings.PatronPin, new[] { 1234 });
             Assert.IsTrue(response.Data.PAPIErrorCode == -10);
         }
 


### PR DESCRIPTION
### Motivation
- The test invoked `PatronReadingHistoryClearAsync` without a patron PIN or an explicit staff-override requirement, which could cause accidental unauthenticated mutating calls or unpredictable staff-override behavior when running integration tests.

### Description
- Update `PatronReadingHistoryClearTest` in `src/polaris-api-csharpTests/Methods/PapiClientTests.cs` to call `PatronReadingHistoryClearAsync(Settings.PatronBarcode, Settings.PatronPin, new[] { 1234 })`, keeping `[TestCategory("MutatingIntegration")]`, `[DoNotParallelize]`, and the expected `PAPIErrorCode == -10` unchanged.

### Testing
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"`, and the test run passed with `Passed: 114, Failed: 0, Skipped: 0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2334e42f7c8323b11a6b6c32c9c5e8)