### PR TITLE
Expose guarded ExecutePapiAsync<T> on PapiClient

### DIFF
--- a/src/polaris-api-csharp/Methods/ApiKeyValidate.cs
+++ b/src/polaris-api-csharp/Methods/ApiKeyValidate.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api
             var url = "/public/v1/1033/100/1/apikeyvalidate";
             var request = PapiRestRequest.Get(url);
             request.BlockStaffOverride = true;
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/ApiVersionGet.cs
+++ b/src/polaris-api-csharp/Methods/ApiVersionGet.cs
@@ -20,7 +20,7 @@ namespace Clc.Polaris.Api
         {
             var url = "/public/v1/1033/100/1/api";
             var request = PapiRestRequest.Get(url);
-            return await ExecutePapiAsync<ApiResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<ApiResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/AuthenticatePatron.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticatePatron.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
             var body = new { Barcode = barcode, Password = password };
             var request = PapiRestRequest.Post(url, body: body);
             request.BlockStaffOverride = true;
-            return await ExecutePapiAsync<PatronAuthenticationResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronAuthenticationResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
         {
             var request = PapiRestRequest.Post("/protected/v1/1033/100/1/authenticator/staff", body: staffUser);
 
-            return await ExecutePapiAsync<ProtectedToken>(request, cancellationToken, ProtectedTokenPreloadMode.Skip).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<ProtectedToken>(request, cancellationToken, ProtectedTokenPreloadMode.Skip).ConfigureAwait(false);
         }
 
 

--- a/src/polaris-api-csharp/Methods/BibGet.cs
+++ b/src/polaris-api-csharp/Methods/BibGet.cs
@@ -22,7 +22,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/bib/{bibId}";
             var request = PapiRestRequest.Get(url);
-            return await ExecutePapiAsync<BibGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<BibGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/BibSearch.cs
+++ b/src/polaris-api-csharp/Methods/BibSearch.cs
@@ -25,7 +25,7 @@ namespace Clc.Polaris.Api
             request.QueryParameters.Add("bibsperpage", options.PageSize);
             request.QueryParameters.Add("limit", options.Limit ?? string.Empty);
 
-            return await ExecutePapiAsync<BibSearchResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<BibSearchResult>(request, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<IRestResponse<BibSearchResult>> BibKeywordSearchAsync(string keyword, int? branchId = null, int page = 1, int pageSize = 10, SearchSortOptions sortBy = SearchSortOptions.MP, CancellationToken cancellationToken = default)

--- a/src/polaris-api-csharp/Methods/CollectionsGet.cs
+++ b/src/polaris-api-csharp/Methods/CollectionsGet.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/collections";
             var request = PapiRestRequest.Get(url);
             request.BlockStaffOverride = true;
-            return await ExecutePapiAsync<CollectionsGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<CollectionsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
+++ b/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
@@ -21,7 +21,7 @@ namespace Clc.Polaris.Api
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
 
-            return await ExecutePapiAsync<CreatePatronBlocksResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<CreatePatronBlocksResult>(request, cancellationToken).ConfigureAwait(false);
         }
 
 

--- a/src/polaris-api-csharp/Methods/DatesClosedGet.cs
+++ b/src/polaris-api-csharp/Methods/DatesClosedGet.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/{organizationId}/datesclosed";
             var request = PapiRestRequest.Get(url);
             request.BlockStaffOverride = true;
-            return await ExecutePapiAsync<DatesClosedGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<DatesClosedGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/HoldRequestCancel.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestCancel.cs
@@ -13,7 +13,7 @@ namespace Clc.Polaris.Api
             var request = PapiRestRequest.Put(url, password: password);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
-            return await ExecutePapiAsync<HoldRequestCancelResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<HoldRequestCancelResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/HoldRequestCreate.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestCreate.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/{holdParams.RequestingOrgID}/holdrequest";
             var request = PapiRestRequest.Post(url, body: holdParams);
-            return await ExecutePapiAsync<HoldRequestCreateResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<HoldRequestCreateResult>(request, cancellationToken).ConfigureAwait(false);
         }
         public async Task<IRestResponse<HoldRequestCreateResult>> HoldRequestCreateAsync(int patronId, int bibId, int pickupBranchId = 0, DateTime? activationDate = null, int? userId = null, int? workstationId = null, int? requestingOrgId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
             request.QueryParameters.Add("branch", branchId);
             request.QueryParameters.Add("branchtype", (int)branchType);
             request.QueryParameters.Add("requeststatus", (int)status);
-            return await ExecutePapiAsync<HoldRequestGetListResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<HoldRequestGetListResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/HoldRequestReactivate.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestReactivate.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/active";
             var body = new { HoldRequestActivationData = new { UserId = userId ?? UserId, activationDate } };
             var request = PapiRestRequest.Put(url, body: body, password: password);
-            return await ExecutePapiAsync<HoldRequestActivationResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<HoldRequestActivationResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/HoldRequestReply.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestReply.cs
@@ -27,7 +27,7 @@ namespace Clc.Polaris.Api
             };
 
             var request = PapiRestRequest.Put(url, body: body);
