### PR TITLE
Expose guarded custom PAPI execution

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -152,8 +152,28 @@ namespace Clc.Polaris.Api
             public bool HasValidToken => Status == ProtectedTokenAcquisitionStatus.ValidTokenAvailable && IsProtectedTokenUsable(Token);
         }
 
-        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// Executes a custom or unsupported PAPI endpoint using the normal <see cref="PapiClient"/> request pipeline.
+        /// </summary>
+        /// <remarks>
+        /// This method is an escape hatch for unsupported or custom PAPI endpoints. Callers must pass a
+        /// <see cref="PapiRestRequest"/> whose path is a relative PAPI path, such as
+        /// <c>/public/v1/1033/100/1/...</c> or <c>/protected/v1/1033/100/1/...</c>. Absolute URLs and
+        /// protocol-relative URLs are rejected. Requests still execute through the normal
+        /// <see cref="PapiClient"/> pipeline, including protected-token acquisition,
+        /// <see cref="ProtectedToken.Placeholder"/> replacement, staff override behavior, PolarisDate,
+        /// Authorization signing, and URL construction/path prefix behavior.
+        /// </remarks>
+        /// <typeparam name="T">The response body type.</typeparam>
+        /// <param name="request">The PAPI request to execute.</param>
+        /// <param name="cancellationToken">A token that can be used to cancel the request.</param>
+        /// <returns>The REST response returned by the PAPI endpoint.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="request"/> has an invalid PAPI path.</exception>
+        public async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
         {
+            ValidateCustomPapiRequest(request);
+
             var pathContainsProtectedTokenPlaceholder = RequestPathContainsProtectedTokenPlaceholder(request);
             var requiresProtectedToken = RequiresProtectedToken(request, pathContainsProtectedTokenPlaceholder);
 
@@ -173,6 +193,41 @@ namespace Clc.Polaris.Api
             }
 
             return await ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static void ValidateCustomPapiRequest(PapiRestRequest request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (string.IsNullOrWhiteSpace(request.Path))
+            {
+                throw new ArgumentException("PAPI request path must not be null, empty, or whitespace.", nameof(request));
+            }
+
+            if (request.Path.Contains("://", StringComparison.Ordinal))
+            {
+                throw new ArgumentException("PAPI request path must be a relative path, not an absolute URL.", nameof(request));
+            }
+
+            if (request.Path.StartsWith("//", StringComparison.Ordinal))
+            {
+                throw new ArgumentException("PAPI request path must not be a protocol-relative URL.", nameof(request));
+            }
+
+            if (!request.Path.StartsWith("/", StringComparison.Ordinal))
+            {
+                throw new ArgumentException("PAPI request path must begin with '/'.", nameof(request));
+            }
+
+            if (request.AuthRequired &&
+                !request.Path.StartsWith("/public/", StringComparison.OrdinalIgnoreCase) &&
+                !request.Path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("Authenticated custom PAPI request paths must begin with '/public/' or '/protected/'.", nameof(request));
+            }
         }
 
         private bool RequiresProtectedToken(PapiRestRequest request, bool pathContainsProtectedTokenPlaceholder)

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -1057,12 +1057,7 @@ namespace Clc.Polaris.Api.Tests
 
         private static async Task ExecuteRawPapiRequestAsync(PapiClient client, PapiRestRequest request)
         {
-            var executePapiAsync = typeof(PapiClient)
-                .GetMethod("ExecutePapiAsync", BindingFlags.Instance | BindingFlags.NonPublic)!
-                .MakeGenericMethod(typeof(PapiResponseCommon));
-
-            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None })!;
-            await task.ConfigureAwait(false);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request).ConfigureAwait(false);
         }
 
         private static bool InvokeIsStaffAuthenticatorRequest(PapiRestRequest? request)

