### PR TITLE
Harden protected token cache keys

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -220,13 +220,47 @@ namespace Clc.Polaris.Api
             if (StaffOverrideAccount == null ||
                 string.IsNullOrWhiteSpace(Hostname) ||
                 string.IsNullOrWhiteSpace(AccessID) ||
+                string.IsNullOrWhiteSpace(AccessKey) ||
                 string.IsNullOrWhiteSpace(StaffOverrideAccount.Domain) ||
-                string.IsNullOrWhiteSpace(StaffOverrideAccount.Username))
+                string.IsNullOrWhiteSpace(StaffOverrideAccount.Username) ||
+                string.IsNullOrWhiteSpace(StaffOverrideAccount.Password))
             {
                 return null;
             }
 
-            return $"{Hostname.Trim()}|{AccessID.Trim()}|{StaffOverrideAccount.Domain.Trim()}|{StaffOverrideAccount.Username.Trim()}";
+            var normalizedHostname = Hostname.Trim();
+            var normalizedAccessId = AccessID.Trim();
+            var normalizedDomain = StaffOverrideAccount.Domain.Trim();
+            var normalizedUsername = StaffOverrideAccount.Username.Trim();
+            var credentialFingerprint = BuildProtectedTokenCredentialFingerprint(
+                normalizedHostname,
+                normalizedAccessId,
+                AccessKey,
+                normalizedDomain,
+                normalizedUsername,
+                StaffOverrideAccount.Password);
+
+            return $"{normalizedHostname}|{normalizedAccessId}|{normalizedDomain}|{normalizedUsername}|{credentialFingerprint}";
+        }
+
+        private static string BuildProtectedTokenCredentialFingerprint(
+            string normalizedHostname,
+            string normalizedAccessId,
+            string accessKey,
+            string normalizedDomain,
+            string normalizedUsername,
+            string password)
+        {
+            var credentialMaterial = string.Join(
+                "\u001F",
+                normalizedHostname,
+                normalizedAccessId,
+                accessKey,
+                normalizedDomain,
+                normalizedUsername,
+                password);
+            var credentialHash = SHA256.HashData(Encoding.UTF8.GetBytes(credentialMaterial));
+            return Convert.ToHexString(credentialHash);
         }
 
         private static bool IsProtectedTokenMissingOrExpired(ProtectedToken? token)
@@ -241,13 +275,19 @@ namespace Clc.Polaris.Api
                 return false;
             }
 
-            if (ProtectedTokenCache.TryGetValue(cacheKey, out var cachedToken) && !IsProtectedTokenMissingOrExpired(cachedToken))
+            if (!ProtectedTokenCache.TryGetValue(cacheKey, out var cachedToken))
             {
-                _token = new ProtectedToken(cachedToken);
-                return true;
+                return false;
             }
 
-            return false;
+            if (IsProtectedTokenMissingOrExpired(cachedToken))
+            {
+                ProtectedTokenCache.TryRemove(cacheKey, out _);
+                return false;
+            }
+
+            _token = new ProtectedToken(cachedToken);
+            return true;
         }
 
         private async Task<ProtectedToken?> AuthenticateAndLoadProtectedTokenAsync(string? cacheKey, CancellationToken cancellationToken)
@@ -268,6 +308,11 @@ namespace Clc.Polaris.Api
                 string.IsNullOrWhiteSpace(responseData.AccessToken) ||
                 string.IsNullOrWhiteSpace(responseData.AccessSecret))
             {
+                if (!string.IsNullOrWhiteSpace(cacheKey))
+                {
+                    ProtectedTokenCache.TryRemove(cacheKey, out _);
+                }
+
                 _token = currentToken;
                 return _token;
             }

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -238,6 +238,159 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual("cached-token", client.Token?.AccessToken);
         }
 
