### PR TITLE
Fail closed when protected token preload fails

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -339,18 +339,20 @@ namespace Clc.Polaris.Api
                 return false;
             }
 
-            if (ProtectedTokenCache.TryGetValue(cacheKey, out var cachedToken))
+            if (!ProtectedTokenCache.TryGetValue(cacheKey, out var cachedToken))
             {
-                if (!IsProtectedTokenMissingOrExpired(cachedToken))
-                {
-                    _token = new ProtectedToken(cachedToken);
-                    return true;
-                }
-
-                ProtectedTokenCache.TryRemove(cacheKey, out _);
+                return false;
             }
 
-            return false;
+            if (!IsProtectedTokenUsable(cachedToken))
+            {
+                ProtectedTokenCache.TryRemove(cacheKey, out _);
+                _token = null;
+                return false;
+            }
+
+            _token = new ProtectedToken(cachedToken);
+            return true;
         }
 
         private async Task<ProtectedTokenAcquisitionResult> AuthenticateAndLoadProtectedTokenAsync(string? cacheKey, CancellationToken cancellationToken)

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -136,21 +136,46 @@ namespace Clc.Polaris.Api
             Skip
         }
 
+        private enum ProtectedTokenAcquisitionStatus
+        {
+            ValidTokenAvailable,
+            NoTokenNeeded,
+            NoStaffCredentialsConfigured,
+            StaffAuthenticationFailed,
+            InvalidTokenReturned
+        }
+
+        private sealed class ProtectedTokenAcquisitionResult
+        {
+            public ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus status, ProtectedToken? token = null)
+            {
+                Status = status;
+                Token = token;
+            }
+
+            public ProtectedTokenAcquisitionStatus Status { get; }
+            public ProtectedToken? Token { get; }
+            public bool HasValidToken => Status == ProtectedTokenAcquisitionStatus.ValidTokenAvailable && IsProtectedTokenUsable(Token);
+        }
+
         private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default, ProtectedTokenPreloadMode tokenPreloadMode = ProtectedTokenPreloadMode.Auto)
         {
             var pathContainsProtectedTokenPlaceholder = RequestPathContainsProtectedTokenPlaceholder(request);
+            var requiresProtectedToken = RequiresProtectedToken(request, pathContainsProtectedTokenPlaceholder);
 
             if (tokenPreloadMode == ProtectedTokenPreloadMode.Skip && pathContainsProtectedTokenPlaceholder)
             {
                 throw new InvalidOperationException("ProtectedToken.Placeholder cannot be used when protected token preloading is skipped.");
             }
 
-            if (tokenPreloadMode == ProtectedTokenPreloadMode.Auto &&
-                (pathContainsProtectedTokenPlaceholder ||
-                 (request.AuthRequired &&
-                  ((request.IsPublicMethod && AllowStaffOverrideRequests && string.IsNullOrWhiteSpace(request.Password) && !request.BlockStaffOverride) || request.IsProtectedMethod))))
+            if (tokenPreloadMode == ProtectedTokenPreloadMode.Auto && requiresProtectedToken)
             {
-                await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
+                var tokenResult = await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!tokenResult.HasValidToken)
+                {
+                    ThrowProtectedTokenRequired(tokenResult.Status, pathContainsProtectedTokenPlaceholder);
+                }
             }
 
             if (pathContainsProtectedTokenPlaceholder)
@@ -159,6 +184,43 @@ namespace Clc.Polaris.Api
             }
 
             return await ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        private bool RequiresProtectedToken(PapiRestRequest request, bool pathContainsProtectedTokenPlaceholder)
+        {
+            if (pathContainsProtectedTokenPlaceholder)
+            {
+                return true;
+            }
+
+            if (request.IsProtectedMethod && string.IsNullOrWhiteSpace(request.Password))
+            {
+                return true;
+            }
+
+            return request.IsPublicMethod &&
+                request.AuthRequired &&
+                AllowStaffOverrideRequests &&
+                string.IsNullOrWhiteSpace(request.Password) &&
+                !request.BlockStaffOverride &&
+                StaffOverrideAccount != null;
+        }
+
+        private static void ThrowProtectedTokenRequired(ProtectedTokenAcquisitionStatus status, bool pathContainsProtectedTokenPlaceholder)
+        {
+            var reason = status switch
+            {
+                ProtectedTokenAcquisitionStatus.NoStaffCredentialsConfigured => "No staff override credentials are configured.",
+                ProtectedTokenAcquisitionStatus.StaffAuthenticationFailed => "Staff authentication did not succeed.",
+                ProtectedTokenAcquisitionStatus.InvalidTokenReturned => "Staff authentication did not return a usable protected access token.",
+                _ => "A usable protected access token is not available."
+            };
+
+            var placeholderReason = pathContainsProtectedTokenPlaceholder
+                ? " ProtectedToken.Placeholder cannot be replaced without a valid protected access token."
+                : string.Empty;
+
+            throw new InvalidOperationException($"A valid protected access token is required for this request. {reason}{placeholderReason}");
         }
 
         private static bool RequestPathContainsProtectedTokenPlaceholder(PapiRestRequest request)