--- a/src/polaris-api-csharpTests/PapiClientCustomExecutionTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientCustomExecutionTests.cs
@@ -1,0 +1,312 @@
+using Clc.Polaris.Api.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Clc.Polaris.Api.Tests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class PapiClientCustomExecutionTests
+    {
+        [TestMethod]
+        public void ExecutePapiAsync_IsPublicOnPapiClient()
+        {
+            var method = typeof(PapiClient).GetMethod(
+                "ExecutePapiAsync",
+                BindingFlags.Instance | BindingFlags.Public);
+
+            Assert.IsNotNull(method);
+            Assert.IsTrue(method!.IsGenericMethodDefinition);
+        }
+
+        [TestMethod]
+        public void ExecutePapiAsync_IsNotPresentOnIPapiClient()
+        {
+            var method = typeof(IPapiClient).GetMethods()
+                .SingleOrDefault(candidate => candidate.Name == "ExecutePapiAsync");
+
+            Assert.IsNull(method);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_NullRequest_ThrowsBeforeSendingHttpRequest()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var client = CreateClient(handler);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(() =>
+                client.ExecutePapiAsync<PapiResponseCommon>(null!));
+
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("   ")]
+        public async Task ExecutePapiAsync_BlankPath_ThrowsBeforeSendingHttpRequest(string? path)
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/custom");
+            request.Path = path!;
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                client.ExecutePapiAsync<PapiResponseCommon>(request));
+
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_AbsoluteUrlPath_ThrowsBeforeSendingHttpRequest()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("https://example.com/public/v1/1033/100/1/custom");
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                client.ExecutePapiAsync<PapiResponseCommon>(request));
+
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_ProtocolRelativeUrlPath_ThrowsBeforeSendingHttpRequest()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("//example.com/foo");
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                client.ExecutePapiAsync<PapiResponseCommon>(request));
+
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_PathWithoutLeadingSlash_ThrowsBeforeSendingHttpRequest()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("public/v1/1033/100/1/custom");
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                client.ExecutePapiAsync<PapiResponseCommon>(request));
+
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_AuthenticatedPathOutsidePublicOrProtected_ThrowsBeforeSendingHttpRequest()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("/custom/v1/1033/100/1/endpoint");
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                client.ExecutePapiAsync<PapiResponseCommon>(request));
+
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_CustomPublicGet_UsesPapiPipelineAndSignsRequest()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/custom/endpoint");
+
+            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            var captured = handler.SingleCustomRequest();
+            Assert.AreEqual(HttpMethod.Get, captured.Method);
+            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/custom/endpoint", captured.AbsoluteUri);
+            Assert.IsTrue(captured.Headers.ContainsKey("PolarisDate"));
+            Assert.IsTrue(captured.Headers.ContainsKey("Authorization"));
+            AssertAuthorizationHashesSentUri(captured, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_CustomPublicPost_SerializesBodyAndSignsRequest()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Post(
+                "/public/v1/1033/100/1/custom/endpoint",
+                new { Value = "example-body" });
+
+            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            var captured = handler.SingleCustomRequest();
+            Assert.AreEqual(HttpMethod.Post, captured.Method);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(captured.Body));
+            StringAssert.Contains(captured.Body, "example-body");
+            Assert.IsTrue(captured.Headers.ContainsKey("Authorization"));
+            AssertAuthorizationHashesSentUri(captured, string.Empty);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_CustomProtectedRequestWithProtectedTokenPlaceholder_AcquiresAndReplacesToken()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = CreateStaffUser();
+            var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/endpoint");
+
+            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            var captured = handler.SingleCustomRequest();
+            Assert.AreEqual("https://example.test/PAPIService/REST/protected/v1/1033/100/1/protected-token/custom/endpoint", captured.AbsoluteUri);
+            Assert.IsFalse(captured.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
+            AssertAuthorizationHashesSentUri(captured, "protected-secret");
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_CustomPublicRequest_UsesStaffOverrideWhenAllowed()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = CreateStaffUser();
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/custom/endpoint");
+
+            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            var captured = handler.SingleCustomRequest();
+            Assert.AreEqual("protected-token", captured.Headers["X-PAPI-AccessToken"]);
+            AssertAuthorizationHashesSentUri(captured, "protected-secret");
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_CustomPublicRequest_BlockStaffOverridePreventsAccessTokenHeader()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var client = CreateClient(handler);
+            client.AllowStaffOverrideRequests = true;
+            client.StaffOverrideAccount = CreateStaffUser();
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/custom/endpoint");
+            request.BlockStaffOverride = true;
+
+            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            Assert.AreEqual(0, handler.AuthenticationRequestCount);
+            var captured = handler.SingleCustomRequest();
+            Assert.IsFalse(captured.Headers.ContainsKey("X-PAPI-AccessToken"));
+            AssertAuthorizationHashesSentUri(captured, string.Empty);
+        }
+
+        private static PapiClient CreateClient(RecordingHttpMessageHandler handler)
+        {
+            var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://example.test/")
+            };
+
+            return new PapiClient(httpClient, null)
+            {
+                Hostname = "https://example.test",
+                AccessID = "access-id",
+                AccessKey = "access-key",
+                OrganizationId = 1,
+                UserId = 1,
+                WorkstationId = 1,
+                UseProtectedTokenCache = false,
+                AllowStaffOverrideRequests = false
+            };
+        }
+
+        private static PolarisUser CreateStaffUser()
+        {
+            return new PolarisUser
+            {
+                Domain = "domain",
+                Username = "staff",
+                Password = "password"
+            };
+        }
+
+        private static void AssertAuthorizationHashesSentUri(CapturedRequest request, string password)
+        {
+            var date = request.Headers["PolarisDate"];
+            var expectedHash = ComputePapiHash(request.Method.Method, request.AbsoluteUri, date, password, "access-key");
+            Assert.AreEqual($"PWS access-id:{expectedHash}", request.Headers["Authorization"]);
+        }
+
+        private static string ComputePapiHash(string httpMethod, string uri, string date, string password, string accessKey)
+        {
+            var hashString = httpMethod + uri + date + password;
+            var computedHash = HMACSHA1.HashData(Encoding.UTF8.GetBytes(accessKey), Encoding.UTF8.GetBytes(hashString));
+            return Convert.ToBase64String(computedHash);
+        }
+
+        private sealed class CapturedRequest
+        {
+            public CapturedRequest(HttpRequestMessage request, string body)
+            {
+                Method = request.Method;
+                AbsoluteUri = request.RequestUri!.AbsoluteUri;
+                Path = request.RequestUri.AbsolutePath;
+                Body = body;
+                Headers = request.Headers.ToDictionary(
+                    header => header.Key,
+                    header => string.Join(",", header.Value),
+                    StringComparer.OrdinalIgnoreCase);
+            }
+
+            public HttpMethod Method { get; }
+            public string AbsoluteUri { get; }
+            public string Path { get; }
+            public string Body { get; }
+            public IReadOnlyDictionary<string, string> Headers { get; }
+        }
+
+        private sealed class RecordingHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly List<CapturedRequest> _requests = new();
+
+            public int RequestCount => _requests.Count;
+            public int AuthenticationRequestCount => _requests.Count(request => IsStaffAuthenticationRequest(request));
+
+            public CapturedRequest SingleCustomRequest()
+            {
+                return _requests.Single(request => !IsStaffAuthenticationRequest(request));
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var body = request.Content == null
+                    ? string.Empty
+                    : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                var capturedRequest = new CapturedRequest(request, body);
+                _requests.Add(capturedRequest);
+
+                var responseJson = IsStaffAuthenticationRequest(capturedRequest)
+                    ? "{\"PAPIErrorCode\":0,\"AccessToken\":\"protected-token\",\"AccessSecret\":\"protected-secret\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}"
+                    : "{\"PAPIErrorCode\":0}";
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+                };
+            }
+
+            private static bool IsStaffAuthenticationRequest(CapturedRequest request)
+            {
+                return request.Method == HttpMethod.Post &&
+                    request.Path.EndsWith("/authenticator/staff", StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+}

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -1089,11 +1089,7 @@ namespace Clc.Polaris.Api.Tests
 
         private static async Task ExecuteRawPapiRequestAsync(PapiClient client, PapiRestRequest request)
         {
-            var executePapiAsync = typeof(PapiClient)
-                .GetMethod("ExecutePapiAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
-                .MakeGenericMethod(typeof(PapiResponseCommon));
-            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None })!;
-            await task.ConfigureAwait(false);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request).ConfigureAwait(false);
         }
 
         private static void AssertAuthorizationHashesSentUri(HttpRequestMessage request, string password)


