### PR TITLE
Update Polaris API integration test categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Protected-token-in-path endpoints use `ProtectedToken.Placeholder` internally. M
 
 ## Local tests
 
-Run non-integration tests from the repository root:
+Run non-live/unit tests from the repository root:
 
 ```bash
 dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"
@@ -71,25 +71,32 @@ dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "T
 
 Integration tests require a live Polaris dev environment plus local dev credentials and test data in `src/polaris-api-csharpTests/appsettings.Test.json`, so they are not run by default in CI. Keep this file local only: do not commit real secrets, and remember that `appsettings.Test.json` is ignored by git.
 
-The live-test tiers are:
+The live-test categories are:
 
-- `Integration`: basic read-only tests that require only the live Polaris dev environment and standard local dev settings.
-- `ProtectedIntegration`: protected read-only tests that require staff override credentials in `PapiSettings.PolarisOverrideAccount`.
-- `MutatingIntegration`: mutating/destructive tests that may create or modify data and should only run against disposable or nightly-refreshed Polaris dev environments. Mutating tests may leave artifacts behind.
+- `Integration`: any test that requires a live Polaris/API environment.
+- `ReadOnlyIntegration`: live test that only reads/returns data and does not mutate Polaris state.
+- `ProtectedIntegration`: live test that requires staff/protected credentials.
+- `MutatingIntegration`: live test that creates, updates, cancels, deletes, clears, pays, voids, moves, renews, submits, or otherwise changes Polaris state.
 
-Run basic read-only integration tests when you have local Polaris dev settings configured. This command excludes staff-required protected read-only tests and mutating tests:
-
-```bash
-dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Integration&TestCategory!=MutatingIntegration&TestCategory!=ProtectedIntegration"
-```
-
-Run protected read-only integration tests only when `PapiSettings.PolarisOverrideAccount` is configured with staff override credentials:
+Run read-only live tests that do not require staff credentials when you have local Polaris dev settings configured:
 
 ```bash
-dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ProtectedIntegration&TestCategory!=MutatingIntegration"
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ReadOnlyIntegration&TestCategory!=ProtectedIntegration"
 ```
 
-Run mutating/destructive integration tests only against a disposable Polaris dev environment that is refreshed nightly or otherwise safe to dirty:
+Run protected read-only live tests only when `PapiSettings.PolarisOverrideAccount` is configured with staff override credentials:
+
+```bash
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ReadOnlyIntegration&TestCategory=ProtectedIntegration"
+```
+
+Run all read-only live tests:
+
+```bash
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ReadOnlyIntegration"
+```
+
+Run mutating live tests only against a disposable Polaris dev environment that is refreshed nightly or otherwise safe to dirty:
 
 ```bash
 dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=MutatingIntegration"

