### PR TITLE
Add ProtectedIntegration category for staff-required read-only tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,16 @@ dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "T
 
 Integration tests require live Polaris dev credentials and local test data in `src/polaris-api-csharpTests/appsettings.Test.json`, so they are not run by default in CI. Keep this file local only: do not commit real secrets, and remember that `appsettings.Test.json` is ignored by git.
 
-Run read-only integration tests only when you have local Polaris dev settings configured:
+Run basic read-only integration tests only when you have local Polaris dev settings configured. This excludes protected read-only tests that require staff override credentials:
 
 ```bash
-dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Integration&TestCategory!=MutatingIntegration"
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Integration&TestCategory!=MutatingIntegration&TestCategory!=ProtectedIntegration"
+```
+
+Run protected read-only integration tests only when your local settings include staff override credentials in `PapiSettings.PolarisOverrideAccount`:
+
+```bash
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ProtectedIntegration&TestCategory!=MutatingIntegration"
 ```
 
 Run mutating/destructive integration tests only against a disposable Polaris dev environment that is refreshed nightly or otherwise safe to dirty:

--- a/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
@@ -115,6 +115,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task AuthenticateStaffUserTest()
         {
             var staffOverrideAccount = papi.StaffOverrideAccount;
@@ -238,6 +239,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task HoldRequestGetListTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -322,6 +324,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task Patron_GetBarcodeFromIdTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -527,6 +530,7 @@ namespace Clc.Polaris.Api.Tests
         //}
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task PatronRenewBlocksGetTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -543,6 +547,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task PatronSearchTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -687,6 +692,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task RecordSetRecordsGetTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -703,6 +709,7 @@ namespace Clc.Polaris.Api.Tests
         //}
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task SA_GetValueByOrgTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -719,6 +726,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task Synch_BibsByIdGetTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);


### PR DESCRIPTION
### Motivation
- Separate basic read-only integration tests from read-only tests that require staff override credentials so users with only basic PAPI credentials can run a clear, non-protected filter. 
- Mark tests that call `IntegrationTestRequirements.RequireStaffOverrideAccount` (but are non-mutating) so they can be excluded from the standard read-only run. 

### Description
- Added `[TestCategory("ProtectedIntegration")]` to staff-required, read-only tests in `src/polaris-api-csharpTests/Methods/PapiClientTests.cs` while preserving the class-level `[TestCategory("Integration")]`. 
- Tagged the following tests as `ProtectedIntegration`: `AuthenticateStaffUserTest`, `HoldRequestGetListTest`, `Patron_GetBarcodeFromIdTest`, `PatronRenewBlocksGetTest`, `PatronSearchTest`, `RecordSetRecordsGetTest`, `SA_GetValueByOrgTest`, and `Synch_BibsByIdGetTest`. 
- Updated `README.md` to document new test filters that exclude protected read-only tests and to show how to run protected read-only tests explicitly. 

### Testing
- Ran `dotnet test ... --filter "TestCategory=ProtectedIntegration&TestCategory!=MutatingIntegration" --list-tests` and the build/listing completed successfully and showed the expected protected tests. 
- Ran `dotnet test ... --no-restore --no-build --list-tests --filter "TestCategory=Integration&TestCategory!=MutatingIntegration&TestCategory!=ProtectedIntegration"` and the build/listing completed successfully and showed the basic read-only tests. 
- Ran `dotnet test ... --no-restore --no-build --list-tests --filter "TestCategory=MutatingIntegration"` and the build/listing completed successfully and showed the mutating tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2335f1e1b0832397c71b682570bd23)