### PR TITLE
Remove ProtectedTokenPreloadMode and derive skip-preload from staff-auth route

### DIFF
--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
         {
             var request = PapiRestRequest.Post("/protected/v1/1033/100/1/authenticator/staff", body: staffUser);
 
-            return await ExecutePapiAsync<ProtectedToken>(request, cancellationToken, ProtectedTokenPreloadMode.Skip).ConfigureAwait(false);
+            return await ExecutePapiAsync<ProtectedToken>(request, cancellationToken).ConfigureAwait(false);
         }
 
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -130,12 +130,6 @@ namespace Clc.Polaris.Api
             return papiRequest;
         }
 
-        private enum ProtectedTokenPreloadMode
-        {
-            Auto,
-            Skip
-        }
-
         private enum ProtectedTokenAcquisitionStatus
         {
             ValidTokenAvailable,
@@ -158,17 +152,12 @@ namespace Clc.Polaris.Api
             public bool HasValidToken => Status == ProtectedTokenAcquisitionStatus.ValidTokenAvailable && IsProtectedTokenUsable(Token);
         }
 
-        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default, ProtectedTokenPreloadMode tokenPreloadMode = ProtectedTokenPreloadMode.Auto)
+        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
         {
             var pathContainsProtectedTokenPlaceholder = RequestPathContainsProtectedTokenPlaceholder(request);
             var requiresProtectedToken = RequiresProtectedToken(request, pathContainsProtectedTokenPlaceholder);
 
-            if (tokenPreloadMode == ProtectedTokenPreloadMode.Skip && pathContainsProtectedTokenPlaceholder)
-            {
-                throw new InvalidOperationException("ProtectedToken.Placeholder cannot be used when protected token preloading is skipped.");
-            }
-
-            if (tokenPreloadMode == ProtectedTokenPreloadMode.Auto && requiresProtectedToken)
+            if (requiresProtectedToken)
             {
                 var tokenResult = await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
@@ -188,6 +177,11 @@ namespace Clc.Polaris.Api
 
         private bool RequiresProtectedToken(PapiRestRequest request, bool pathContainsProtectedTokenPlaceholder)
         {
+            if (IsStaffAuthenticatorRequest(request))
+            {
+                return false;
+            }
+
             if (pathContainsProtectedTokenPlaceholder)
             {
                 return true;
@@ -221,6 +215,14 @@ namespace Clc.Polaris.Api
                 : string.Empty;
 
             throw new InvalidOperationException($"A valid protected access token is required for this request. {reason}{placeholderReason}");
+        }
+
+        private static bool IsStaffAuthenticatorRequest(PapiRestRequest request)
+        {
+            return request.Method == HttpMethod.Post &&
+                request.Path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase) &&
+                request.Path.EndsWith("/authenticator/staff", StringComparison.OrdinalIgnoreCase) &&
+                request.Path.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) < 0;
         }
 
         private static bool RequestPathContainsProtectedTokenPlaceholder(PapiRestRequest request)

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -656,24 +656,18 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
-        public async Task ExecutePapiAsync_WithSkippedProtectedTokenPreloadAndPlaceholder_FailsBeforeSending()
+        public async Task ExecutePapiAsync_MalformedStaffAuthenticatorPath_RequiresProtectedTokenBeforeSending()
         {
             var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
             var client = CreateClient(handler);
-            var request = new PapiRestRequest($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/search/patrons/Boolean");
-            var executePapiAsync = typeof(PapiClient)
-                .GetMethod("ExecutePapiAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
-                .MakeGenericMethod(typeof(PapiResponseCommon));
-            var skipMode = Enum.Parse(
-                typeof(PapiClient).GetNestedType("ProtectedTokenPreloadMode", System.Reflection.BindingFlags.NonPublic)!,
-                "Skip");
+            var request = PapiRestRequest.Post("/protected/v1/1033/100/1/authenticator/staff-extra");
 
-            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None, skipMode })!;
-            var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await task);
+            var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => ExecuteRawPapiRequestAsync(client, request));
 
-            StringAssert.Contains(exception.Message, "ProtectedToken.Placeholder");
+            StringAssert.Contains(exception.Message, "valid protected access token");
             Assert.IsNull(handler.LastRequest);
-            Assert.AreEqual($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/search/patrons/Boolean", request.Path);
+            Assert.AreEqual("/protected/v1/1033/100/1/authenticator/staff-extra", request.Path);
         }
 
         [TestMethod]
@@ -1113,11 +1107,8 @@ namespace Clc.Polaris.Api.Tests
             var executePapiAsync = typeof(PapiClient)
                 .GetMethod("ExecutePapiAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
                 .MakeGenericMethod(typeof(PapiResponseCommon));
-            var autoMode = Enum.Parse(
-                typeof(PapiClient).GetNestedType("ProtectedTokenPreloadMode", System.Reflection.BindingFlags.NonPublic)!,
-                "Auto");
 
-            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None, autoMode })!;
+            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None })!;
             await task.ConfigureAwait(false);
         }
 


### PR DESCRIPTION
### Motivation
- Simplify protected-token preload behavior by removing the internal `ProtectedTokenPreloadMode` enum and stop passing a skip flag into `ExecutePapiAsync<T>`. 
- Make the staff authenticator bootstrap route the only case that bypasses protected-token preloading, encoded in route-based logic instead of via a parameter.

### Description
- Removed the private `ProtectedTokenPreloadMode` enum and eliminated the `tokenPreloadMode` parameter from `ExecutePapiAsync<T>` so the method signature is now `ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)`. 
- Moved protected-token preload decision into request-based logic and removed all branches that referenced the removed enum. 
- Added a private helper `IsStaffAuthenticatorRequest(PapiRestRequest request)` that identifies POST `/protected/.../authenticator/staff` requests (including placeholder absence check). 
- Updated `RequiresProtectedToken` to return `false` for the staff authenticator request before the existing placeholder, protected-method, and public staff-override rules. 
- Updated `AuthenticateStaffUserAsync` to call the simplified `ExecutePapiAsync<T>(request, cancellationToken)` signature. 
- Adjusted unit tests to match the new private execution signature and to validate the staff-authenticator route remains the only skip case; specifically `RestClientMigrationCharacterizationTests` was updated to stop reflecting the removed enum and to add/adjust the malformed-staff-auth path test and raw execution helper. 

### Testing
- Ran `dotnet test src/polaris-api-csharp.sln` and the test suite passed: all tests completed successfully (145 passed, 69 skipped). 
- Verified no references remain to the removed enum with `rg -n "ProtectedTokenPreloadMode|tokenPreloadMode" .` which returned no matches. 
- Updated and executed modified characterization tests which compiled and passed under the new `ExecutePapiAsync<T>` signature.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a24d19639b48323a49e6974dde7d2cc)