--- a/src/polaris-api-csharpTests/Methods/PapiClientTestCategoryTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTestCategoryTests.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 
 namespace Clc.Polaris.Api.Tests
 {
@@ -7,60 +9,181 @@ namespace Clc.Polaris.Api.Tests
     [TestCategory("Unit")]
     public class PapiClientTestCategoryTests
     {
+        private const string IntegrationCategory = "Integration";
+        private const string ReadOnlyIntegrationCategory = "ReadOnlyIntegration";
         private const string ProtectedIntegrationCategory = "ProtectedIntegration";
         private const string MutatingIntegrationCategory = "MutatingIntegration";
 
-        [TestMethod]
-        public void KnownStaffRequiredReadOnlyTestsHaveProtectedIntegrationCategory()
+        private static readonly string[] ReadOnlyIntegrationTests =
         {
-            var protectedIntegrationTests = new[]
-            {
-                nameof(PapiClientTests.AuthenticateStaffUserTest),
-                nameof(PapiClientTests.HoldRequestGetListTest),
-                nameof(PapiClientTests.Patron_GetBarcodeFromIdTest),
-                nameof(PapiClientTests.PatronRenewBlocksGetTest),
-                nameof(PapiClientTests.PatronSearchTest),
-                nameof(PapiClientTests.RecordSetRecordsGetTest),
-                nameof(PapiClientTests.SA_GetValueByOrgTest),
-                nameof(PapiClientTests.Synch_BibsByIdGetTest),
-            };
+            nameof(PapiClientTests.ApiKeyValidateTest),
+            nameof(PapiClientTests.ApiVersionGetTest),
+            nameof(PapiClientTests.BibGetTest),
+            nameof(PapiClientTests.BibGetTest_PassBranchId),
+            nameof(PapiClientTests.BibSearchTest),
+            nameof(PapiClientTests.CollectionsGetTest),
+            nameof(PapiClientTests.DatesClosedGetTest),
+            nameof(PapiClientTests.HoldingsGetTest),
+            nameof(PapiClientTests.ItemStatusesGetAsyncTest),
+            nameof(PapiClientTests.LimitFiltersGetTest),
+            nameof(PapiClientTests.MARCTypeOfMaterialsGetAsyncTest),
+            nameof(PapiClientTests.OrganizationsGetTest),
+            nameof(PapiClientTests.PatronAccountGetTest),
+            nameof(PapiClientTests.PatronBasicDataGetTest),
+            nameof(PapiClientTests.PatronCirculateBlocksGetTest),
+            nameof(PapiClientTests.PatronCodesGetTest),
+            nameof(PapiClientTests.PatronHoldRequestsGetTest),
+            nameof(PapiClientTests.PatronILLRequestsGetTest),
+            nameof(PapiClientTests.PatronItemsOutGetTest),
+            nameof(PapiClientTests.PatronMessagesGetTest),
+            nameof(PapiClientTests.PatronPreferencesGetTest),
+            nameof(PapiClientTests.PatronReadingHistoryGetTest),
+            nameof(PapiClientTests.PatronSavedSearchesGetTest),
+            nameof(PapiClientTests.PatronTitleListGetTitlesTest),
+            nameof(PapiClientTests.PatronValidateTest),
+            nameof(PapiClientTests.PickupBranchesGetTest),
+            nameof(PapiClientTests.ShelfLocationsGetTest),
+            nameof(PapiClientTests.AuthenticateStaffUserTest),
+            nameof(PapiClientTests.HoldRequestGetListTest),
+            nameof(PapiClientTests.Patron_GetBarcodeFromIdTest),
+            nameof(PapiClientTests.PatronRenewBlocksGetTest),
+            nameof(PapiClientTests.PatronSearchTest),
+            nameof(PapiClientTests.RecordSetRecordsGetTest),
+            nameof(PapiClientTests.SA_GetValueByOrgTest),
+            nameof(PapiClientTests.Synch_BibsByIdGetTest),
+        };
 
-            AssertMethodsHaveCategory(protectedIntegrationTests, ProtectedIntegrationCategory);
+        private static readonly string[] ProtectedReadOnlyIntegrationTests =
+        {
+            nameof(PapiClientTests.AuthenticateStaffUserTest),
+            nameof(PapiClientTests.HoldRequestGetListTest),
+            nameof(PapiClientTests.Patron_GetBarcodeFromIdTest),
+            nameof(PapiClientTests.PatronRenewBlocksGetTest),
+            nameof(PapiClientTests.PatronSearchTest),
+            nameof(PapiClientTests.RecordSetRecordsGetTest),
+            nameof(PapiClientTests.SA_GetValueByOrgTest),
+            nameof(PapiClientTests.Synch_BibsByIdGetTest),
+        };
+
+        private static readonly string[] MutatingIntegrationTests =
+        {
+            nameof(PapiClientTests.CreatePatronBlocksTest_FreeTextBlock),
+            nameof(PapiClientTests.CreatePatronBlocksTest_SystemBlock),
+            nameof(PapiClientTests.CreatePatronBlocksTest_LibraryAssignedBlock),
+            nameof(PapiClientTests.HoldRequestCancelTest),
+            nameof(PapiClientTests.HoldRequestCreateTest),
+            nameof(PapiClientTests.HoldRequestCreateTest2),
+            nameof(PapiClientTests.HoldRequestReactivateTest),
+            nameof(PapiClientTests.HoldRequestReplyTest),
+            nameof(PapiClientTests.HoldRequestSuspendTest),
+            nameof(PapiClientTests.ItemRenewTest),
+            nameof(PapiClientTests.NotificationUpdateTest),
+            nameof(PapiClientTests.PatronAccountCreateCreditTest),
+            nameof(PapiClientTests.TestTitleListCreate_Get_Delete),
+            nameof(PapiClientTests.PatronAccountDepositCreditTest),
+            nameof(PapiClientTests.PatronAccountPayTest),
+            nameof(PapiClientTests.PatronAccountPayAllTest),
+            nameof(PapiClientTests.PatronAccountRefundCreditTest),
+            nameof(PapiClientTests.PatronAccountVoidTest),
+            nameof(PapiClientTests.PatronMessageDeleteTest),
+            nameof(PapiClientTests.PatronMessageUpdateStatusTest),
+            nameof(PapiClientTests.PatronReadingHistoryClearTest),
+            nameof(PapiClientTests.PatronTitleListAddTitleTest),
+            nameof(PapiClientTests.PatronTitleListCopyAllTitlesTest),
+            nameof(PapiClientTests.PatronTitleListCopyTitleTest),
+            nameof(PapiClientTests.PatronTitleListDeleteAllTitlesTest),
+            nameof(PapiClientTests.PatronTitleListDeleteTitleTest),
+            nameof(PapiClientTests.PatronTitleListMoveTitleTest),
+            nameof(PapiClientTests.PatronUpdateTest),
+            nameof(PapiClientTests.PatronUpdateUserNameTest),
+            nameof(PapiClientTests.RecordSetContentAddTest),
+            nameof(PapiClientTests.RecordSetContentAddTest_List),
+            nameof(PapiClientTests.RecordSetContentRemoveTest),
+            nameof(PapiClientTests.RecordSetContentRemoveTest_List),
+        };
+
+        [TestMethod]
+        public void SpecializedIntegrationCategoriesAlwaysIncludeIntegrationCategory()
+        {
+            var missingIntegrationCategory = GetPapiClientTestMethods()
+                .Where(method => MethodHasAnyCategory(method, ReadOnlyIntegrationCategory, ProtectedIntegrationCategory, MutatingIntegrationCategory))
+                .Where(method => !MethodOrClassHasCategory(method, IntegrationCategory))
+                .Select(method => method.Name)
+                .ToArray();
+
+            Assert.IsFalse(
+                missingIntegrationCategory.Any(),
+                $"Expected methods with specialized integration categories to also have TestCategory(\"{IntegrationCategory}\") at method level or class level: {string.Join(", ", missingIntegrationCategory)}");
         }
 
         [TestMethod]
-        public void KnownMutatingTestsHaveMutatingIntegrationCategory()
+        public void ReadOnlyAndMutatingIntegrationCategoriesAreMutuallyExclusive()
         {
-            var mutatingIntegrationTests = new[]
-            {
-                nameof(PapiClientTests.CreatePatronBlocksTest_FreeTextBlock),
-                nameof(PapiClientTests.CreatePatronBlocksTest_SystemBlock),
-                nameof(PapiClientTests.CreatePatronBlocksTest_LibraryAssignedBlock),
-                nameof(PapiClientTests.NotificationUpdateTest),
-                nameof(PapiClientTests.PatronAccountCreateCreditTest),
-                nameof(PapiClientTests.TestTitleListCreate_Get_Delete),
-                nameof(PapiClientTests.PatronAccountDepositCreditTest),
-                nameof(PapiClientTests.PatronAccountPayTest),
-                nameof(PapiClientTests.PatronAccountPayAllTest),
-                nameof(PapiClientTests.PatronAccountRefundCreditTest),
-                nameof(PapiClientTests.PatronAccountVoidTest),
-                nameof(PapiClientTests.PatronMessageDeleteTest),
-                nameof(PapiClientTests.PatronMessageUpdateStatusTest),
-                nameof(PapiClientTests.PatronReadingHistoryClearTest),
-                nameof(PapiClientTests.PatronTitleListAddTitleTest),
-                nameof(PapiClientTests.PatronTitleListCopyAllTitlesTest),
-                nameof(PapiClientTests.PatronTitleListCopyTitleTest),
-                nameof(PapiClientTests.PatronTitleListDeleteAllTitlesTest),
-                nameof(PapiClientTests.PatronTitleListDeleteTitleTest),
-                nameof(PapiClientTests.PatronTitleListMoveTitleTest),
-                nameof(PapiClientTests.PatronUpdateTest),
-                nameof(PapiClientTests.RecordSetContentAddTest),
-                nameof(PapiClientTests.RecordSetContentAddTest_List),
-                nameof(PapiClientTests.RecordSetContentRemoveTest),
-                nameof(PapiClientTests.RecordSetContentRemoveTest_List),
-            };
+            var conflictingMethods = GetPapiClientTestMethods()
+                .Where(method => MethodHasCategory(method, ReadOnlyIntegrationCategory) && MethodHasCategory(method, MutatingIntegrationCategory))
+                .Select(method => method.Name)
+                .ToArray();
 
-            AssertMethodsHaveCategory(mutatingIntegrationTests, MutatingIntegrationCategory);
+            Assert.IsFalse(
+                conflictingMethods.Any(),
+                $"Expected no methods to have both TestCategory(\"{ReadOnlyIntegrationCategory}\") and TestCategory(\"{MutatingIntegrationCategory}\"): {string.Join(", ", conflictingMethods)}");
+        }
+
+        [TestMethod]
+        public void MutatingIntegrationTestsAreNotParallelized()
+        {
+            var documentedExceptions = Array.Empty<string>();
+            var missingDoNotParallelize = GetPapiClientTestMethods()
+                .Where(method => MethodHasCategory(method, MutatingIntegrationCategory))
+                .Where(method => !documentedExceptions.Contains(method.Name))
+                .Where(method => !method.GetCustomAttributes<DoNotParallelizeAttribute>(inherit: false).Any())
+                .Select(method => method.Name)
+                .ToArray();
+
+            Assert.IsFalse(
+                missingDoNotParallelize.Any(),
+                $"Expected MutatingIntegration methods to have [DoNotParallelize] unless documented in {nameof(documentedExceptions)}: {string.Join(", ", missingDoNotParallelize)}");
+        }
+
+        [TestMethod]
+        public void StaffOverrideRequiredTestsHaveProtectedIntegrationCategory()
+        {
+            var staffRequiredMethods = GetPapiClientTestsSourceMethods()
+                .Where(method => method.Value.Contains("IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings)", StringComparison.Ordinal))
+                .Select(method => method.Key)
+                .ToArray();
+
+            AssertMethodsHaveCategory(staffRequiredMethods, ProtectedIntegrationCategory);
+        }
+
+        [TestMethod]
+        public void KnownReadOnlyIntegrationTestsHaveReadOnlyIntegrationCategory()
+        {
+            AssertMethodsHaveCategory(ReadOnlyIntegrationTests, ReadOnlyIntegrationCategory);
+        }
+
+        [TestMethod]
+        public void KnownProtectedReadOnlyIntegrationTestsHaveProtectedIntegrationCategory()
+        {
+            AssertMethodsHaveCategory(ProtectedReadOnlyIntegrationTests, ProtectedIntegrationCategory);
+        }
+
+        [TestMethod]
+        public void KnownMutatingIntegrationTestsHaveMutatingIntegrationCategory()
+        {
+            AssertMethodsHaveCategory(MutatingIntegrationTests, MutatingIntegrationCategory);
+        }
+
+        [TestMethod]
+        public void KnownMutatingIntegrationTestsDoNotHaveReadOnlyIntegrationCategory()
+        {
+            var mutatingTestsWithReadOnlyCategory = MutatingIntegrationTests
+                .Where(methodName => MethodHasCategory(methodName, ReadOnlyIntegrationCategory))
+                .ToArray();
+
+            Assert.IsFalse(
+                mutatingTestsWithReadOnlyCategory.Any(),
+                $"Expected known mutating integration tests not to have TestCategory(\"{ReadOnlyIntegrationCategory}\"): {string.Join(", ", mutatingTestsWithReadOnlyCategory)}");
         }
 
         private static void AssertMethodsHaveCategory(IEnumerable<string> methodNames, string expectedCategory)
@@ -74,16 +197,88 @@ namespace Clc.Polaris.Api.Tests
                 $"Expected these {nameof(PapiClientTests)} methods to be marked with TestCategory(\"{expectedCategory}\"): {string.Join(", ", missingCategory)}");
         }
 