-            return await ExecutePapiAsync<HoldRequestReplyResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<HoldRequestReplyResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/HoldRequestSuspend.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestSuspend.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/inactive";
             var json = new { HoldRequestActivationData = new { UserId = userId ?? UserId, activationDate } };
             var request = PapiRestRequest.Put(url, body: json, password: password);
-            return await ExecutePapiAsync<HoldRequestActivationResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<HoldRequestActivationResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/HoldingsGet.cs
+++ b/src/polaris-api-csharp/Methods/HoldingsGet.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/bib/{bibId}/holdings";
             var request = PapiRestRequest.Get(url);
-            return await ExecutePapiAsync<BibHoldingsGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<BibHoldingsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/ItemRenew.cs
+++ b/src/polaris-api-csharp/Methods/ItemRenew.cs
@@ -13,7 +13,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/itemsout/{itemId}";
             var request = PapiRestRequest.Put(url, body: renewOptions ?? new ItemRenewOptions(), password: password);
-            return await ExecutePapiAsync<ItemRenewResultWrapper>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<ItemRenewResultWrapper>(request, cancellationToken).ConfigureAwait(false);
         }
         public Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAllForPatronAsync(string barcode, string password = "", ItemRenewOptions? renewOptions = null, CancellationToken cancellationToken = default)
             => ItemRenewAsync(barcode, 0, password, renewOptions, cancellationToken);

--- a/src/polaris-api-csharp/Methods/ItemStatusesGet.cs
+++ b/src/polaris-api-csharp/Methods/ItemStatusesGet.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/itemstatuses";
             var request = PapiRestRequest.Get(url);
             request.BlockStaffOverride = true;
-            return await ExecutePapiAsync<ItemStatusesGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<ItemStatusesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
+++ b/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
             var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", transactionBranchId ?? WorkstationId);
             if (!string.IsNullOrWhiteSpace(oldBarcode)) { request.QueryParameters.Add("isBarcode", 1); }
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
 
 

--- a/src/polaris-api-csharp/Methods/LimitFiltersGet.cs
+++ b/src/polaris-api-csharp/Methods/LimitFiltersGet.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/limitfilters";
             var request = PapiRestRequest.Get(url);
             request.BlockStaffOverride = true;
-            return await ExecutePapiAsync<LimitFiltersGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<LimitFiltersGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/MARCTypeOfMaterialsGet.cs
+++ b/src/polaris-api-csharp/Methods/MARCTypeOfMaterialsGet.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/marctypeofmaterials";
             var request = PapiRestRequest.Get(url);
             request.BlockStaffOverride = true;
-            return await ExecutePapiAsync<MARCTypeOfMaterialsGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<MARCTypeOfMaterialsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/MaterialTypesGet.cs
+++ b/src/polaris-api-csharp/Methods/MaterialTypesGet.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/materialtypes";
             var request = PapiRestRequest.Get(url);
             request.BlockStaffOverride = true;
-            return await ExecutePapiAsync<MaterialTypesGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<MaterialTypesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
+++ b/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
             //"protected/{Version}/{LangID}/{AppID}/{OrgID}/{AccessToken}/notification
             var url = $"/protected/v1/1033/24/{orgId}/{ProtectedToken.Placeholder}/notification/";
             var request = PapiRestRequest.Get(url);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/NotificationUpdate.cs
+++ b/src/polaris-api-csharp/Methods/NotificationUpdate.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/notification/{updateParams.NotificationTypeId}";
             var request = PapiRestRequest.Put(url, body: updateParams);