### PR DESCRIPTION
### Motivation
- Provide a guarded escape hatch on `PapiClient` so callers can execute custom/unsupported PAPI endpoints while keeping `IPapiClient` unchanged and preserving existing protected-token and signing behavior.

### Description
- Change `PapiClient.ExecutePapiAsync<T>` from private to public and add XML docs describing its intent, path requirements, and that it runs through the normal `PapiClient` pipeline (protected-token acquisition, `ProtectedToken.Placeholder` replacement, staff override behavior, `PolarisDate`, Authorization signing, and URL construction/path prefix behavior).
- Add `ValidateCustomPapiRequest(PapiRestRequest)` as a private static helper that validates non-null requests and enforces relative PAPI path rules (reject absolute URLs, protocol-relative URLs, missing leading slash, blank path, and enforce `/public/` or `/protected/` for authenticated requests).
- Invoke `ValidateCustomPapiRequest` at the start of `ExecutePapiAsync<T>` and otherwise preserve the existing logic path (call to `EnsureProtectedTokenAsync`, placeholder replacement, and `ExecuteAsync<T>`), without duplicating signing or request construction logic.
- Add unit coverage in `PapiClientCustomExecutionTests.cs` for method visibility, absence from `IPapiClient`, validation-before-send cases, public GET/POST signing, protected token placeholder replacement, staff override behavior and `BlockStaffOverride`, and update existing tests to call the now-public method directly instead of using reflection.

### Testing
- Ran the full test suite with `dotnet test src/polaris-api-csharp.sln --verbosity minimal` and the test run passed: Passed 163, Failed 0, Skipped 69, Total 232.
- New unit tests covering the public API and validation (e.g. `ExecutePapiAsync_IsPublicOnPapiClient`, `ExecutePapiAsync_IsNotPresentOnIPapiClient`, `ExecutePapiAsync_NullRequest_ThrowsBeforeSendingHttpRequest`, `ExecutePapiAsync_BlankPath_ThrowsBeforeSendingHttpRequest`, `ExecutePapiAsync_CustomPublicGet_UsesPapiPipelineAndSignsRequest`, `ExecutePapiAsync_CustomProtectedRequestWithProtectedTokenPlaceholder_AcquiresAndReplacesToken`, `ExecutePapiAsync_CustomPublicRequest_BlockStaffOverridePreventsAccessTokenHeader`) were added and executed as part of the test run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a24d64629f88323aba6a6a0a834f925)