+
+        [TestMethod]
+        public async Task PatronSearchAsync_CachedTokenWithSameStaffButBlankPassword_DoesNotReuseOrWriteCache()
+        {
+            var hostname = $"https://example-{Guid.NewGuid():N}.test";
+            var staffA = CreateStaffUser("correct-1");
+            var clientA = CreateProtectedClient(new ProtectedTokenHttpMessageHandler());
+            clientA.Hostname = hostname;
+            clientA.StaffOverrideAccount = staffA;
+            SetCachedToken(hostname, clientA.AccessID, clientA.AccessKey, staffA, new ProtectedToken
+            {
+                AccessToken = "cached-token-a",
+                AccessSecret = "cached-secret-a",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            });
+
+            var handlerB = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("token-b", "secret-b", DateTime.Now.AddHours(1)));
+            var clientB = CreateProtectedClient(handlerB);
+            clientB.Hostname = hostname;
+            clientB.StaffOverrideAccount = CreateStaffUser(string.Empty);
+
+            await clientB.PatronSearchAsync("name=Jones");
+
+            Assert.AreEqual(1, handlerB.AuthenticationRequestCount);
+            Assert.AreEqual(1, handlerB.ProtectedRequestCount);
+            Assert.AreEqual("token-b", clientB.Token?.AccessToken);
+            Assert.IsTrue(TryGetCachedToken(hostname, clientA.AccessID, clientA.AccessKey, staffA, out var cachedTokenA));
+            Assert.IsNotNull(cachedTokenA);
+            Assert.AreEqual("cached-token-a", cachedTokenA.AccessToken);
+            Assert.AreEqual(1, ProtectedTokenCacheCount());
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_CachedTokenWithSameStaffButDifferentPassword_DoesNotReuseCache()
+        {
+            var hostname = $"https://example-{Guid.NewGuid():N}.test";
+            var staffA = CreateStaffUser("correct-1");
+            var handlerA = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("token-a", "secret-a", DateTime.Now.AddHours(1)));
+            var clientA = CreateProtectedClient(handlerA);
+            clientA.Hostname = hostname;
+            clientA.StaffOverrideAccount = staffA;
+
+            await clientA.PatronSearchAsync("name=Smith");
+
+            var handlerB = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("token-b", "secret-b", DateTime.Now.AddHours(1)));
+            var clientB = CreateProtectedClient(handlerB);
+            clientB.Hostname = hostname;
+            clientB.StaffOverrideAccount = CreateStaffUser("different-2");
+
+            await clientB.PatronSearchAsync("name=Jones");
+
+            Assert.AreEqual(1, handlerA.AuthenticationRequestCount);
+            Assert.AreEqual(1, handlerB.AuthenticationRequestCount);
+            Assert.AreEqual("token-b", clientB.Token?.AccessToken);
+            Assert.AreNotEqual("token-a", clientB.Token?.AccessToken);
+            Assert.AreEqual(2, ProtectedTokenCacheCount());
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_CachedTokenWithDifferentAccessKey_DoesNotReuseCache()
+        {
+            var hostname = $"https://example-{Guid.NewGuid():N}.test";
+            var staff = CreateStaffUser("correct-1");
+            var handlerA = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("token-a", "secret-a", DateTime.Now.AddHours(1)));
+            var clientA = CreateProtectedClient(handlerA);
+            clientA.Hostname = hostname;
+            clientA.StaffOverrideAccount = staff;
+            clientA.AccessKey = "access-key-a";
+
+            await clientA.PatronSearchAsync("name=Smith");
+
+            var handlerB = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("token-b", "secret-b", DateTime.Now.AddHours(1)));
+            var clientB = CreateProtectedClient(handlerB);
+            clientB.Hostname = hostname;
+            clientB.StaffOverrideAccount = staff;
+            clientB.AccessKey = "access-key-b";
+
+            await clientB.PatronSearchAsync("name=Jones");
+
+            Assert.AreEqual(1, handlerA.AuthenticationRequestCount);
+            Assert.AreEqual(1, handlerB.AuthenticationRequestCount);
+            Assert.AreEqual("token-b", clientB.Token?.AccessToken);
+            Assert.AreNotEqual("token-a", clientB.Token?.AccessToken);
+            Assert.AreEqual(2, ProtectedTokenCacheCount());
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_BlankStaffPassword_DoesNotReadFromOrWriteToProtectedTokenCache()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("blank-password-token", "blank-password-secret", DateTime.Now.AddHours(1)));
+            var client = CreateProtectedClient(handler);
+            client.StaffOverrideAccount = CreateStaffUser(" ");
+
+            await client.PatronSearchAsync("name=Smith");
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual("blank-password-token", client.Token?.AccessToken);
+            Assert.AreEqual(0, ProtectedTokenCacheCount());
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_ExpiredCachedToken_RemovesExpiredEntry()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var client = CreateProtectedClient(handler);
+            SetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, new ProtectedToken
+            {
+                AccessToken = "expired-token",
+                AccessSecret = "expired-secret",
+                ExpirationDate = DateTime.Now.AddMinutes(-1)
+            });
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.IsNull(client.Token);
+            Assert.AreEqual(0, ProtectedTokenCacheCount());
+        }
+
+        [TestMethod]
+        public void BuildProtectedTokenCacheKey_DoesNotExposeRawStaffPasswordOrAccessKey()
+        {
+            const string rawPassword = " correct-1 ";
+            const string rawAccessKey = " access-key-secret ";
+            var client = new PapiClient
+            {
+                Hostname = " https://example.test ",
+                AccessID = " access-id ",
+                AccessKey = rawAccessKey,
+                StaffOverrideAccount = CreateStaffUser(rawPassword)
+            };
+
+            var cacheKey = BuildCacheKey(client);
+
+            Assert.IsNotNull(cacheKey);
+            Assert.IsFalse(cacheKey!.Contains(rawPassword, StringComparison.Ordinal), "Cache key exposed the raw staff password.");
+            Assert.IsFalse(cacheKey.Contains(rawAccessKey, StringComparison.Ordinal), "Cache key exposed the raw access key.");
+            StringAssert.Contains(cacheKey, "https://example.test|access-id|domain|user|");
+        }
+
         [TestMethod]
         public async Task PatronSearchAsync_SameHostAndStaffWithDifferentAccessIds_AuthenticatesAndCachesSeparateTokens()
         {
@@ -523,13 +676,13 @@ namespace Clc.Polaris.Api.Tests
             };
         }
 
