### PR TITLE
Remove ProtectedTokenPreloadMode and derive skip from staff-auth route

### DIFF
--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
         {
             var request = PapiRestRequest.Post("/protected/v1/1033/100/1/authenticator/staff", body: staffUser);
 
-            return await ExecutePapiAsync<ProtectedToken>(request, cancellationToken, ProtectedTokenPreloadMode.Skip).ConfigureAwait(false);
+            return await ExecutePapiAsync<ProtectedToken>(request, cancellationToken).ConfigureAwait(false);
         }
 
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -130,12 +130,6 @@ namespace Clc.Polaris.Api
             return papiRequest;
         }
 
-        private enum ProtectedTokenPreloadMode
-        {
-            Auto,
-            Skip
-        }
-
         private enum ProtectedTokenAcquisitionStatus
         {
             ValidTokenAvailable,
@@ -158,17 +152,12 @@ namespace Clc.Polaris.Api
             public bool HasValidToken => Status == ProtectedTokenAcquisitionStatus.ValidTokenAvailable && IsProtectedTokenUsable(Token);
         }
 
-        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default, ProtectedTokenPreloadMode tokenPreloadMode = ProtectedTokenPreloadMode.Auto)
+        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
         {
             var pathContainsProtectedTokenPlaceholder = RequestPathContainsProtectedTokenPlaceholder(request);
             var requiresProtectedToken = RequiresProtectedToken(request, pathContainsProtectedTokenPlaceholder);
 
-            if (tokenPreloadMode == ProtectedTokenPreloadMode.Skip && pathContainsProtectedTokenPlaceholder)
-            {
-                throw new InvalidOperationException("ProtectedToken.Placeholder cannot be used when protected token preloading is skipped.");
-            }
-
-            if (tokenPreloadMode == ProtectedTokenPreloadMode.Auto && requiresProtectedToken)
+            if (requiresProtectedToken)
             {
                 var tokenResult = await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
@@ -188,6 +177,11 @@ namespace Clc.Polaris.Api
 
         private bool RequiresProtectedToken(PapiRestRequest request, bool pathContainsProtectedTokenPlaceholder)
         {
+            if (IsStaffAuthenticatorRequest(request))
+            {
+                return false;
+            }
+
             if (pathContainsProtectedTokenPlaceholder)
             {
                 return true;
@@ -204,6 +198,14 @@ namespace Clc.Polaris.Api
                 string.IsNullOrWhiteSpace(request.Password) &&
                 !request.BlockStaffOverride &&
                 StaffOverrideAccount != null;
+        }
+
+        private static bool IsStaffAuthenticatorRequest(PapiRestRequest request)
+        {
+            return request.Method == HttpMethod.Post &&
+                request.Path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase) &&
+                request.Path.EndsWith("/authenticator/staff", StringComparison.OrdinalIgnoreCase) &&
+                request.Path.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) < 0;
         }
 
         private static void ThrowProtectedTokenRequired(ProtectedTokenAcquisitionStatus status, bool pathContainsProtectedTokenPlaceholder)

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -200,12 +200,15 @@ namespace Clc.Polaris.Api
                 StaffOverrideAccount != null;
         }
 