-            return await ExecutePapiAsync<NotificationUpdateResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<NotificationUpdateResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/OrganizationsGet.cs
+++ b/src/polaris-api-csharp/Methods/OrganizationsGet.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/1/organizations/{type}";
             var request = PapiRestRequest.Get(url);
             request.BlockStaffOverride = true;
-            return await ExecutePapiAsync<OrganizationsGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<OrganizationsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
@@ -20,7 +20,7 @@ namespace Clc.Polaris.Api
             var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronAccountCreateTitleList.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountCreateTitleList.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patronaccountcreatetitlelist";
             var body = new PatronAccountCreateTitleListData { RecordStoreName = listName };
             var request = PapiRestRequest.Post(url, body: body, password: password);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronAccountDeleteTitleList.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDeleteTitleList.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patronaccountdeletetitlelist";
             var request = PapiRestRequest.Delete(url, password: password);
             request.QueryParameters.Add("list", listId);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
@@ -22,7 +22,7 @@ namespace Clc.Polaris.Api
             var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronAccountGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountGet.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/account/outstanding";
             var request = PapiRestRequest.Get(url, password: password);
-            return await ExecutePapiAsync<PatronAccountGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronAccountGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronAccountGetTitleLists.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountGetTitleLists.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patronaccountgettitlelists";
             var request = PapiRestRequest.Get(url, password: password);
-            return await ExecutePapiAsync<PatronAccountGetTitleListsResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronAccountGetTitleListsResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronAccountPay.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPay.cs
@@ -22,7 +22,7 @@ namespace Clc.Polaris.Api
             var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
@@ -22,7 +22,7 @@ namespace Clc.Polaris.Api
             var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
@@ -22,7 +22,7 @@ namespace Clc.Polaris.Api
             var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
@@ -21,7 +21,7 @@ namespace Clc.Polaris.Api
             var request = PapiRestRequest.Delete(url);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronBasicDataGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronBasicDataGet.cs
@@ -20,7 +20,7 @@ namespace Clc.Polaris.Api
             var request = PapiRestRequest.Get(url, password: password);
             request.QueryParameters.Add("addresses", Convert.ToInt32(addresses));
             request.QueryParameters.Add("notes", Convert.ToInt32(notes));
-            return await ExecutePapiAsync<PatronBasicDataGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronBasicDataGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronCirculateBlocksGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronCirculateBlocksGet.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/circulationblocks";
             var request = PapiRestRequest.Get(url, password: password);
-            return await ExecutePapiAsync<PatronCirculateBlocksResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronCirculateBlocksResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronCodesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronCodesGet.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/patroncodes";
             var request = PapiRestRequest.Get(url);
             request.BlockStaffOverride = true;
-            return await ExecutePapiAsync<PatronCodesGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronCodesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronHoldRequestsGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronHoldRequestsGet.cs
@@ -14,7 +14,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{status}";
             var request = PapiRestRequest.Get(url, password: password);
-            return await ExecutePapiAsync<PatronHoldRequestsGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronHoldRequestsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronILLRequestsGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronILLRequestsGet.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/illrequests/{status}";
             var request = PapiRestRequest.Get(url, password: password);
-            return await ExecutePapiAsync<PatronILLRequestsGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronILLRequestsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronItemsOutGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronItemsOutGet.cs
@@ -13,7 +13,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/itemsout/{status}";
             var request = PapiRestRequest.Get(url, password: password);
-            return await ExecutePapiAsync<PatronItemsOutGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronItemsOutGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronMessageDelete.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessageDelete.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/messages/{messageType}/{messageId}";
             var request = PapiRestRequest.Delete(url, password: password);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronMessageUpdateStatus.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessageUpdateStatus.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/messages/{messageType}/{messageId}";
             var request = PapiRestRequest.Put(url, password: password);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronMessagesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessagesGet.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/messages";
             var request = PapiRestRequest.Get(url, password: password);
             request.QueryParameters.Add("unreadonly", unreadOnly ? 1 : 0);
-            return await ExecutePapiAsync<PatronMessagesGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronMessagesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronPreferencesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronPreferencesGet.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/preferences";
             var request = PapiRestRequest.Get(url, password: password);