@@ -178,18 +240,28 @@ namespace Clc.Polaris.Api
             request.Path = request.Path.Replace(ProtectedToken.Placeholder, accessToken, StringComparison.Ordinal);
         }
 
-        private async Task<ProtectedToken?> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
+        private async Task<ProtectedTokenAcquisitionResult> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
         {
             var token = Token;
-            if (StaffOverrideAccount == null || token != null)
+            if (IsProtectedTokenUsable(token))
             {
-                return token;
+                return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.ValidTokenAvailable, token);
+            }
+
+            if (token != null)
+            {
+                _token = null;
+            }
+
+            if (StaffOverrideAccount == null)
+            {
+                return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.NoStaffCredentialsConfigured);
             }
 
             var cacheKey = BuildProtectedTokenCacheKey();
             if (TryLoadProtectedTokenFromCache(cacheKey))
             {
-                return _token;
+                return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.ValidTokenAvailable, _token);
             }
 
             if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
@@ -202,9 +274,19 @@ namespace Clc.Polaris.Api
             try
             {
                 token = Token;
-                if (token != null || TryLoadProtectedTokenFromCache(cacheKey))
+                if (IsProtectedTokenUsable(token))
                 {
-                    return _token;
+                    return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.ValidTokenAvailable, token);
+                }
+
+                if (token != null)
+                {
+                    _token = null;
+                }
+
+                if (TryLoadProtectedTokenFromCache(cacheKey))
+                {
+                    return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.ValidTokenAvailable, _token);
                 }
 
                 return await AuthenticateAndLoadProtectedTokenAsync(cacheKey, cancellationToken).ConfigureAwait(false);
@@ -243,6 +325,13 @@ namespace Clc.Polaris.Api
             return token == null || !token.ExpirationDate.HasValue || token.ExpirationDate <= DateTime.Now;
         }
 
+        private static bool IsProtectedTokenUsable(ProtectedToken? token)
+        {
+            return !IsProtectedTokenMissingOrExpired(token) &&
+                !string.IsNullOrWhiteSpace(token?.AccessToken) &&
+                !string.IsNullOrWhiteSpace(token.AccessSecret);
+        }
+
         private bool TryLoadProtectedTokenFromCache(string? cacheKey)
         {
             if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
@@ -264,41 +353,47 @@ namespace Clc.Polaris.Api
             return false;
         }
 
-        private async Task<ProtectedToken?> AuthenticateAndLoadProtectedTokenAsync(string? cacheKey, CancellationToken cancellationToken)
+        private async Task<ProtectedTokenAcquisitionResult> AuthenticateAndLoadProtectedTokenAsync(string? cacheKey, CancellationToken cancellationToken)
         {
-            var currentToken = Token;
             var staffOverrideAccount = StaffOverrideAccount;
             if (staffOverrideAccount == null)
             {
-                return currentToken;
+                return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.NoStaffCredentialsConfigured);
             }
 
             var response = await AuthenticateStaffUserAsync(staffOverrideAccount, cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
             var responseData = response?.Data;
-            if (response?.Response == null ||
-                !response.Response.IsSuccessStatusCode ||
-                responseData == null ||
-                IsProtectedTokenMissingOrExpired(responseData) ||
-                string.IsNullOrWhiteSpace(responseData.AccessToken) ||
-                string.IsNullOrWhiteSpace(responseData.AccessSecret))
+            if (response?.Response == null || !response.Response.IsSuccessStatusCode)
             {
-                if (!string.IsNullOrWhiteSpace(cacheKey))
-                {
-                    ProtectedTokenCache.TryRemove(cacheKey, out _);
-                }
+                ClearFailedProtectedToken(cacheKey);
+                return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.StaffAuthenticationFailed);
+            }
 
-                _token = currentToken;
-                return _token;
+            if (!IsProtectedTokenUsable(responseData))
+            {
+                ClearFailedProtectedToken(cacheKey);
+                return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.InvalidTokenReturned);
             }
 
             _token = responseData;
 
             if (UseProtectedTokenCache && !string.IsNullOrWhiteSpace(cacheKey))
             {
-                ProtectedTokenCache[cacheKey] = new ProtectedToken(_token);
+                ProtectedTokenCache[cacheKey] = new ProtectedToken(responseData!);
             }
 