-        private static PolarisUser CreateStaffUser()
+        private static PolarisUser CreateStaffUser(string password = "password")
         {
             return new PolarisUser
             {
                 Domain = "domain",
                 Username = "user",
-                Password = "password"
+                Password = password
             };
         }
 
@@ -627,15 +780,38 @@ namespace Clc.Polaris.Api.Tests
 
         private static void SetCachedToken(string hostname, string accessId, PolarisUser? staffUser, ProtectedToken token)
         {
+            SetCachedToken(hostname, accessId, "access-key", staffUser, token);
+        }
+
+        private static void SetCachedToken(string hostname, string accessId, string accessKey, PolarisUser? staffUser, ProtectedToken token)
+        {
+            var cacheKey = BuildCacheKey(hostname, accessId, accessKey, staffUser);
+            if (cacheKey == null)
+            {
+                return;
+            }
+
             var cache = GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache");
-            cache?.TryAdd(BuildCacheKey(hostname, accessId, staffUser), token);
+            cache?.TryAdd(cacheKey, token);
         }
 
         private static bool TryGetCachedToken(string hostname, string accessId, PolarisUser? staffUser, out ProtectedToken? token)
         {
+            return TryGetCachedToken(hostname, accessId, "access-key", staffUser, out token);
+        }
+
+        private static bool TryGetCachedToken(string hostname, string accessId, string accessKey, PolarisUser? staffUser, out ProtectedToken? token)
+        {
             token = null;
+            var cacheKey = BuildCacheKey(hostname, accessId, accessKey, staffUser);
             var cache = GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache");
-            return staffUser != null && cache?.TryGetValue(BuildCacheKey(hostname, accessId, staffUser), out token) == true;
+            return cacheKey != null && cache?.TryGetValue(cacheKey, out token) == true;
+        }
+
+        private static int ProtectedTokenCacheCount()
+        {
+            var cache = GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache");
+            return cache?.Count ?? 0;
         }
 
         private static T? GetPrivateStaticProperty<T>(string propertyName) where T : class
@@ -644,10 +820,23 @@ namespace Clc.Polaris.Api.Tests
             return cacheProperty?.GetValue(null) as T;
         }
 
-        private static string BuildCacheKey(string hostname, string accessId, PolarisUser? staffUser)
+        private static string? BuildCacheKey(string hostname, string accessId, string accessKey, PolarisUser? staffUser)
         {
-            if (staffUser == null) { throw new ArgumentNullException(nameof(staffUser)); }
-            return $"{hostname.Trim()}|{accessId.Trim()}|{staffUser.Domain.Trim()}|{staffUser.Username.Trim()}";
+            var client = new PapiClient
+            {
+                Hostname = hostname,
+                AccessID = accessId,
+                AccessKey = accessKey,
+                StaffOverrideAccount = staffUser
+            };
+
+            return BuildCacheKey(client);
+        }
+
+        private static string? BuildCacheKey(PapiClient client)
+        {
+            var buildCacheKeyMethod = typeof(PapiClient).GetMethod("BuildProtectedTokenCacheKey", BindingFlags.NonPublic | BindingFlags.Instance);
+            return buildCacheKeyMethod?.Invoke(client, null) as string;
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent protected-token reuse across PapiClient instances when any auth-relevant credential differs, and disable static cache use when staff password or other required fields are missing. 
- Avoid embedding raw secrets in cache keys while ensuring credential changes (password or access key) invalidate cache reuse. 

### Description
- Require `AccessKey` and a non-empty `StaffOverrideAccount.Password` before `BuildProtectedTokenCacheKey` returns a cache key, returning `null` if any required field is blank. 
- Add `BuildProtectedTokenCredentialFingerprint` (private) which computes a deterministic SHA256 fingerprint over hostname, access id, access key, domain, username, and the staff password and append it to the cache key, without exposing raw password or access key. 
- Prevent cache use when the cache key is `null`; preserve existing public API surface and only add a private helper. 
- Evict expired entries in `TryLoadProtectedTokenFromCache` when encountered and keep copying cached `ProtectedToken` instances into `_token` (no shared references). 
- On failed/invalid staff authentication, remove the exact cache entry for that key and do not populate the cache with the invalid result. 
- Preserve `ProtectedTokenPreloadMode.Skip` behavior and other request signing semantics.
- Update test helpers to construct/inspect cache keys by invoking the production `BuildProtectedTokenCacheKey` logic so tests exercise fingerprint behavior.

### Testing
- Added unit tests in `src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs` that cover: blank staff password read/write avoidance, different staff passwords isolating cache entries, differing `AccessKey` isolating cache entries, expired cached-token eviction, and that the cache key does not contain raw secrets. 
- Ran unit tests: `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"` which passed (122 passed, 0 failed). 
- Built library: `dotnet build src/polaris-api-csharp/Clc.Polaris.Api.csproj` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a245b5d452c8323b58d7d6b535814ff)