-            return await ExecutePapiAsync<PatronPreferencesGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronPreferencesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
+++ b/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
@@ -26,7 +26,7 @@ namespace Clc.Polaris.Api
                 request.QueryParameters.Add("ids", string.Join(",", idList));
             }
 
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronReadingHistoryGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronReadingHistoryGet.cs
@@ -19,7 +19,7 @@ namespace Clc.Polaris.Api
             var request = PapiRestRequest.Get(url, password: password);
             request.QueryParameters.Add("page", page);
             request.QueryParameters.Add("rowsperpage", rowsPerPage);
-            return await ExecutePapiAsync<PatronReadingHistoryGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronReadingHistoryGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronRegistrationCreate.cs
+++ b/src/polaris-api-csharp/Methods/PatronRegistrationCreate.cs
@@ -20,7 +20,7 @@ namespace Clc.Polaris.Api
             var url = "/public/v1/1033/100/1/patron";
             var request = PapiRestRequest.Post(url, body: _params);
             request.BlockStaffOverride = true;
-            return await ExecutePapiAsync<PatronRegistrationCreateResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronRegistrationCreateResult>(request, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<IRestResponse<PatronRegistrationCreateResult>> PatronRegistrationCreateV2Async(PatronRegistrationData _params, CancellationToken cancellationToken = default)
@@ -28,7 +28,7 @@ namespace Clc.Polaris.Api
             var url = "/public/v2/1033/100/1/patron";
             var request = PapiRestRequest.Post(url, body: _params);
             request.BlockStaffOverride = true;
-            return await ExecutePapiAsync<PatronRegistrationCreateResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronRegistrationCreateResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronRenewBlocksGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronRenewBlocksGet.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/protected/v1/1033/100/{branchId ?? OrganizationId}/{ProtectedToken.Placeholder}/circulation/patron/{patronId}/renewblocks";
             var request = PapiRestRequest.Get(url);
-            return await ExecutePapiAsync<PatronRenewBlocksResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronRenewBlocksResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronSavedSearchesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronSavedSearchesGet.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/savedsearches";
             var request = PapiRestRequest.Get(url, password: password);
-            return await ExecutePapiAsync<PatronSavedSearchesGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronSavedSearchesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronSearch.cs
+++ b/src/polaris-api-csharp/Methods/PatronSearch.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
             request.QueryParameters.Add("patronsperpage", pageSize);
             request.QueryParameters.Add("page", page);
             request.QueryParameters.Add("sort", sortBy);
-            return await ExecutePapiAsync<PatronSearchResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronSearchResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronTitleListAddTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListAddTitle.cs
@@ -20,7 +20,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistaddtitle/";
             var body = new PatronTitleListAddTitleData { RecordStoreId = recordStoreId, LocalControlNumber = localControlNumber };
             var request = PapiRestRequest.Post(url, body: body, password: password);
-            return await ExecutePapiAsync<PatronTitleListAddTitleResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronTitleListAddTitleResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronTitleListCopyAllTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListCopyAllTitles.cs
@@ -20,7 +20,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistcopyalltitles/";
             var body = new PatronTitleListCopyAllTitlesData { FromRecordStoreId = fromRecordStoreId, ToRecordStoreId = toRecordStoreId };
             var request = PapiRestRequest.Post(url, body: body, password: password);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronTitleListCopyTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListCopyTitle.cs
@@ -26,7 +26,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistcopytitle/";
             var body = new PatronTitleListCopyTitleData { FromRecordStoreId = fromRecordStoreId, FromPosition = fromPosition, ToRecordStoreId = toRecordStoreId };
             var request = PapiRestRequest.Post(url, body: body, password: password);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronTitleListDeleteAllTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListDeleteAllTitles.cs
@@ -20,7 +20,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistdeletealltitles";
             var request = PapiRestRequest.Delete(url, password: password);
             request.QueryParameters.Add("list", listId);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs
@@ -29,7 +29,7 @@ namespace Clc.Polaris.Api
             var request = PapiRestRequest.Delete(url, password: password);
             request.QueryParameters.Add("list", listId);
             request.QueryParameters.Add("position", position);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronTitleListGetTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListGetTitles.cs
@@ -20,7 +20,7 @@ namespace Clc.Polaris.Api
             request.QueryParameters.Add("list", listId);
             request.QueryParameters.Add("startPosition", startPosition);
             request.QueryParameters.Add("endPosition", endPosition);
-            return await ExecutePapiAsync<PatronTitleListGetTitlesResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronTitleListGetTitlesResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronTitleListMoveTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListMoveTitle.cs
@@ -29,7 +29,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistmovetitle/";
             var body = new PatronTitleListMoveTitleData { FromRecordStoreId = fromRecordStoreId, FromPosition = fromPosition, ToRecordStoreId = toRecordStoreId };
             var request = PapiRestRequest.Post(url, body: body, password: password);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronUpdate.cs
+++ b/src/polaris-api-csharp/Methods/PatronUpdate.cs
@@ -21,7 +21,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}";
             var request = PapiRestRequest.Put(url, body: updateParams, password: password);
             request.QueryParameters.Add("ignoresa", ignoresa);