-            return _token;
+            return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.ValidTokenAvailable, _token);
+        }
+
+        private void ClearFailedProtectedToken(string? cacheKey)
+        {
+            if (!string.IsNullOrWhiteSpace(cacheKey))
+            {
+                ProtectedTokenCache.TryRemove(cacheKey, out _);
+            }
+
+            _token = null;
         }
 
         private string GetPAPIHash(string httpMethod, string date, string uri, string password)

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -446,10 +446,10 @@ namespace Clc.Polaris.Api.Tests
             var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
             var client = CreateProtectedClient(handler);
 
-            var response = await client.PatronAccountGetAsync("ABC123");
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
 
-            Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
@@ -460,10 +460,10 @@ namespace Clc.Polaris.Api.Tests
             var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, "{}");
             var client = CreateProtectedClient(handler);
 
-            var response = await client.PatronAccountGetAsync("ABC123");
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
 
-            Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
@@ -480,10 +480,10 @@ namespace Clc.Polaris.Api.Tests
                 ExpirationDate = DateTime.Now.AddHours(-1)
             };
 
-            var response = await client.PatronAccountGetAsync("ABC123");
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
 
-            Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
@@ -500,10 +500,10 @@ namespace Clc.Polaris.Api.Tests
                 ExpirationDate = DateTime.Now.AddHours(-1)
             };
 
-            var response = await client.PatronAccountGetAsync("ABC123");
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
 
-            Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
@@ -523,13 +523,158 @@ namespace Clc.Polaris.Api.Tests
                 ExpirationDate = DateTime.Now.AddHours(-1)
             };
 
-            var response = await client.PatronAccountGetAsync("ABC123");
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
 
