### PR TITLE
Update integration test categories and add validation for PAPI client tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,22 +71,29 @@ dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "T
 
 Integration tests require a live Polaris dev environment plus local dev credentials and test data in `src/polaris-api-csharpTests/appsettings.Test.json`, so they are not run by default in CI. Keep this file local only: do not commit real secrets, and remember that `appsettings.Test.json` is ignored by git.
 
-The live-test tiers are:
+The live-test categories are:
 
-- `Integration`: basic read-only tests that require only the live Polaris dev environment and standard local dev settings.
-- `ProtectedIntegration`: protected read-only tests that require staff override credentials in `PapiSettings.PolarisOverrideAccount`.
-- `MutatingIntegration`: mutating/destructive tests that may create or modify data and should only run against disposable or nightly-refreshed Polaris dev environments. Mutating tests may leave artifacts behind.
+- `Integration`: any test that requires a live Polaris/API environment.
+- `ReadOnlyIntegration`: live test that only reads/returns data and does not mutate Polaris state.
+- `ProtectedIntegration`: live test that requires staff/protected credentials.
+- `MutatingIntegration`: live test that creates, updates, cancels, deletes, clears, pays, voids, moves, renews, submits, or otherwise changes Polaris state.
 
-Run basic read-only integration tests when you have local Polaris dev settings configured. This command excludes staff-required protected read-only tests and mutating tests:
+Run read-only integration tests that do not require staff credentials when you have local Polaris dev settings configured:
 
 ```bash
-dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Integration&TestCategory!=MutatingIntegration&TestCategory!=ProtectedIntegration"
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ReadOnlyIntegration&TestCategory!=ProtectedIntegration"
 ```
 
 Run protected read-only integration tests only when `PapiSettings.PolarisOverrideAccount` is configured with staff override credentials:
 
 ```bash
-dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ProtectedIntegration&TestCategory!=MutatingIntegration"
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ReadOnlyIntegration&TestCategory=ProtectedIntegration"
+```
+
+Run all read-only integration tests when both standard and staff/protected local credentials are available:
+
+```bash
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ReadOnlyIntegration"
 ```
 
 Run mutating/destructive integration tests only against a disposable Polaris dev environment that is refreshed nightly or otherwise safe to dirty:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Protected-token-in-path endpoints use `ProtectedToken.Placeholder` internally. M
 
 ## Local tests
 