-            return await ExecutePapiAsync<PatronUpdateResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronUpdateResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronUpdateUserName.cs
+++ b/src/polaris-api-csharp/Methods/PatronUpdateUserName.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/username/{WebUtility.UrlEncode(newUsername)}";
             var request = PapiRestRequest.Put(url, password: password);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PatronValidate.cs
+++ b/src/polaris-api-csharp/Methods/PatronValidate.cs
@@ -13,7 +13,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}";
             var request = PapiRestRequest.Get(url, password: password);
-            return await ExecutePapiAsync<PatronValidateResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PatronValidateResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
+++ b/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/barcode";
             var request = PapiRestRequest.Get(url);
             request.QueryParameters.Add("patronid", patronId);
-            return await ExecutePapiAsync<GetBarcodeAndPatronIDResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<GetBarcodeAndPatronIDResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/PickupBranchesGet.cs
+++ b/src/polaris-api-csharp/Methods/PickupBranchesGet.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/{organizationId ?? OrganizationId}/pickupbranches";
             var request = PapiRestRequest.Get(url);
             request.BlockStaffOverride = true;
-            return await ExecutePapiAsync<PickupBranchesGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PickupBranchesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
@@ -21,7 +21,7 @@ namespace Clc.Polaris.Api
             request.QueryParameters.Add("action", action);
             request.QueryParameters.Add("userid", userId ?? UserId);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
         public async Task<IRestResponse<PapiResponseCommon>> RecordSetContentAddAsync(int recordSetId, int recordId, int userId = 1, int workstationId = 1, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
@@ -21,7 +21,7 @@ namespace Clc.Polaris.Api
             request.QueryParameters.Add("numRecords", numRecords);
             request.QueryParameters.Add("userid", userId);
             request.QueryParameters.Add("wsid", workstationId);
-            return await ExecutePapiAsync<RecordSetRecordsGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<RecordSetRecordsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
+++ b/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
@@ -22,7 +22,7 @@ namespace Clc.Polaris.Api
             request.QueryParameters.Add("maxitems", maxItems);
             request.QueryParameters.Add("listtype", (int)listType);
             if (startItemRecordId.HasValue) { request.QueryParameters.Add("startitemrecordid", startItemRecordId.Value); }
-            return await ExecutePapiAsync<RemoteStorageItemsGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<RemoteStorageItemsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
+++ b/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
@@ -23,7 +23,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/organization/{organizationId ?? OrganizationId}/sysadmin/attribute/{attribute}";
             var request = PapiRestRequest.Get(url);
-            return await ExecutePapiAsync<StringResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<StringResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/ShelfLocationsGet.cs
+++ b/src/polaris-api-csharp/Methods/ShelfLocationsGet.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/{branchId ?? OrganizationId}/shelflocations";
             var request = PapiRestRequest.Get(url);
             request.BlockStaffOverride = true;
-            return await ExecutePapiAsync<ShelfLocationsGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<ShelfLocationsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
+++ b/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
@@ -20,7 +20,7 @@ namespace Clc.Polaris.Api
             {
                 request.QueryParameters.Add("includeItems", 1);
             }
-            return await ExecutePapiAsync<Sync_BibsByIdGetResult>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<Sync_BibsByIdGetResult>(request, cancellationToken).ConfigureAwait(false);
         }
 
         public Task<IRestResponse<Sync_BibsByIdGetResult>> Synch_BibsByIdGetAsync(int bibId, bool includeItems = false, CancellationToken cancellationToken = default) => Synch_BibsByIdGetAsync(new int[] { bibId }, includeItems, cancellationToken);

