### PR TITLE
Make free-text patron block test artifact unique

### DIFF
--- a/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
@@ -171,7 +171,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.FreeText, Settings.FreeTextBlock);
+            var blockText = CreateUniqueTestArtifactText(Settings.FreeTextBlock, maxLength: 80);
+            var response = await papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.FreeText, blockText);
             Assert.IsTrue(new[] { 0, -3507 }.Contains(response.Data.PAPIErrorCode));
         }
 


### PR DESCRIPTION
### Motivation
- Avoid same-day artifact collisions in `CreatePatronBlocksTest_FreeTextBlock` so the test more reliably exercises creation instead of duplicate/block-exists behavior.

### Description
- Update `CreatePatronBlocksTest_FreeTextBlock` to generate a unique free-text value with `CreateUniqueTestArtifactText(Settings.FreeTextBlock, maxLength: 80)` and pass the resulting `blockText` into `CreatePatronBlocksAsync`, while preserving the existing mutating integration attributes and accepted response codes `{ 0, -3507 }`; changes made in `src/polaris-api-csharpTests/Methods/PapiClientTests.cs`.

### Testing
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"` which passed (Passed: 114, Failed: 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a23395afce083239fd33fa4f7f1b47c)