-        private static bool IsStaffAuthenticatorRequest(PapiRestRequest request)
+        private static bool IsStaffAuthenticatorRequest(PapiRestRequest? request)
         {
-            return request.Method == HttpMethod.Post &&
-                request.Path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase) &&
-                request.Path.EndsWith("/authenticator/staff", StringComparison.OrdinalIgnoreCase) &&
-                request.Path.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) < 0;
+            var path = request?.Path;
+
+            return request?.Method == HttpMethod.Post &&
+                !string.IsNullOrWhiteSpace(path) &&
+                path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase) &&
+                path.EndsWith("/authenticator/staff", StringComparison.OrdinalIgnoreCase) &&
+                path.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) < 0;
         }
 
         private static void ThrowProtectedTokenRequired(ProtectedTokenAcquisitionStatus status, bool pathContainsProtectedTokenPlaceholder)

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -199,6 +199,49 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNull(client.Token);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.ProtectedRequestCount);
+            var request = handler.CapturedRequests.Single();
+            Assert.IsTrue(request.IsStaffAuthenticationRequest);
+            Assert.AreEqual("POST", request.Method);
+            StringAssert.EndsWith(request.Path, "/protected/v1/1033/100/1/authenticator/staff");
+            AssertAuthorizationHash(request, string.Empty, client.AccessKey, client.AccessID);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_ProtectedRequestWithoutPlaceholderOrPassword_AcquiresProtectedToken()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("route-token", "route-secret", DateTime.Now.AddHours(1)));
+            var client = CreateProtectedClient(handler);
+            var request = PapiRestRequest.Get("/protected/v1/1033/100/1/patron/ABC123/account/outstanding");
+
+            await ExecuteRawPapiRequestAsync(client, request);
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual("route-token", client.Token?.AccessToken);
+            var finalRequest = handler.CapturedRequests.Single(capturedRequest => !capturedRequest.IsStaffAuthenticationRequest);
+            StringAssert.EndsWith(finalRequest.Path, "/protected/v1/1033/100/1/patron/ABC123/account/outstanding");
+            AssertAuthorizationHash(finalRequest, "route-secret", client.AccessKey, client.AccessID);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_ProtectedPathEndingDifferentlyThanStaffAuthenticator_AcquiresProtectedToken()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("malformed-token", "malformed-secret", DateTime.Now.AddHours(1)));
+            var client = CreateProtectedClient(handler);
+            var request = PapiRestRequest.Post("/protected/v1/1033/100/1/authenticator/staff/extra");
+
+            await ExecuteRawPapiRequestAsync(client, request);
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual("malformed-token", client.Token?.AccessToken);
+            var finalRequest = handler.CapturedRequests.Single(capturedRequest => !capturedRequest.IsStaffAuthenticationRequest);
+            StringAssert.EndsWith(finalRequest.Path, "/protected/v1/1033/100/1/authenticator/staff/extra");
+            AssertAuthorizationHash(finalRequest, "malformed-secret", client.AccessKey, client.AccessID);
         }
 
         [TestMethod]
@@ -994,6 +1037,16 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsTrue(protectedRequest.Headers.ContainsKey("Authorization"));
         }
 
