### PR TITLE
Add PAPI integration category guard tests

### DIFF
--- a/src/polaris-api-csharpTests/Methods/PapiClientTestCategoryTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTestCategoryTests.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+
+namespace Clc.Polaris.Api.Tests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class PapiClientTestCategoryTests
+    {
+        private const string ProtectedIntegrationCategory = "ProtectedIntegration";
+        private const string MutatingIntegrationCategory = "MutatingIntegration";
+
+        [TestMethod]
+        public void KnownStaffRequiredReadOnlyTestsHaveProtectedIntegrationCategory()
+        {
+            var protectedIntegrationTests = new[]
+            {
+                nameof(PapiClientTests.AuthenticateStaffUserTest),
+                nameof(PapiClientTests.HoldRequestGetListTest),
+                nameof(PapiClientTests.Patron_GetBarcodeFromIdTest),
+                nameof(PapiClientTests.PatronRenewBlocksGetTest),
+                nameof(PapiClientTests.PatronSearchTest),
+                nameof(PapiClientTests.RecordSetRecordsGetTest),
+                nameof(PapiClientTests.SA_GetValueByOrgTest),
+                nameof(PapiClientTests.Synch_BibsByIdGetTest),
+            };
+
+            AssertMethodsHaveCategory(protectedIntegrationTests, ProtectedIntegrationCategory);
+        }
+
+        [TestMethod]
+        public void KnownMutatingTestsHaveMutatingIntegrationCategory()
+        {
+            var mutatingIntegrationTests = new[]
+            {
+                nameof(PapiClientTests.CreatePatronBlocksTest_FreeTextBlock),
+                nameof(PapiClientTests.CreatePatronBlocksTest_SystemBlock),
+                nameof(PapiClientTests.CreatePatronBlocksTest_LibraryAssignedBlock),
+                nameof(PapiClientTests.NotificationUpdateTest),
+                nameof(PapiClientTests.PatronAccountCreateCreditTest),
+                nameof(PapiClientTests.TestTitleListCreate_Get_Delete),
+                nameof(PapiClientTests.PatronAccountDepositCreditTest),
+                nameof(PapiClientTests.PatronAccountPayTest),
+                nameof(PapiClientTests.PatronAccountPayAllTest),
+                nameof(PapiClientTests.PatronAccountRefundCreditTest),
+                nameof(PapiClientTests.PatronAccountVoidTest),
+                nameof(PapiClientTests.PatronMessageDeleteTest),
+                nameof(PapiClientTests.PatronMessageUpdateStatusTest),
+                nameof(PapiClientTests.PatronReadingHistoryClearTest),
+                nameof(PapiClientTests.PatronTitleListAddTitleTest),
+                nameof(PapiClientTests.PatronTitleListCopyAllTitlesTest),
+                nameof(PapiClientTests.PatronTitleListCopyTitleTest),
+                nameof(PapiClientTests.PatronTitleListDeleteAllTitlesTest),
+                nameof(PapiClientTests.PatronTitleListDeleteTitleTest),
+                nameof(PapiClientTests.PatronTitleListMoveTitleTest),
+                nameof(PapiClientTests.PatronUpdateTest),
+                nameof(PapiClientTests.RecordSetContentAddTest),
+                nameof(PapiClientTests.RecordSetContentAddTest_List),
+                nameof(PapiClientTests.RecordSetContentRemoveTest),
+                nameof(PapiClientTests.RecordSetContentRemoveTest_List),
+            };
+
+            AssertMethodsHaveCategory(mutatingIntegrationTests, MutatingIntegrationCategory);
+        }
+
+        private static void AssertMethodsHaveCategory(IEnumerable<string> methodNames, string expectedCategory)
+        {
+            var missingCategory = methodNames
+                .Where(methodName => !MethodHasCategory(methodName, expectedCategory))
+                .ToArray();
+
+            Assert.IsFalse(
+                missingCategory.Any(),
+                $"Expected these {nameof(PapiClientTests)} methods to be marked with TestCategory(\"{expectedCategory}\"): {string.Join(", ", missingCategory)}");
+        }
+
+        private static bool MethodHasCategory(string methodName, string expectedCategory)
+        {
+            var method = typeof(PapiClientTests).GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public);
+
+            Assert.IsNotNull(method, $"Expected to find public test method {nameof(PapiClientTests)}.{methodName}.");
+
+            return method
+                .GetCustomAttributes<TestCategoryAttribute>(inherit: false)
+                .SelectMany(attribute => attribute.TestCategories)
+                .Contains(expectedCategory);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent future regressions where tests that call `RequireStaffOverrideAccount` lose the `ProtectedIntegration` or `MutatingIntegration` categories. 
- The integration suite relies on the three categories `Integration`, `ProtectedIntegration`, and `MutatingIntegration` and those mappings must remain accurate. 
- Provide a low-friction, credential-free guard that fails fast when known tests are mis-categorized.

### Description
- Add a new MSTest class `PapiClientTestCategoryTests` placed at `src/polaris-api-csharpTests/Methods/PapiClientTestCategoryTests.cs` and marked with `[TestCategory("Unit")]` so it runs when integration tests are filtered out. 
- Implement reflection-based assertions that a curated list of known staff-required read-only methods are marked with `ProtectedIntegration`. 
- Implement reflection-based assertions that a curated list of known mutating methods are marked with `MutatingIntegration`. 
- Use a helper that inspects `TestCategoryAttribute` on public methods via reflection so the test does not parse method bodies or require live Polaris credentials.

### Testing
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"` and the run completed successfully with `Passed: 116, Failed: 0`. 
- The added tests run under the non-integration filter so no live Polaris credentials are required. 
- The unit-category guard fails if any listed method loses its expected category, satisfying the acceptance criteria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a23396f4804832394c1e5e0ec18b8c9)