-            Assert.IsNotNull(response);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_FailedStaffAuthentication_ThrowsBeforeFinalProtectedRequest()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var client = CreateProtectedClient(handler);
+
+            var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+
+            StringAssert.Contains(exception.Message, "Staff authentication did not succeed");
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_NullDataStaffAuthentication_ThrowsBeforeFinalProtectedRequest()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, "null");
+            var client = CreateProtectedClient(handler);
+
+            var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+
+            StringAssert.Contains(exception.Message, "did not return a usable protected access token");
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_BlankAccessTokenStaffAuthentication_ThrowsBeforeFinalProtectedRequest()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson(" ", "protected-secret", DateTime.Now.AddHours(1)));
+            var client = CreateProtectedClient(handler);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_BlankAccessSecretStaffAuthentication_ThrowsBeforeFinalProtectedRequest()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("protected-token", " ", DateTime.Now.AddHours(1)));
+            var client = CreateProtectedClient(handler);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_ExpiredTokenStaffAuthentication_ThrowsBeforeFinalProtectedRequest()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("protected-token", "protected-secret", DateTime.Now.AddMinutes(-1)));
+            var client = CreateProtectedClient(handler);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_ProtectedTokenPlaceholder_ThrowsBeforeFinalRequestWhenTokenAcquisitionFails()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.Unauthorized, "{\"PAPIErrorCode\":1}");
+            var client = CreateProtectedClient(handler);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.IsFalse(handler.RequestPaths.Any(path => path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal)));
+        }
+
+        [TestMethod]
+        public async Task PatronAccountGetAsync_PublicStaffOverride_FailedStaffAuthentication_ThrowsBeforeFinalRequest()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var client = CreateProtectedClient(handler);
+
+            var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
+
+            StringAssert.Contains(exception.Message, "Staff authentication did not succeed");
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
+        }
+
+        [TestMethod]
+        public async Task PatronAccountGetAsync_PublicRequestWithoutStaffOverrideAccount_ContinuesAsOrdinaryPublicRequest()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var client = CreateProtectedClient(handler);
+            client.StaffOverrideAccount = null;
+            client.AllowStaffOverrideRequests = true;
+
+            var response = await client.PatronAccountGetAsync("ABC123");
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(0, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            StringAssert.Contains(handler.RequestPaths.Single(), "/public/v1/1033/100/1/patron/ABC123/account/outstanding");
+        }
+
+        [TestMethod]
+        public async Task PatronAccountGetAsync_PublicRequestWithExplicitPassword_DoesNotRequireStaffOverrideToken()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var client = CreateProtectedClient(handler);
+
+            var response = await client.PatronAccountGetAsync("ABC123", password: "patron-password");
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual(0, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            StringAssert.Contains(handler.RequestPaths.Single(), "/public/v1/1033/100/1/patron/ABC123/account/outstanding");
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_CancellationDuringProtectedTokenAuthentication_PropagatesCancellation()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateProtectedClient(handler);
+            using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(10));
+
+            try
+            {
+                await client.PatronSearchAsync("name=Smith", cancellationToken: cancellationTokenSource.Token);
+                Assert.Fail("Expected cancellation to propagate.");
+            }
+            catch (OperationCanceledException)
+            {
+            }
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
+        }
+
 
         [TestMethod]
         public void PreformatRestRequest_ExpiredProtectedToken_DoesNotUseSecretForProtectedMethodSigning()

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -356,6 +356,53 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public async Task PatronSearchAsync_CachedTokenWithBlankAccessToken_IsRemovedAndNewTokenIsUsed()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("new-token", "new-secret", DateTime.Now.AddHours(1)));
+            var client = CreateProtectedClient(handler);
+            SetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, new ProtectedToken
+            {
+                AccessToken = " ",
+                AccessSecret = "cached-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            });
+
+            await client.PatronSearchAsync("name=Smith");
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual("new-token", client.Token?.AccessToken);
+            Assert.AreNotEqual(" ", client.Token?.AccessToken);
+            Assert.IsTrue(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out var cachedToken));
+            Assert.IsNotNull(cachedToken);
+            Assert.AreEqual("new-token", cachedToken.AccessToken);
+            Assert.AreEqual("new-secret", cachedToken.AccessSecret);
+            StringAssert.Contains(handler.RequestPaths.Last(), "/protected/v1/1033/100/1/new-token/search/patrons/Boolean");
+        }
+
+        [TestMethod]
+        public async Task PatronSearchAsync_CachedTokenWithBlankAccessSecret_IsRemovedAndNotUsedWhenAuthenticationFails()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var client = CreateProtectedClient(handler);
+            SetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, new ProtectedToken
+            {
+                AccessToken = "cached-token",
+                AccessSecret = " ",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            });
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
+            Assert.IsNull(client.Token);
+        }
+
+        [TestMethod]
         public void BuildProtectedTokenCacheKey_UsesCredentialFingerprintWithoutRawSecrets()
         {
             var client = CreateProtectedClient(new ProtectedTokenHttpMessageHandler());


### PR DESCRIPTION
### Motivation
- Ensure any request that truly requires a protected staff token does not continue to the final PAPI endpoint when token acquisition fails or returns an unusable token.
- Make required-token logic explicit (placeholder paths, protected methods with blank password, and configured public staff-override cases) and favor safe fail-closed behavior for the 4.0 breaking-change branch.

### Description
- Compute `requiresProtectedToken` up-front in `ExecutePapiAsync` and preserve the `ProtectedTokenPreloadMode.Skip` recursion guard; preload only when required and fail before `ExecuteAsync` when no valid token becomes available.
- Introduce `ProtectedTokenAcquisitionStatus` and `ProtectedTokenAcquisitionResult` to communicate acquisition outcomes (valid token, no staff credentials, auth failure, invalid token) back to callers.
- Refactor `EnsureProtectedTokenAsync` and `AuthenticateAndLoadProtectedTokenAsync` to return `ProtectedTokenAcquisitionResult`, treat unsuccessful HTTP responses, null Data, expired token, blank `AccessToken`/`AccessSecret` as failures, clear unusable token/cache state, and preserve cancellation propagation.
- Add `RequiresProtectedToken` helper implementing the detailed rules for placeholder, protected blank-password, and public-staff-override cases; keep public requests without a configured staff account or explicit password as ordinary public requests.
- Keep path placeholder replacement gated on a valid token and keep `PreformatRestRequest` signing logic unchanged because `ExecutePapiAsync` now prevents required-token failures from reaching signing.
- Minor helpers added: `IsProtectedTokenUsable` and `ClearFailedProtectedToken` to centralize validation and cache-clearing.
- Tests updated/added in `src/polaris-api-csharpTests` to assert fail-closed behavior for the listed failure modes and to verify public/no-staff/explicit-password paths remain unchanged.

### Testing
- Ran unit tests: `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"` and all non-integration tests passed (131 passed, 0 failed).
- Built library: `dotnet build src/polaris-api-csharp/Clc.Polaris.Api.csproj` succeeded with no errors.
- Updated/added unit tests cover the requested scenarios including failed HTTP auth, null Data, blank token/secret, expired token, placeholder requests failing before the final request, public staff-override failing closed when configured, continuation for public requests without a staff account, explicit-password bypass, recursive skip behavior for `AuthenticateStaffUserAsync`, and cancellation propagation during auth.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a245e56cfd88323a2e0aed3433228b6)