+        private static async Task ExecuteRawPapiRequestAsync(PapiClient client, PapiRestRequest request)
+        {
+            var executePapiAsync = typeof(PapiClient)
+                .GetMethod("ExecutePapiAsync", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .MakeGenericMethod(typeof(PapiResponseCommon));
+
+            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None })!;
+            await task.ConfigureAwait(false);
+        }
+
         private static PapiClient CreateClient(CapturingHttpMessageHandler handler)
         {
             var hostname = $"https://example-{Guid.NewGuid():N}.test";
@@ -1130,7 +1183,9 @@ namespace Clc.Polaris.Api.Tests
                 AbsoluteUri = request.RequestUri!.AbsoluteUri;
                 Path = request.RequestUri.AbsolutePath;
                 Body = body;
-                IsStaffAuthenticationRequest = Path.Contains("/authenticator/staff", StringComparison.Ordinal);
+                IsStaffAuthenticationRequest = request.Method == HttpMethod.Post &&
+                    Path.EndsWith("/authenticator/staff", StringComparison.OrdinalIgnoreCase) &&
+                    Path.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) < 0;
                 Headers = request.Headers
                     .ToDictionary(header => header.Key, header => string.Join(",", header.Value), StringComparer.OrdinalIgnoreCase);
             }

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -245,6 +245,24 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public void IsStaffAuthenticatorRequest_InvalidOrMissingPath_ReturnsFalse()
+        {
+            Assert.IsFalse(InvokeIsStaffAuthenticatorRequest(null));
+            Assert.IsFalse(InvokeIsStaffAuthenticatorRequest(CreateStaffAuthenticatorRequestWithPath(null)));
+            Assert.IsFalse(InvokeIsStaffAuthenticatorRequest(CreateStaffAuthenticatorRequestWithPath(string.Empty)));
+            Assert.IsFalse(InvokeIsStaffAuthenticatorRequest(CreateStaffAuthenticatorRequestWithPath("   ")));
+        }
+
+        [TestMethod]
+        public void IsStaffAuthenticatorRequest_RequiresExactProtectedPostStaffRouteWithoutPlaceholder()
+        {
+            Assert.IsTrue(InvokeIsStaffAuthenticatorRequest(CreateStaffAuthenticatorRequestWithPath("/protected/v1/1033/100/1/authenticator/staff")));
+            Assert.IsFalse(InvokeIsStaffAuthenticatorRequest(PapiRestRequest.Get("/protected/v1/1033/100/1/authenticator/staff")));
+            Assert.IsFalse(InvokeIsStaffAuthenticatorRequest(PapiRestRequest.Post("/protected/v1/1033/100/1/authenticator/staff/extra")));
+            Assert.IsFalse(InvokeIsStaffAuthenticatorRequest(PapiRestRequest.Post($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/authenticator/staff")));
+        }
+
+        [TestMethod]
         public async Task PatronSearchAsync_ConcurrentProtectedRequestsForSameCacheKey_AuthenticateOnce()
         {
             var handler = new ProtectedTokenHttpMessageHandler();
@@ -1045,6 +1063,22 @@ namespace Clc.Polaris.Api.Tests
 
             var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None })!;
             await task.ConfigureAwait(false);
+        }
+
+        private static bool InvokeIsStaffAuthenticatorRequest(PapiRestRequest? request)
+        {
+            var isStaffAuthenticatorRequest = typeof(PapiClient)
+                .GetMethod("IsStaffAuthenticatorRequest", BindingFlags.Static | BindingFlags.NonPublic)!;
+
+            return (bool)isStaffAuthenticatorRequest.Invoke(null, new object?[] { request })!;
+        }
+
+        private static PapiRestRequest CreateStaffAuthenticatorRequestWithPath(string? path)
+        {
+            var request = PapiRestRequest.Post("/protected/v1/1033/100/1/authenticator/staff");
+            request.Path = path!;
+
+            return request;
         }
 
         private static PapiClient CreateClient(CapturingHttpMessageHandler handler)

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -656,27 +656,6 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
-        public async Task ExecutePapiAsync_WithSkippedProtectedTokenPreloadAndPlaceholder_FailsBeforeSending()
-        {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
-            var client = CreateClient(handler);
-            var request = new PapiRestRequest($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/search/patrons/Boolean");
-            var executePapiAsync = typeof(PapiClient)
-                .GetMethod("ExecutePapiAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
-                .MakeGenericMethod(typeof(PapiResponseCommon));
-            var skipMode = Enum.Parse(
-                typeof(PapiClient).GetNestedType("ProtectedTokenPreloadMode", System.Reflection.BindingFlags.NonPublic)!,
-                "Skip");
-
-            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None, skipMode })!;
-            var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await task);
-
-            StringAssert.Contains(exception.Message, "ProtectedToken.Placeholder");
-            Assert.IsNull(handler.LastRequest);
-            Assert.AreEqual($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/search/patrons/Boolean", request.Path);
-        }
-
-        [TestMethod]
         public async Task BibSearch_RequestShape_IsStable()
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
@@ -1113,11 +1092,7 @@ namespace Clc.Polaris.Api.Tests
             var executePapiAsync = typeof(PapiClient)
                 .GetMethod("ExecutePapiAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
                 .MakeGenericMethod(typeof(PapiResponseCommon));
-            var autoMode = Enum.Parse(
-                typeof(PapiClient).GetNestedType("ProtectedTokenPreloadMode", System.Reflection.BindingFlags.NonPublic)!,
-                "Auto");
-
-            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None, autoMode })!;
+            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None })!;
             await task.ConfigureAwait(false);
         }
 


### PR DESCRIPTION
### Motivation
- Simplify protected-token preload logic by removing an internal enum and making the single skip case (staff authenticator bootstrap) a route-driven decision instead of being passed around as a parameter.

### Description
- Removed the private `ProtectedTokenPreloadMode` enum and deleted the `tokenPreloadMode` parameter from `ExecutePapiAsync<T>` so the method signature is now `private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)`.
- Added a private helper `IsStaffAuthenticatorRequest(PapiRestRequest request)` and updated `RequiresProtectedToken` to return `false` for the staff authenticator bootstrap request before the normal placeholder/protected/public staff-override rules run.
- Updated `AuthenticateStaffUserAsync` to call the simplified `ExecutePapiAsync<ProtectedToken>(request, cancellationToken)` signature and removed all branches that referenced the removed enum.
- Updated and added unit test helpers and tests to use the simplified signature and to verify: staff-auth does not preload a protected token, normal protected routes still acquire tokens, placeholder behavior remains, and malformed staff-auth-like paths do not skip acquisition (changes in `src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs` and `src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs`).

### Testing
- Ran the full test suite with `dotnet test src/polaris-api-csharp.sln` and all tests passed (0 failed, 146 passed, 69 skipped, total 215).
- Ran the focused token tests with `dotnet test src/polaris-api-csharp.sln --filter PapiClientTokenTests` and they passed.
- Verified there are no remaining references to the removed enum with `rg "ProtectedTokenPreloadMode" .` which returned no results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a24d19639b48323a49e6974dde7d2cc)