-Run non-integration tests from the repository root:
+Run non-live/unit tests from the repository root:
 
 ```bash
 dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"

--- a/src/polaris-api-csharpTests/Methods/PapiClientTestCategoryTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTestCategoryTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
 namespace Clc.Polaris.Api.Tests
@@ -102,6 +103,27 @@ namespace Clc.Polaris.Api.Tests
         };
 
         [TestMethod]
+        public void AllPapiClientIntegrationTestsAreClassifiedOrDocumentedExceptions()
+        {
+            var documentedExceptions = new[]
+            {
+                nameof(PapiClientTests.HeadingsSearchTest),
+            };
+
+            var unclassified = GetPapiClientTestMethods()
+                .Where(method => !documentedExceptions.Contains(method.Name))
+                .Where(method => MethodOrClassHasCategory(method, IntegrationCategory))
+                .Where(method => !MethodHasCategory(method, ReadOnlyIntegrationCategory))
+                .Where(method => !MethodHasCategory(method, MutatingIntegrationCategory))
+                .Select(method => method.Name)
+                .ToArray();
+
+            Assert.IsFalse(
+                unclassified.Any(),
+                $@"Expected all PapiClient integration tests to be marked with TestCategory(""{ReadOnlyIntegrationCategory}""), TestCategory(""{MutatingIntegrationCategory}""), or documented in {nameof(documentedExceptions)}: {string.Join(", ", unclassified)}");
+        }
+
+        [TestMethod]
         public void SpecializedIntegrationCategoriesRequireIntegrationCategory()
         {
             var missingIntegration = GetPapiClientTestMethods()
@@ -149,8 +171,8 @@ namespace Clc.Polaris.Api.Tests
         public void StaffOverrideIntegrationTestsHaveProtectedIntegrationCategory()
         {
             var methodsRequiringStaffOverride = PapiClientTestSourceMethods()
-                .Where(method => method.Body.Contains("IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings)"))
-                .Select(method => method.Name)
+                .Where(method => method.Value.Contains("IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings)"))
+                .Select(method => method.Key)
                 .ToArray();
 
             AssertMethodsHaveCategory(methodsRequiringStaffOverride, ProtectedIntegrationCategory);
@@ -230,22 +252,26 @@ namespace Clc.Polaris.Api.Tests
                     .Contains(expectedCategory);
         }
 
-        private static IEnumerable<(string Name, string Body)> PapiClientTestSourceMethods()
+        private static Dictionary<string, string> PapiClientTestSourceMethods([CallerFilePath] string categoryTestSourcePath = "")
         {
-            var source = File.ReadAllText(FindPapiClientTestsSourcePath());
+            var testSourcePath = Path.Combine(Path.GetDirectoryName(categoryTestSourcePath)!, "PapiClientTests.cs");
+            var source = File.ReadAllText(testSourcePath);
+            var sourceMethods = new Dictionary<string, string>();
             var methodMatches = Regex.Matches(
                 source,
-                @"public\s+async\s+Task\s+(?<name>\w+)\s*\(",
+                @"public\s+(?:async\s+)?(?:Task|void)\s+(?<name>\w+)\s*\([^)]*\)\s*\{",
                 RegexOptions.CultureInvariant);
 
             foreach (Match methodMatch in methodMatches)
             {
-                var openingBraceIndex = source.IndexOf('{', methodMatch.Index + methodMatch.Length);
+                var openingBraceIndex = source.IndexOf('{', methodMatch.Index + methodMatch.Length - 1);
                 Assert.AreNotEqual(-1, openingBraceIndex, $"Expected to find opening brace for {methodMatch.Groups["name"].Value}.");
 
                 var closingBraceIndex = FindClosingBrace(source, openingBraceIndex);
-                yield return (methodMatch.Groups["name"].Value, source.Substring(openingBraceIndex, closingBraceIndex - openingBraceIndex + 1));
+                sourceMethods[methodMatch.Groups["name"].Value] = source[methodMatch.Index..(closingBraceIndex + 1)];
             }
+
+            return sourceMethods;
         }
 
         private static int FindClosingBrace(string source, int openingBraceIndex)
@@ -273,29 +299,5 @@ namespace Clc.Polaris.Api.Tests
             return -1;
         }
 
-        private static string FindPapiClientTestsSourcePath()
-        {
-            var directory = new DirectoryInfo(AppContext.BaseDirectory);
-
-            while (directory != null)
-            {
-                var candidate = Path.Combine(directory.FullName, "Methods", "PapiClientTests.cs");
-                if (File.Exists(candidate))
-                {
-                    return candidate;
-                }
-
-                candidate = Path.Combine(directory.FullName, "src", "polaris-api-csharpTests", "Methods", "PapiClientTests.cs");
-                if (File.Exists(candidate))
-                {
-                    return candidate;
-                }
-
-                directory = directory.Parent;
-            }
-
-            Assert.Fail("Expected to find Methods/PapiClientTests.cs while walking up from the test output directory.");
-            return string.Empty;
-        }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PapiClientTestCategoryTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTestCategoryTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace Clc.Polaris.Api.Tests
 {
@@ -7,60 +8,189 @@ namespace Clc.Polaris.Api.Tests
     [TestCategory("Unit")]
     public class PapiClientTestCategoryTests
     {
+        private const string IntegrationCategory = "Integration";
+        private const string ReadOnlyIntegrationCategory = "ReadOnlyIntegration";
         private const string ProtectedIntegrationCategory = "ProtectedIntegration";
         private const string MutatingIntegrationCategory = "MutatingIntegration";
+
+        private static readonly string[] KnownReadOnlyIntegrationTests =
+        {
+            nameof(PapiClientTests.ApiKeyValidateTest),
+            nameof(PapiClientTests.ApiVersionGetTest),
+            nameof(PapiClientTests.BibGetTest),
+            nameof(PapiClientTests.BibGetTest_PassBranchId),
+            nameof(PapiClientTests.BibSearchTest),
+            nameof(PapiClientTests.CollectionsGetTest),
+            nameof(PapiClientTests.DatesClosedGetTest),
+            nameof(PapiClientTests.HoldingsGetTest),
+            nameof(PapiClientTests.ItemStatusesGetAsyncTest),
+            nameof(PapiClientTests.LimitFiltersGetTest),
+            nameof(PapiClientTests.MARCTypeOfMaterialsGetAsyncTest),
+            nameof(PapiClientTests.OrganizationsGetTest),
+            nameof(PapiClientTests.PatronAccountGetTest),
+            nameof(PapiClientTests.PatronBasicDataGetTest),
+            nameof(PapiClientTests.PatronCirculateBlocksGetTest),
+            nameof(PapiClientTests.PatronCodesGetTest),
+            nameof(PapiClientTests.PatronHoldRequestsGetTest),
+            nameof(PapiClientTests.PatronILLRequestsGetTest),
+            nameof(PapiClientTests.PatronItemsOutGetTest),
+            nameof(PapiClientTests.PatronMessagesGetTest),
+            nameof(PapiClientTests.PatronPreferencesGetTest),
+            nameof(PapiClientTests.PatronReadingHistoryGetTest),
+            nameof(PapiClientTests.PatronSavedSearchesGetTest),
+            nameof(PapiClientTests.PatronTitleListGetTitlesTest),
+            nameof(PapiClientTests.PatronValidateTest),
+            nameof(PapiClientTests.PickupBranchesGetTest),
+            nameof(PapiClientTests.ShelfLocationsGetTest),
+            nameof(PapiClientTests.AuthenticateStaffUserTest),
+            nameof(PapiClientTests.HoldRequestGetListTest),
+            nameof(PapiClientTests.Patron_GetBarcodeFromIdTest),
+            nameof(PapiClientTests.PatronRenewBlocksGetTest),
+            nameof(PapiClientTests.PatronSearchTest),
+            nameof(PapiClientTests.RecordSetRecordsGetTest),
+            nameof(PapiClientTests.SA_GetValueByOrgTest),
+            nameof(PapiClientTests.Synch_BibsByIdGetTest),
+        };
+
+        private static readonly string[] KnownProtectedIntegrationTests =
+        {
+            nameof(PapiClientTests.AuthenticateStaffUserTest),
+            nameof(PapiClientTests.HoldRequestGetListTest),
+            nameof(PapiClientTests.Patron_GetBarcodeFromIdTest),
+            nameof(PapiClientTests.PatronRenewBlocksGetTest),
+            nameof(PapiClientTests.PatronSearchTest),
+            nameof(PapiClientTests.RecordSetRecordsGetTest),
+            nameof(PapiClientTests.SA_GetValueByOrgTest),
+            nameof(PapiClientTests.Synch_BibsByIdGetTest),
+        };
+
+        private static readonly string[] KnownMutatingIntegrationTests =
+        {
+            nameof(PapiClientTests.CreatePatronBlocksTest_FreeTextBlock),
+            nameof(PapiClientTests.CreatePatronBlocksTest_SystemBlock),
+            nameof(PapiClientTests.CreatePatronBlocksTest_LibraryAssignedBlock),
+            nameof(PapiClientTests.HoldRequestCancelTest),
+            nameof(PapiClientTests.HoldRequestCreateTest),
+            nameof(PapiClientTests.HoldRequestCreateTest2),
+            nameof(PapiClientTests.HoldRequestReactivateTest),
+            nameof(PapiClientTests.HoldRequestReplyTest),
+            nameof(PapiClientTests.HoldRequestSuspendTest),
+            nameof(PapiClientTests.ItemRenewTest),
+            nameof(PapiClientTests.NotificationUpdateTest),
+            nameof(PapiClientTests.PatronAccountCreateCreditTest),
+            nameof(PapiClientTests.TestTitleListCreate_Get_Delete),
+            nameof(PapiClientTests.PatronAccountDepositCreditTest),
+            nameof(PapiClientTests.PatronAccountPayTest),
+            nameof(PapiClientTests.PatronAccountPayAllTest),
+            nameof(PapiClientTests.PatronAccountRefundCreditTest),
+            nameof(PapiClientTests.PatronAccountVoidTest),
+            nameof(PapiClientTests.PatronMessageDeleteTest),
+            nameof(PapiClientTests.PatronMessageUpdateStatusTest),
+            nameof(PapiClientTests.PatronReadingHistoryClearTest),
+            nameof(PapiClientTests.PatronTitleListAddTitleTest),
+            nameof(PapiClientTests.PatronTitleListCopyAllTitlesTest),
+            nameof(PapiClientTests.PatronTitleListCopyTitleTest),
+            nameof(PapiClientTests.PatronTitleListDeleteAllTitlesTest),
+            nameof(PapiClientTests.PatronTitleListDeleteTitleTest),
+            nameof(PapiClientTests.PatronTitleListMoveTitleTest),
+            nameof(PapiClientTests.PatronUpdateTest),
+            nameof(PapiClientTests.PatronUpdateUserNameTest),
+            nameof(PapiClientTests.RecordSetContentAddTest),
+            nameof(PapiClientTests.RecordSetContentAddTest_List),
+            nameof(PapiClientTests.RecordSetContentRemoveTest),
+            nameof(PapiClientTests.RecordSetContentRemoveTest_List),
+        };
+
+        [TestMethod]
+        public void SpecializedIntegrationCategoriesRequireIntegrationCategory()
+        {
+            var missingIntegration = GetPapiClientTestMethods()
+                .Where(method =>
+                    (MethodHasCategory(method, ReadOnlyIntegrationCategory)
+                        || MethodHasCategory(method, ProtectedIntegrationCategory)
+                        || MethodHasCategory(method, MutatingIntegrationCategory))
+                    && !MethodOrClassHasCategory(method, IntegrationCategory))
+                .Select(method => method.Name)
+                .ToArray();
+
+            Assert.IsFalse(
+                missingIntegration.Any(),
+                $"Expected specialized integration tests to also be marked with TestCategory(\"{IntegrationCategory}\") at method or class level: {string.Join(", ", missingIntegration)}");
+        }
+
+        [TestMethod]
+        public void ReadOnlyAndMutatingIntegrationCategoriesAreMutuallyExclusive()
+        {
+            var conflictingMethods = GetPapiClientTestMethods()
+                .Where(method => MethodHasCategory(method, ReadOnlyIntegrationCategory) && MethodHasCategory(method, MutatingIntegrationCategory))
+                .Select(method => method.Name)
+                .ToArray();
+
+            Assert.IsFalse(
+                conflictingMethods.Any(),
+                $"Expected no test to have both TestCategory(\"{ReadOnlyIntegrationCategory}\") and TestCategory(\"{MutatingIntegrationCategory}\"): {string.Join(", ", conflictingMethods)}");
+        }
+
+        [TestMethod]
+        public void MutatingIntegrationTestsAreNotParallelized()
+        {
+            var missingDoNotParallelize = GetPapiClientTestMethods()
+                .Where(method => MethodHasCategory(method, MutatingIntegrationCategory))
+                .Where(method => !method.GetCustomAttributes<DoNotParallelizeAttribute>(inherit: false).Any())
+                .Select(method => method.Name)
+                .ToArray();
+
+            Assert.IsFalse(
+                missingDoNotParallelize.Any(),
+                $"Expected mutating integration tests to be marked with {nameof(DoNotParallelizeAttribute)} unless a documented exception is added to this test: {string.Join(", ", missingDoNotParallelize)}");
+        }
+
+        [TestMethod]
+        public void StaffOverrideIntegrationTestsHaveProtectedIntegrationCategory()
+        {
+            var methodsRequiringStaffOverride = PapiClientTestSourceMethods()
+                .Where(method => method.Body.Contains("IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings)"))
+                .Select(method => method.Name)
+                .ToArray();
+
+            AssertMethodsHaveCategory(methodsRequiringStaffOverride, ProtectedIntegrationCategory);
+        }
+
+        [TestMethod]
+        public void KnownReadOnlyTestsHaveReadOnlyIntegrationCategory()
+        {
+            AssertMethodsHaveCategory(KnownReadOnlyIntegrationTests, ReadOnlyIntegrationCategory);
+        }
 
         [TestMethod]
         public void KnownStaffRequiredReadOnlyTestsHaveProtectedIntegrationCategory()
         {
-            var protectedIntegrationTests = new[]
-            {
-                nameof(PapiClientTests.AuthenticateStaffUserTest),
-                nameof(PapiClientTests.HoldRequestGetListTest),
-                nameof(PapiClientTests.Patron_GetBarcodeFromIdTest),
-                nameof(PapiClientTests.PatronRenewBlocksGetTest),
-                nameof(PapiClientTests.PatronSearchTest),
-                nameof(PapiClientTests.RecordSetRecordsGetTest),
-                nameof(PapiClientTests.SA_GetValueByOrgTest),
-                nameof(PapiClientTests.Synch_BibsByIdGetTest),
-            };
-
-            AssertMethodsHaveCategory(protectedIntegrationTests, ProtectedIntegrationCategory);
+            AssertMethodsHaveCategory(KnownProtectedIntegrationTests, ProtectedIntegrationCategory);
         }
 
         [TestMethod]
         public void KnownMutatingTestsHaveMutatingIntegrationCategory()
         {
-            var mutatingIntegrationTests = new[]
-            {
-                nameof(PapiClientTests.CreatePatronBlocksTest_FreeTextBlock),
-                nameof(PapiClientTests.CreatePatronBlocksTest_SystemBlock),
-                nameof(PapiClientTests.CreatePatronBlocksTest_LibraryAssignedBlock),
-                nameof(PapiClientTests.NotificationUpdateTest),
-                nameof(PapiClientTests.PatronAccountCreateCreditTest),
-                nameof(PapiClientTests.TestTitleListCreate_Get_Delete),
-                nameof(PapiClientTests.PatronAccountDepositCreditTest),
-                nameof(PapiClientTests.PatronAccountPayTest),
-                nameof(PapiClientTests.PatronAccountPayAllTest),
-                nameof(PapiClientTests.PatronAccountRefundCreditTest),
-                nameof(PapiClientTests.PatronAccountVoidTest),
-                nameof(PapiClientTests.PatronMessageDeleteTest),
-                nameof(PapiClientTests.PatronMessageUpdateStatusTest),
-                nameof(PapiClientTests.PatronReadingHistoryClearTest),
-                nameof(PapiClientTests.PatronTitleListAddTitleTest),
-                nameof(PapiClientTests.PatronTitleListCopyAllTitlesTest),
-                nameof(PapiClientTests.PatronTitleListCopyTitleTest),
-                nameof(PapiClientTests.PatronTitleListDeleteAllTitlesTest),
-                nameof(PapiClientTests.PatronTitleListDeleteTitleTest),
-                nameof(PapiClientTests.PatronTitleListMoveTitleTest),
-                nameof(PapiClientTests.PatronUpdateTest),
-                nameof(PapiClientTests.RecordSetContentAddTest),
-                nameof(PapiClientTests.RecordSetContentAddTest_List),
-                nameof(PapiClientTests.RecordSetContentRemoveTest),
-                nameof(PapiClientTests.RecordSetContentRemoveTest_List),
-            };
+            AssertMethodsHaveCategory(KnownMutatingIntegrationTests, MutatingIntegrationCategory);
+        }
 
-            AssertMethodsHaveCategory(mutatingIntegrationTests, MutatingIntegrationCategory);
+        [TestMethod]
+        public void KnownMutatingTestsDoNotHaveReadOnlyIntegrationCategory()
+        {
+            var incorrectlyReadOnly = KnownMutatingIntegrationTests
+                .Where(methodName => MethodHasCategory(methodName, ReadOnlyIntegrationCategory))
+                .ToArray();
+
+            Assert.IsFalse(
+                incorrectlyReadOnly.Any(),
+                $"Expected known mutating tests not to be marked with TestCategory(\"{ReadOnlyIntegrationCategory}\"): {string.Join(", ", incorrectlyReadOnly)}");
+        }
+
+        private static IEnumerable<MethodInfo> GetPapiClientTestMethods()
+        {
+            return typeof(PapiClientTests)
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                .Where(method => method.GetCustomAttributes<TestMethodAttribute>(inherit: false).Any());
         }
 
         private static void AssertMethodsHaveCategory(IEnumerable<string> methodNames, string expectedCategory)
@@ -80,10 +210,92 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.IsNotNull(method, $"Expected to find public test method {nameof(PapiClientTests)}.{methodName}.");
 
+            return MethodHasCategory(method, expectedCategory);
+        }
+
+        private static bool MethodHasCategory(MethodInfo method, string expectedCategory)
+        {
             return method
                 .GetCustomAttributes<TestCategoryAttribute>(inherit: false)
                 .SelectMany(attribute => attribute.TestCategories)
                 .Contains(expectedCategory);
+        }
+
+        private static bool MethodOrClassHasCategory(MethodInfo method, string expectedCategory)
+        {
+            return MethodHasCategory(method, expectedCategory)
+                || typeof(PapiClientTests)
+                    .GetCustomAttributes<TestCategoryAttribute>(inherit: false)
+                    .SelectMany(attribute => attribute.TestCategories)
+                    .Contains(expectedCategory);
+        }
+
+        private static IEnumerable<(string Name, string Body)> PapiClientTestSourceMethods()
+        {
+            var source = File.ReadAllText(FindPapiClientTestsSourcePath());
+            var methodMatches = Regex.Matches(
+                source,
+                @"public\s+async\s+Task\s+(?<name>\w+)\s*\(",
+                RegexOptions.CultureInvariant);
+
+            foreach (Match methodMatch in methodMatches)
+            {
+                var openingBraceIndex = source.IndexOf('{', methodMatch.Index + methodMatch.Length);
+                Assert.AreNotEqual(-1, openingBraceIndex, $"Expected to find opening brace for {methodMatch.Groups["name"].Value}.");
+
+                var closingBraceIndex = FindClosingBrace(source, openingBraceIndex);
+                yield return (methodMatch.Groups["name"].Value, source.Substring(openingBraceIndex, closingBraceIndex - openingBraceIndex + 1));
+            }
+        }
+
+        private static int FindClosingBrace(string source, int openingBraceIndex)
+        {
+            var depth = 0;
+
+            for (var i = openingBraceIndex; i < source.Length; i++)
+            {
+                if (source[i] == '{')
+                {
+                    depth++;
+                }
+                else if (source[i] == '}')
+                {
+                    depth--;
+
+                    if (depth == 0)
+                    {
+                        return i;
+                    }
+                }
+            }
+
+            Assert.Fail($"Expected to find closing brace matching character index {openingBraceIndex}.");
+            return -1;
+        }
+
+        private static string FindPapiClientTestsSourcePath()
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (directory != null)
+            {
+                var candidate = Path.Combine(directory.FullName, "Methods", "PapiClientTests.cs");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+
+                candidate = Path.Combine(directory.FullName, "src", "polaris-api-csharpTests", "Methods", "PapiClientTests.cs");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+
+                directory = directory.Parent;
+            }
+
+            Assert.Fail("Expected to find Methods/PapiClientTests.cs while walking up from the test output directory.");
+            return string.Empty;
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
@@ -100,6 +100,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task ApiKeyValidateTest()
         {
             var response = await papi.ApiKeyValidateAsync();
@@ -107,6 +109,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task ApiVersionGetTest()
         {
             var response = await papi.ApiVersionGetAsync();
@@ -115,6 +119,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task AuthenticateStaffUserTest()
         {
@@ -128,6 +134,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task BibGetTest()
         {
             var response = await papi.BibGetAsync(478907);
@@ -138,6 +146,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task BibGetTest_PassBranchId()
         {
             var response = await papi.BibGetAsync(bibId, 7);
@@ -147,6 +157,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task BibSearchTest()
         {
             var response = await papi.BibSearchAsync(new BibSearchOptions { Term = "dogs", PageSize = 10 });
@@ -156,6 +168,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task CollectionsGetTest()
         {
             var response = await papi.CollectionsGetAsync();
@@ -165,6 +179,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task CreatePatronBlocksTest_FreeTextBlock()
@@ -177,6 +193,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task CreatePatronBlocksTest_SystemBlock()
@@ -188,6 +206,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task CreatePatronBlocksTest_LibraryAssignedBlock()
@@ -199,6 +219,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task DatesClosedGetTest()
         {
             var response = await papi.DatesClosedGetAsync(7);
@@ -212,6 +234,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task HoldingsGetTest()
         {
             var response = await papi.HoldingsGetAsync(bibId);
@@ -219,6 +243,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task HoldRequestCancelTest()
         {
             var response = await papi.HoldRequestCancelAsync(Settings.PatronBarcode, 1234, Settings.PatronPin);
@@ -226,6 +253,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task HoldRequestCreateTest()
         {
             var response = await papi.HoldRequestCreateAsync(new HoldRequestCreateParams(Settings.PatronId, 1234, 7, 7));
@@ -233,6 +263,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task HoldRequestCreateTest2()
         {
             var response = await ((PapiClient)papi).HoldRequestCreateAsync(Settings.PatronId, 1234, 7);
@@ -240,6 +273,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task HoldRequestGetListTest()
         {
@@ -250,6 +285,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task HoldRequestReactivateTest()
         {
             var response = await papi.HoldRequestReactivateAsync(Settings.PatronBarcode, Settings.PatronPin, 1234, DateTime.Now);
@@ -257,6 +295,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task HoldRequestReplyTest()
         {
             var hold = new HoldRequestCreateResult { RequestGuid = new Guid() };
@@ -265,6 +306,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task HoldRequestSuspendTest()
         {
             var response = await papi.HoldRequestSuspendAsync(Settings.PatronBarcode, 1234, DateTime.Now, Settings.PatronPin);
@@ -272,6 +316,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task ItemRenewTest()
         {
             var response = await papi.ItemRenewAsync(Settings.PatronBarcode, 1234, Settings.PatronPin);
@@ -279,6 +326,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task ItemStatusesGetAsyncTest()
         {
             var response = await papi.ItemStatusesGetAsync(7);
@@ -293,6 +342,8 @@ namespace Clc.Polaris.Api.Tests
         //}
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task LimitFiltersGetTest()
         {
             var response = (await papi.LimitFiltersGetAsync()).Data;
@@ -300,6 +351,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task MARCTypeOfMaterialsGetAsyncTest()
         {
             var response = (await papi.MARCTypeOfMaterialsGetAsync()).Data;
@@ -307,6 +360,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task NotificationUpdateTest()
@@ -318,6 +373,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task OrganizationsGetTest()
         {
             var response = await papi.OrganizationsGetAsync();
@@ -325,6 +382,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task Patron_GetBarcodeFromIdTest()
         {
@@ -335,6 +394,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronAccountCreateCreditTest()
@@ -346,6 +407,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task TestTitleListCreate_Get_Delete()
@@ -365,6 +427,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronAccountDepositCreditTest()
@@ -376,6 +440,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronAccountGetTest()
         {
             var response = await papi.PatronAccountGetAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -384,6 +450,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronAccountPayTest()
@@ -395,6 +463,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronAccountPayAllTest()
@@ -406,6 +476,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronAccountRefundCreditTest()
@@ -417,6 +489,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronAccountVoidTest()
@@ -428,6 +502,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronBasicDataGetTest()
         {
             var response = await papi.PatronBasicDataGetAsync(Settings.PatronBarcode, Settings.PatronPin, true);
@@ -437,6 +513,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronCirculateBlocksGetTest()
         {
             var response = await papi.PatronCirculateBlocksGetAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -444,6 +522,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronCodesGetTest()
         {
             var response = await papi.PatronCodesGetAsync();
@@ -452,6 +532,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronHoldRequestsGetTest()
         {
             var response = await papi.PatronHoldRequestsGetAsync(Settings.PatronBarcode, PatronHoldStatus.all, Settings.PatronPin);
@@ -460,6 +542,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronILLRequestsGetTest()
         {
             var response = await papi.PatronILLRequestsGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
@@ -468,6 +552,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronItemsOutGetTest()
         {
             var response = await papi.PatronItemsOutGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
@@ -476,6 +562,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronMessageDeleteTest()
@@ -485,6 +572,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronMessagesGetTest()
         {
             var response = await papi.PatronMessagesGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
@@ -492,6 +581,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronMessageUpdateStatusTest()
@@ -501,6 +591,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronPreferencesGetTest()
         {
             var response = await papi.PatronPreferencesGetAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -508,6 +600,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronReadingHistoryClearTest()
@@ -517,6 +610,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronReadingHistoryGetTest()
         {
             var response = await papi.PatronReadingHistoryGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
@@ -531,6 +626,8 @@ namespace Clc.Polaris.Api.Tests
         //}
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task PatronRenewBlocksGetTest()
         {
@@ -541,6 +638,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronSavedSearchesGetTest()
         {
             var response = await papi.PatronSavedSearchesGetAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -548,6 +647,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task PatronSearchTest()
         {
@@ -558,6 +659,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronTitleListAddTitleTest()
@@ -567,6 +669,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronTitleListCopyAllTitlesTest()
@@ -576,6 +679,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronTitleListCopyTitleTest()
@@ -585,6 +689,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronTitleListDeleteAllTitlesTest()
@@ -594,6 +699,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronTitleListDeleteTitleTest()
@@ -603,6 +709,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronTitleListGetTitlesTest()
         {
             var response = await papi.PatronTitleListGetTitlesAsync(Settings.PatronBarcode, 1234, password: Settings.PatronPin);
@@ -610,6 +718,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronTitleListMoveTitleTest()
@@ -619,6 +728,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task PatronUpdateTest()
@@ -628,6 +738,9 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("MutatingIntegration")]
+        [DoNotParallelize]
         public async Task PatronUpdateUserNameTest()
         {
             var response = await papi.PatronUpdateUserNameAsync(Settings.PatronBarcode + "1234", Settings.PatronPin, Settings.PatronPin);
@@ -635,6 +748,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PatronValidateTest()
         {
             var response = await papi.PatronValidateAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -642,6 +757,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task PickupBranchesGetTest()
         {
             var response = await papi.PickupBranchesGetAsync();
@@ -649,6 +766,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task RecordSetContentAddTest()
@@ -660,6 +779,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task RecordSetContentAddTest_List()
@@ -671,6 +792,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task RecordSetContentRemoveTest()
@@ -682,6 +805,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ProtectedIntegration")]
         [TestCategory("MutatingIntegration")]
         [DoNotParallelize]
         public async Task RecordSetContentRemoveTest_List()
@@ -693,6 +818,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task RecordSetRecordsGetTest()
         {
@@ -710,6 +837,8 @@ namespace Clc.Polaris.Api.Tests
         //}
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task SA_GetValueByOrgTest()
         {
@@ -720,6 +849,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         public async Task ShelfLocationsGetTest()
         {
             var response = await papi.ShelfLocationsGetAsync(7);
@@ -727,6 +858,8 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
+        [TestCategory("Integration")]
+        [TestCategory("ReadOnlyIntegration")]
         [TestCategory("ProtectedIntegration")]
         public async Task Synch_BibsByIdGetTest()
         {


### PR DESCRIPTION
### Motivation

- Make live Polaris/API test filtering explicit and reliable.
- Allow developers to run read-only integration tests separately from mutating/destructive integration tests.
- Prevent accidental live state changes when running integration tests locally.
- Add automated validation so future `PapiClientTests` cannot be added without a clear integration-test classification.

### Description

- Added explicit method-level test categories in `src/polaris-api-csharpTests/Methods/PapiClientTests.cs`.
- Added the new `ReadOnlyIntegration` category for live tests that only read/return data and do not mutate Polaris state.
- Updated protected read-only tests to use:
  - `Integration`
  - `ReadOnlyIntegration`
  - `ProtectedIntegration`
- Updated mutating tests to use:
  - `Integration`
  - `MutatingIntegration`
- Added `ProtectedIntegration` to mutating tests that require staff/protected credentials.
- Ensured mutating integration tests are marked `[DoNotParallelize]`.
- Left `HeadingsSearchTest` uncategorized as a documented exception because it does not execute a live API request; it asserts `NotImplementedException`.

### Validation added

Reworked `src/polaris-api-csharpTests/Methods/PapiClientTestCategoryTests.cs` to validate the category taxonomy automatically:

- Specialized integration categories require the broad `Integration` category.
- `ReadOnlyIntegration` and `MutatingIntegration` are mutually exclusive.
- Mutating integration tests must be marked `[DoNotParallelize]`.
- Tests that call `IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings)` must have `ProtectedIntegration`.
- Known read-only tests must have `ReadOnlyIntegration`.
- Known mutating tests must have `MutatingIntegration`.
- Known mutating tests must not have `ReadOnlyIntegration`.
- All `PapiClientTests` integration tests must be classified as either `ReadOnlyIntegration`, `MutatingIntegration`, or listed as a documented exception.

The source-based validation now uses `[CallerFilePath]` to read the sibling `PapiClientTests.cs` file and supports `public async Task`, `public Task`, and `public void` test methods.

### Documentation

Updated `README.md` local test instructions to define the live-test categories:

- `Integration`: any test that requires a live Polaris/API environment.
- `ReadOnlyIntegration`: live test that only reads/returns data and does not mutate Polaris state.
- `ProtectedIntegration`: live test that requires staff/protected credentials.
- `MutatingIntegration`: live test that creates, updates, cancels, deletes, clears, pays, voids, moves, renews, submits, or otherwise changes Polaris state.

Added/updated example commands for:

- Non-live/unit tests
- Read-only integration tests that do not require staff credentials
- Protected read-only integration tests
- All read-only integration tests
- Mutating/destructive integration tests

### Testing

Ran:

```bash
dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"