+        private static IEnumerable<MethodInfo> GetPapiClientTestMethods()
+        {
+            return typeof(PapiClientTests)
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                .Where(method => method.GetCustomAttributes<TestMethodAttribute>(inherit: false).Any());
+        }
+
+        private static bool MethodOrClassHasCategory(MethodInfo method, string expectedCategory)
+        {
+            return MethodHasCategory(method, expectedCategory)
+                || typeof(PapiClientTests)
+                    .GetCustomAttributes<TestCategoryAttribute>(inherit: false)
+                    .SelectMany(attribute => attribute.TestCategories)
+                    .Contains(expectedCategory);
+        }
+
+        private static bool MethodHasAnyCategory(MethodInfo method, params string[] expectedCategories)
+        {
+            var methodCategories = GetMethodCategories(method);
+            return expectedCategories.Any(methodCategories.Contains);
+        }
+
         private static bool MethodHasCategory(string methodName, string expectedCategory)
         {
             var method = typeof(PapiClientTests).GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public);
 
             Assert.IsNotNull(method, $"Expected to find public test method {nameof(PapiClientTests)}.{methodName}.");
 
+            return MethodHasCategory(method, expectedCategory);
+        }
+
+        private static bool MethodHasCategory(MethodInfo method, string expectedCategory)
+        {
+            return GetMethodCategories(method).Contains(expectedCategory);
+        }
+
+        private static string[] GetMethodCategories(MethodInfo method)
+        {
             return method
                 .GetCustomAttributes<TestCategoryAttribute>(inherit: false)
                 .SelectMany(attribute => attribute.TestCategories)
-                .Contains(expectedCategory);
+                .ToArray();
+        }
+
+        private static Dictionary<string, string> GetPapiClientTestsSourceMethods([CallerFilePath] string categoryTestSourcePath = "")
+        {
+            var testSourcePath = Path.Combine(Path.GetDirectoryName(categoryTestSourcePath)!, "PapiClientTests.cs");
+            var testSource = File.ReadAllText(testSourcePath);
+            var sourceMethods = new Dictionary<string, string>();
+            var matches = Regex.Matches(testSource, @"public\s+(?:async\s+)?(?:Task|void)\s+(?<name>\w+)\s*\([^)]*\)\s*\{");
+
+            foreach (Match match in matches)
+            {
+                var bodyStart = match.Index;
+                var bodyEnd = FindMatchingCloseBrace(testSource, testSource.IndexOf('{', match.Index));
+                sourceMethods[match.Groups["name"].Value] = testSource[bodyStart..(bodyEnd + 1)];
+            }
+
+            return sourceMethods;
+        }
+
+        private static int FindMatchingCloseBrace(string source, int openBraceIndex)
+        {
+            var depth = 0;
+            for (var index = openBraceIndex; index < source.Length; index++)
+            {
+                if (source[index] == '{')
+                {
+                    depth++;
+                }
+                else if (source[index] == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return index;
+                    }
+                }
+            }
+
+            Assert.Fail($"Could not find matching close brace in {nameof(PapiClientTests)} source.");
+            return -1;
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
@@ -100,6 +100,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task ApiKeyValidateTest()
         {
             var response = await papi.ApiKeyValidateAsync();
@@ -107,6 +109,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task ApiVersionGetTest()
         {
             var response = await papi.ApiVersionGetAsync();
@@ -115,6 +119,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task AuthenticateStaffUserTest()
         {
@@ -128,6 +134,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task BibGetTest()
         {
             var response = await papi.BibGetAsync(478907);
@@ -138,6 +146,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task BibGetTest_PassBranchId()
         {
             var response = await papi.BibGetAsync(bibId, 7);
@@ -147,6 +157,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task BibSearchTest()
         {
             var response = await papi.BibSearchAsync(new BibSearchOptions { Term = "dogs", PageSize = 10 });
@@ -156,6 +168,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task CollectionsGetTest()
         {
             var response = await papi.CollectionsGetAsync();
@@ -165,6 +179,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task CreatePatronBlocksTest_FreeTextBlock()
@@ -177,6 +193,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task CreatePatronBlocksTest_SystemBlock()
@@ -188,6 +206,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task CreatePatronBlocksTest_LibraryAssignedBlock()
@@ -199,6 +219,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task DatesClosedGetTest()
         {
             var response = await papi.DatesClosedGetAsync(7);
@@ -212,6 +234,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task HoldingsGetTest()
         {
             var response = await papi.HoldingsGetAsync(bibId);
@@ -219,6 +243,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task HoldRequestCancelTest()
         {
             var response = await papi.HoldRequestCancelAsync(Settings.PatronBarcode, 1234, Settings.PatronPin);
@@ -226,6 +253,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task HoldRequestCreateTest()
         {
             var response = await papi.HoldRequestCreateAsync(new HoldRequestCreateParams(Settings.PatronId, 1234, 7, 7));
@@ -233,6 +263,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task HoldRequestCreateTest2()
         {
             var response = await ((PapiClient)papi).HoldRequestCreateAsync(Settings.PatronId, 1234, 7);
@@ -240,6 +273,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task HoldRequestGetListTest()
         {
@@ -250,6 +285,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task HoldRequestReactivateTest()
         {
             var response = await papi.HoldRequestReactivateAsync(Settings.PatronBarcode, Settings.PatronPin, 1234, DateTime.Now);
@@ -257,6 +295,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task HoldRequestReplyTest()
         {
             var hold = new HoldRequestCreateResult { RequestGuid = new Guid() };
@@ -265,6 +306,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task HoldRequestSuspendTest()
         {
             var response = await papi.HoldRequestSuspendAsync(Settings.PatronBarcode, 1234, DateTime.Now, Settings.PatronPin);
@@ -272,6 +316,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task ItemRenewTest()
         {
             var response = await papi.ItemRenewAsync(Settings.PatronBarcode, 1234, Settings.PatronPin);
@@ -279,6 +326,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task ItemStatusesGetAsyncTest()
         {
             var response = await papi.ItemStatusesGetAsync(7);
@@ -293,6 +342,8 @@ namespace Clc.Polaris.Api.Tests
         //}
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task LimitFiltersGetTest()
         {
             var response = (await papi.LimitFiltersGetAsync()).Data;
@@ -300,6 +351,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task MARCTypeOfMaterialsGetAsyncTest()
         {
             var response = (await papi.MARCTypeOfMaterialsGetAsync()).Data;
@@ -307,6 +360,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task NotificationUpdateTest()
@@ -318,6 +373,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task OrganizationsGetTest()
         {
             var response = await papi.OrganizationsGetAsync();
@@ -325,6 +382,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task Patron_GetBarcodeFromIdTest()
         {
@@ -335,6 +394,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronAccountCreateCreditTest()
@@ -346,6 +407,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task TestTitleListCreate_Get_Delete()
@@ -365,6 +427,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronAccountDepositCreditTest()
@@ -376,6 +440,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronAccountGetTest()
         {
             var response = await papi.PatronAccountGetAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -384,6 +450,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronAccountPayTest()
@@ -395,6 +463,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronAccountPayAllTest()
@@ -406,6 +476,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronAccountRefundCreditTest()
@@ -417,6 +489,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronAccountVoidTest()
@@ -428,6 +502,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronBasicDataGetTest()
         {
             var response = await papi.PatronBasicDataGetAsync(Settings.PatronBarcode, Settings.PatronPin, true);
@@ -437,6 +513,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronCirculateBlocksGetTest()
         {
             var response = await papi.PatronCirculateBlocksGetAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -444,6 +522,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronCodesGetTest()
         {
             var response = await papi.PatronCodesGetAsync();
@@ -452,6 +532,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronHoldRequestsGetTest()
         {
             var response = await papi.PatronHoldRequestsGetAsync(Settings.PatronBarcode, PatronHoldStatus.all, Settings.PatronPin);
@@ -460,6 +542,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronILLRequestsGetTest()
         {
             var response = await papi.PatronILLRequestsGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
@@ -468,6 +552,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronItemsOutGetTest()
         {
             var response = await papi.PatronItemsOutGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
@@ -476,6 +562,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronMessageDeleteTest()
@@ -485,6 +572,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronMessagesGetTest()
         {
             var response = await papi.PatronMessagesGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
@@ -492,6 +581,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronMessageUpdateStatusTest()
@@ -501,6 +591,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronPreferencesGetTest()
         {
             var response = await papi.PatronPreferencesGetAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -508,6 +600,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronReadingHistoryClearTest()
@@ -517,6 +610,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronReadingHistoryGetTest()
         {
             var response = await papi.PatronReadingHistoryGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
@@ -531,6 +626,8 @@ namespace Clc.Polaris.Api.Tests
         //}
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task PatronRenewBlocksGetTest()
         {
@@ -541,6 +638,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronSavedSearchesGetTest()
         {
             var response = await papi.PatronSavedSearchesGetAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -548,6 +647,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task PatronSearchTest()
         {
@@ -558,6 +659,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronTitleListAddTitleTest()
@@ -567,6 +669,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronTitleListCopyAllTitlesTest()
@@ -576,6 +679,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronTitleListCopyTitleTest()
@@ -585,6 +689,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronTitleListDeleteAllTitlesTest()
@@ -594,6 +699,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronTitleListDeleteTitleTest()
@@ -603,6 +709,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronTitleListGetTitlesTest()
         {
             var response = await papi.PatronTitleListGetTitlesAsync(Settings.PatronBarcode, 1234, password: Settings.PatronPin);
@@ -610,6 +718,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronTitleListMoveTitleTest()
@@ -619,6 +728,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronUpdateTest()
@@ -628,6 +738,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task PatronUpdateUserNameTest()
         {
             var response = await papi.PatronUpdateUserNameAsync(Settings.PatronBarcode + "1234", Settings.PatronPin, Settings.PatronPin);
@@ -635,6 +748,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronValidateTest()
         {
             var response = await papi.PatronValidateAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -642,6 +757,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PickupBranchesGetTest()
         {
             var response = await papi.PickupBranchesGetAsync();
@@ -649,6 +766,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task RecordSetContentAddTest()
@@ -660,6 +779,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task RecordSetContentAddTest_List()
@@ -671,6 +792,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task RecordSetContentRemoveTest()
@@ -682,6 +805,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task RecordSetContentRemoveTest_List()
@@ -693,6 +818,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task RecordSetRecordsGetTest()
         {
@@ -710,6 +837,8 @@ namespace Clc.Polaris.Api.Tests
         //}
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task SA_GetValueByOrgTest()
         {
@@ -720,6 +849,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task ShelfLocationsGetTest()
         {
             var response = await papi.ShelfLocationsGetAsync(7);
@@ -727,6 +858,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task Synch_BibsByIdGetTest()
         {


### PR DESCRIPTION
### Motivation
- Ensure integration tests are correctly classified per the Polaris API Reference and new category rules so filters can run only safe/read-only tests or mutating tests as intended.
- Add automated validation so specialized categories (`ReadOnlyIntegration`, `ProtectedIntegration`, `MutatingIntegration`) always include `Integration` and maintain mutual-exclusion and `DoNotParallelize` rules.

### Description
- Annotated many methods in `src/polaris-api-csharpTests/Methods/PapiClientTests.cs` with method-level `[TestCategory("Integration")]` and added `[TestCategory("ReadOnlyIntegration")|"ProtectedIntegration"|"MutatingIntegration"]` and `[DoNotParallelize]` as appropriate for each test per the requested lists.
- Rewrote/expanded `src/polaris-api-csharpTests/Methods/PapiClientTestCategoryTests.cs` to include explicit read-only/protected/mutating test name lists and reflection/source-based assertions that verify: specialized categories include `Integration`, `ReadOnlyIntegration` and `MutatingIntegration` are exclusive, mutating tests have `[DoNotParallelize]`, and staff-required tests have `ProtectedIntegration`.
- Updated `README.md` test instructions to define the four categories and provided updated `dotnet test` filter examples for non-live, read-only, protected read-only, all read-only, and mutating tests.

### Testing
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"` and the suite passed (144 passed, 0 failed, 0 skipped). 
- Fixed formatting issues and ran `dotnet format` against the test project files after adjusting the command to target the csproj; the project-formatting step completed as part of the change workflow (initial global `dotnet format` without a workspace failed as expected). 
- Ran `git diff --check` with no issues and committed the changes; live `ReadOnlyIntegration` tests were not executed because `src/polaris-api-csharpTests/appsettings.Test.json` (local integration credentials) is missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a24c27857c0832395f03b4e14fcdb46)