### PR TITLE
Tag protected read-only integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,16 @@ dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "T
 
 Integration tests require live Polaris dev credentials and local test data in `src/polaris-api-csharpTests/appsettings.Test.json`, so they are not run by default in CI. Keep this file local only: do not commit real secrets, and remember that `appsettings.Test.json` is ignored by git.
 
-Run read-only integration tests only when you have local Polaris dev settings configured:
+Run basic read-only integration tests only when you have local Polaris dev settings configured. This excludes protected read-only tests that require staff override credentials:
 
 ```bash
-dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Integration&TestCategory!=MutatingIntegration"
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Integration&TestCategory!=MutatingIntegration&TestCategory!=ProtectedIntegration"
+```
+
+Run protected read-only integration tests only when `PapiSettings.PolarisOverrideAccount` is configured with staff override credentials:
+
+```bash
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ProtectedIntegration&TestCategory!=MutatingIntegration"
 ```
 
 Run mutating/destructive integration tests only against a disposable Polaris dev environment that is refreshed nightly or otherwise safe to dirty:

--- a/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
@@ -115,6 +115,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task AuthenticateStaffUserTest()
         {
             var staffOverrideAccount = papi.StaffOverrideAccount;
@@ -238,6 +239,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task HoldRequestGetListTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -322,6 +324,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task Patron_GetBarcodeFromIdTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -527,6 +530,7 @@ namespace Clc.Polaris.Api.Tests
         //}
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task PatronRenewBlocksGetTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -543,6 +547,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task PatronSearchTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -687,6 +692,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task RecordSetRecordsGetTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -703,6 +709,7 @@ namespace Clc.Polaris.Api.Tests
         //}
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task SA_GetValueByOrgTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -719,6 +726,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("ProtectedIntegration")]
         public async Task Synch_BibsByIdGetTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);


### PR DESCRIPTION
### Motivation
- Make the published read-only integration test filter unambiguous by separating basic read-only tests from read-only tests that require staff-override credentials.
- Prevent accidental inclusion of staff-only tests in the common read-only test run for users with only basic PAPI credentials.

### Description
- Added `[TestCategory("ProtectedIntegration")]` to staff-required, non-mutating tests inside `src/polaris-api-csharpTests/Methods/PapiClientTests.cs` while keeping the class-level `[TestCategory("Integration")]` inherited.
- The following read-only tests were tagged as `ProtectedIntegration`: `AuthenticateStaffUserTest`, `HoldRequestGetListTest`, `Patron_GetBarcodeFromIdTest`, `PatronRenewBlocksGetTest`, `PatronSearchTest`, `RecordSetRecordsGetTest`, `SA_GetValueByOrgTest`, and `Synch_BibsByIdGetTest`.
- Did not add `ProtectedIntegration` to tests already marked `[TestCategory("MutatingIntegration")]` and left mutating tests unchanged.
- Updated `README.md` to document separate invocation examples for basic read-only, protected read-only, and mutating integration test filters.

### Testing
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"` which completed successfully with `Passed: 114, Failed: 0`.
- Verified test grouping with `dotnet test --no-build --list-tests` using the filters `"TestCategory=Integration&TestCategory!=MutatingIntegration&TestCategory!=ProtectedIntegration"`, `"TestCategory=ProtectedIntegration&TestCategory!=MutatingIntegration"`, and `"TestCategory=MutatingIntegration"`, and confirmed the expected tests were listed under each filter.
- No test failures were observed during the automated runs or listing checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2335f1e1b0832397c71b682570bd23)