--- a/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
@@ -36,7 +36,7 @@ namespace Clc.Polaris.Api
 
             var request = PapiRestRequest.Post(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/UpdatePickupBranchID.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePickupBranchID.cs
@@ -21,7 +21,7 @@ namespace Clc.Polaris.Api
             request.QueryParameters.Add("userid", userId ?? UserId);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("pickupbranchid", pickupBranchId);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/_template_get.cs
+++ b/src/polaris-api-csharp/Methods/_template_get.cs
@@ -14,7 +14,7 @@ namespace Clc.Polaris.Api
         {
             var url = $"/public/v1/1033/100/1/patron/";
             var request = PapiRestRequest.Get(url, password: password);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/Methods/_template_post.cs
+++ b/src/polaris-api-csharp/Methods/_template_post.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
             var url = $"/public/v1/1033/100/1/foo";
             var body = new object();
             var request = PapiRestRequest.Post(url, body: body, password: password);
-            return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
+            return await ExecutePapiCoreAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/polaris-api-csharp/PapiClient.CustomExecution.cs
+++ b/src/polaris-api-csharp/PapiClient.CustomExecution.cs
@@ -1,0 +1,65 @@
+using Clc.Polaris.Api.Models;
+using Clc.Rest;
+using Clc.Rest.Models;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Clc.Polaris.Api
+{
+    public partial class PapiClient
+    {
+        /// <summary>
+        /// Executes a custom PAPI request through the normal <see cref="PapiClient"/> request pipeline.
+        /// </summary>
+        /// <typeparam name="T">The expected response body model.</typeparam>
+        /// <param name="request">
+        /// The custom PAPI request to execute. Use a relative PAPI path beginning with <c>/</c>, such as
+        /// <c>/public/v1/1033/100/1/...</c> or <c>/protected/v1/1033/100/1/...</c>.
+        /// </param>
+        /// <param name="cancellationToken">A token that can cancel protected-token acquisition and HTTP execution.</param>
+        /// <returns>The REST response returned by the PAPI endpoint.</returns>
+        /// <remarks>
+        /// This method is an escape hatch for unsupported PAPI endpoints that do not yet have typed wrapper methods.
+        /// The request still uses <see cref="PapiClient"/> authentication, signing, staff override, protected token,
+        /// URL-building, and path-prefix behavior.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="request"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="request"/> does not contain a safe relative PAPI path, or when an authenticated
+        /// request path is outside the <c>/public/</c> and <c>/protected/</c> PAPI scopes.
+        /// </exception>
+        public Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
+        {
+            ValidateCustomPapiRequest(request);
+            return ExecutePapiCoreAsync<T>(request, cancellationToken, ProtectedTokenPreloadMode.Auto);
+        }
+
+        private static void ValidateCustomPapiRequest(PapiRestRequest request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (string.IsNullOrWhiteSpace(request.Path))
+            {
+                throw new ArgumentException("Custom PAPI request Path must not be null, empty, or whitespace.", nameof(request));
+            }
+
+            if (request.Path.StartsWith("//", StringComparison.Ordinal) ||
+                Uri.IsWellFormedUriString(request.Path, UriKind.Absolute) ||
+                !request.Path.StartsWith("/", StringComparison.Ordinal))
+            {
+                throw new ArgumentException("Custom PAPI request Path must be a relative PAPI path beginning with '/'.", nameof(request));
+            }
+
+            if (request.AuthRequired &&
+                !request.Path.StartsWith("/public/", StringComparison.OrdinalIgnoreCase) &&
+                !request.Path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("Authenticated custom PAPI request Path must start with '/public/' or '/protected/'.", nameof(request));
+            }
+        }
+    }
+}

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -158,7 +158,7 @@ namespace Clc.Polaris.Api
             public bool HasValidToken => Status == ProtectedTokenAcquisitionStatus.ValidTokenAvailable && IsProtectedTokenUsable(Token);
         }
 
-        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default, ProtectedTokenPreloadMode tokenPreloadMode = ProtectedTokenPreloadMode.Auto)
+        private async Task<IRestResponse<T>> ExecutePapiCoreAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default, ProtectedTokenPreloadMode tokenPreloadMode = ProtectedTokenPreloadMode.Auto)
         {
             var pathContainsProtectedTokenPlaceholder = RequestPathContainsProtectedTokenPlaceholder(request);
             var requiresProtectedToken = RequiresProtectedToken(request, pathContainsProtectedTokenPlaceholder);

--- a/src/polaris-api-csharpTests/PapiClientCustomExecutionTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientCustomExecutionTests.cs
@@ -1,0 +1,235 @@
+using Clc.Polaris.Api.Configuration;
+using Clc.Polaris.Api.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Clc.Polaris.Api.Tests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class PapiClientCustomExecutionTests
+    {
+        [TestMethod]
+        public async Task ExecutePapiAsync_CustomGet_UsesPapiPipelineAndAddsAuthHeaders()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/custom/endpoint");
+
+            var response = await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/custom/endpoint", handler.LastRequest.RequestUri!.AbsoluteUri);
+            Assert.IsNull(handler.LastRequest.Content);
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
+            StringAssert.StartsWith(handler.LastRequest.Headers.GetValues("Authorization").Single(), "PWS access-id:");
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_CustomPost_SerializesBody()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Post("/public/v1/1033/100/1/custom/post", new { Value = "example" });
+
+            var response = await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.AreEqual(HttpMethod.Post, handler.LastRequest!.Method);
+            Assert.IsNotNull(handler.LastRequest.Content);
+            Assert.IsNotNull(handler.LastRequestContent);
+            StringAssert.Contains(handler.LastRequestContent!, "Value");
+            StringAssert.Contains(handler.LastRequestContent!, "example");
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
+            Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
+        }
+
+        [TestMethod]
+        public void ExecutePapiAsync_DoesNotAppearOnIPapiClient()
+        {
+            var interfaceMethodNames = typeof(IPapiClient).GetMethods().Select(method => method.Name).ToArray();
+
+            CollectionAssert.DoesNotContain(interfaceMethodNames, "ExecutePapiAsync");
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_NullRequest_ThrowsArgumentNullException()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+                () => client.ExecutePapiAsync<PapiResponseCommon>(null!));
+
+            Assert.IsNull(handler.LastRequest);
+        }
+
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("   ")]
+        public async Task ExecutePapiAsync_NullEmptyOrWhitespacePath_ThrowsArgumentException(string path)
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = new PapiRestRequest { Path = path! };
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(
+                () => client.ExecutePapiAsync<PapiResponseCommon>(request));
+
+            Assert.IsNull(handler.LastRequest);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_AbsoluteUrlPath_ThrowsArgumentException()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("https://evil.example/public/v1/1033/100/1/foo");
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(
+                () => client.ExecutePapiAsync<PapiResponseCommon>(request));
+
+            Assert.IsNull(handler.LastRequest);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_ProtocolRelativeUrlPath_ThrowsArgumentException()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("//example.com/foo");
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(
+                () => client.ExecutePapiAsync<PapiResponseCommon>(request));
+
+            Assert.IsNull(handler.LastRequest);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_PathNotBeginningWithSlash_ThrowsArgumentException()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("public/v1/1033/100/1/foo");
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(
+                () => client.ExecutePapiAsync<PapiResponseCommon>(request));
+
+            Assert.IsNull(handler.LastRequest);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_AuthenticatedPathOutsidePapiScopes_ThrowsArgumentException()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("/other/v1/1033/100/1/foo");
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(
+                () => client.ExecutePapiAsync<PapiResponseCommon>(request));
+
+            Assert.IsNull(handler.LastRequest);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_PublicCustomRequest_AddsStaffOverrideToken_WhenAllowedAndUnblocked()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "staff-token",
+                AccessSecret = "staff-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            };
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/custom/staff-override");
+
+            var response = await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.IsTrue(handler.LastRequest!.Headers.Contains("X-PAPI-AccessToken"));
+            Assert.AreEqual("staff-token", handler.LastRequest.Headers.GetValues("X-PAPI-AccessToken").Single());
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_PublicCustomRequest_BlockStaffOverride_PreventsStaffOverrideToken()
+        {
+            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.Token = new ProtectedToken
+            {
+                AccessToken = "staff-token",
+                AccessSecret = "staff-secret",
+                ExpirationDate = DateTime.Now.AddHours(1)
+            };
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/custom/staff-override");
+            request.BlockStaffOverride = true;
+
+            var response = await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(handler.LastRequest);
+            Assert.IsFalse(handler.LastRequest!.Headers.Contains("X-PAPI-AccessToken"));
+        }
+
+        private static PapiClient CreateClient(HttpMessageHandler handler)
+        {
+            return new PapiClient(new HttpClient(handler), new TestPapiSettings())
+            {
+                AllowStaffOverrideRequests = false,
+                UseProtectedTokenCache = false
+            };
+        }
+
+        private sealed class TestPapiSettings : IPapiSettings
+        {
+            public string AccessId { get; set; } = "access-id";
+            public string AccessKey { get; set; } = "access-key";
+            public string Hostname { get; set; } = "https://example.test";
+            public int UserId { get; set; } = 1;
+            public int WorkstationId { get; set; } = 1;
+            public int OrganizationId { get; set; } = 1;
+            public PolarisUser? PolarisOverrideAccount { get; set; }
+        }
+
+        private sealed class CapturingHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly string _responseJson;
+
+            public HttpRequestMessage? LastRequest { get; private set; }
+            public string? LastRequestContent { get; private set; }
+
+            public CapturingHttpMessageHandler(string responseJson)
+            {
+                _responseJson = responseJson;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastRequest = request;
+                LastRequestContent = request.Content == null
+                    ? null
+                    : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                };
+            }
+        }
+    }
+}

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -662,7 +662,7 @@ namespace Clc.Polaris.Api.Tests
             var client = CreateClient(handler);
             var request = new PapiRestRequest($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/search/patrons/Boolean");
             var executePapiAsync = typeof(PapiClient)
-                .GetMethod("ExecutePapiAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .GetMethod("ExecutePapiCoreAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
                 .MakeGenericMethod(typeof(PapiResponseCommon));
             var skipMode = Enum.Parse(
                 typeof(PapiClient).GetNestedType("ProtectedTokenPreloadMode", System.Reflection.BindingFlags.NonPublic)!,
@@ -1111,7 +1111,7 @@ namespace Clc.Polaris.Api.Tests
         private static async Task ExecuteRawPapiRequestAsync(PapiClient client, PapiRestRequest request)
         {
             var executePapiAsync = typeof(PapiClient)
-                .GetMethod("ExecutePapiAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .GetMethod("ExecutePapiCoreAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
                 .MakeGenericMethod(typeof(PapiResponseCommon));
             var autoMode = Enum.Parse(
                 typeof(PapiClient).GetNestedType("ProtectedTokenPreloadMode", System.Reflection.BindingFlags.NonPublic)!,


### PR DESCRIPTION
### Motivation
- Provide a public escape hatch to execute unsupported/custom PAPI endpoints from callers without changing the typed `IPapiClient` contract.
- Ensure custom execution still flows through the existing PAPI pipeline (signing, PolarisDate, staff override, protected-token logic, path-prefix/URL building) and prevent bypassing host/path protections.
- Validate caller-supplied requests early to avoid sending unsafe or absolute URLs and to require PAPI-scoped authenticated paths.

### Description
- Added a new partial file `PapiClient.CustomExecution.cs` that exposes `public Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)` with XML docs describing its intent and usage examples (relative `/public/...` and `/protected/...` paths).
- Implemented validation guards in `ValidateCustomPapiRequest` to throw `ArgumentNullException` for null requests and `ArgumentException` for null/empty/whitespace paths, protocol-relative (`//`), absolute URLs, non-leading-slash paths, and authenticated paths outside `/public/` or `/protected/` when `AuthRequired` is true.
- Kept the PAPI pipeline intact by delegating to the existing internal execution path; renamed the previous private `ExecutePapiAsync` to `ExecutePapiCoreAsync` and updated typed wrapper methods to call the core method so they do not hit the public validation layer.
- Added unit tests in `src/polaris-api-csharpTests/PapiClientCustomExecutionTests.cs` covering custom GET/POST execution, null/path/URL guards, interface absence on `IPapiClient`, and staff-override/block behavior; updated internal reflection usages in existing tests to reference the renamed core method.
- Intentionally did not modify `IPapiClient` so the typed interface remains unchanged.

### Testing
- Ran unit test suite: `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj` and all tests passed (Passed: 158, Failed: 0, Skipped: 69, Total: 227).
- New tests added in `PapiClientCustomExecutionTests` executed and passed as part of the run.
- Existing characterization tests were adjusted to reference the renamed private core method and passed, confirming the public method delegates into the same pipeline and preserves signing/staff override/protected-token behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a24cc006a8883238e75e9d627efe9cb)