### PR TITLE
Expose ExecutePapiAsync<T> on PapiClient as a guarded escape hatch

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -152,8 +152,25 @@ namespace Clc.Polaris.Api
             public bool HasValidToken => Status == ProtectedTokenAcquisitionStatus.ValidTokenAvailable && IsProtectedTokenUsable(Token);
         }
 
-        private async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// Executes a caller-supplied <see cref="PapiRestRequest"/> through the normal PAPI pipeline as an
+        /// escape hatch for unsupported or custom PAPI endpoints. Callers must pass a PAPI request whose
+        /// path is a relative PAPI path, such as <c>/public/v1/1033/100/1/...</c> or
+        /// <c>/protected/v1/1033/100/1/...</c>. Absolute URLs and protocol-relative URLs are rejected.
+        /// Requests executed by this method still use the standard <see cref="PapiClient"/> processing,
+        /// including protected-token acquisition, <see cref="ProtectedToken.Placeholder"/> replacement,
+        /// staff override behavior, PolarisDate, Authorization signing, and URL construction/path prefix behavior.
+        /// </summary>
+        /// <typeparam name="T">The response data type.</typeparam>
+        /// <param name="request">The custom PAPI request to execute.</param>
+        /// <param name="cancellationToken">A token that can be used to cancel the request.</param>
+        /// <returns>The REST response returned by the PAPI endpoint.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="request"/> has an invalid custom PAPI path.</exception>
+        public async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
         {
+            ValidateCustomPapiRequest(request);
+
             var pathContainsProtectedTokenPlaceholder = RequestPathContainsProtectedTokenPlaceholder(request);
             var requiresProtectedToken = RequiresProtectedToken(request, pathContainsProtectedTokenPlaceholder);
 
@@ -173,6 +190,41 @@ namespace Clc.Polaris.Api
             }
 
             return await ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static void ValidateCustomPapiRequest(PapiRestRequest request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (string.IsNullOrWhiteSpace(request.Path))
+            {
+                throw new ArgumentException("PAPI request path must not be null, empty, or whitespace.", nameof(request));
+            }
+
+            if (request.Path.Contains("://", StringComparison.Ordinal))
+            {
+                throw new ArgumentException("PAPI request path must be a relative path, not an absolute URL.", nameof(request));
+            }
+
+            if (request.Path.StartsWith("//", StringComparison.Ordinal))
+            {
+                throw new ArgumentException("PAPI request path must not be a protocol-relative URL.", nameof(request));
+            }
+
+            if (!request.Path.StartsWith("/", StringComparison.Ordinal))
+            {
+                throw new ArgumentException("PAPI request path must begin with '/'.", nameof(request));
+            }
+
+            if (request.AuthRequired &&
+                !request.Path.StartsWith("/public/", StringComparison.OrdinalIgnoreCase) &&
+                !request.Path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("Authenticated custom PAPI request paths must begin with '/public/' or '/protected/'.", nameof(request));
+            }
         }
 
         private bool RequiresProtectedToken(PapiRestRequest request, bool pathContainsProtectedTokenPlaceholder)

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -198,7 +198,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual("protected-token", response.Data.AccessToken);
             Assert.IsNull(client.Token);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
             var request = handler.CapturedRequests.Single();
             Assert.IsTrue(request.IsStaffAuthenticationRequest);
             Assert.AreEqual("POST", request.Method);
@@ -218,7 +218,7 @@ namespace Clc.Polaris.Api.Tests
             await ExecuteRawPapiRequestAsync(client, request);
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             Assert.AreEqual("route-token", client.Token?.AccessToken);
             var finalRequest = handler.CapturedRequests.Single(capturedRequest => !capturedRequest.IsStaffAuthenticationRequest);
             StringAssert.EndsWith(finalRequest.Path, "/protected/v1/1033/100/1/patron/ABC123/account/outstanding");
@@ -237,7 +237,7 @@ namespace Clc.Polaris.Api.Tests
             await ExecuteRawPapiRequestAsync(client, request);
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             Assert.AreEqual("malformed-token", client.Token?.AccessToken);
             var finalRequest = handler.CapturedRequests.Single(capturedRequest => !capturedRequest.IsStaffAuthenticationRequest);
             StringAssert.EndsWith(finalRequest.Path, "/protected/v1/1033/100/1/authenticator/staff/extra");
@@ -323,7 +323,7 @@ namespace Clc.Polaris.Api.Tests
             await client.ExecutePapiAsync<PapiResponseCommon>(request);
 
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
-            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             var finalRequest = handler.CapturedRequests.Single();
             Assert.AreEqual("GET", finalRequest.Method);
             StringAssert.Contains(finalRequest.Path, "/public/v1/1033/100/1/custom/unsupported");
@@ -343,7 +343,7 @@ namespace Clc.Polaris.Api.Tests
             await client.ExecutePapiAsync<PapiResponseCommon>(request);
 
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
-            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             var finalRequest = handler.CapturedRequests.Single();
             Assert.AreEqual("POST", finalRequest.Method);
             StringAssert.Contains(finalRequest.Body, "custom-body");
@@ -363,7 +363,7 @@ namespace Clc.Polaris.Api.Tests
             await client.ExecutePapiAsync<PapiResponseCommon>(request);
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             var finalRequest = handler.CapturedRequests.Single(capturedRequest => !capturedRequest.IsStaffAuthenticationRequest);
             StringAssert.Contains(finalRequest.Path, "/protected/v1/1033/100/1/custom-placeholder-token/custom/unsupported");
             Assert.IsFalse(finalRequest.Path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
@@ -382,7 +382,7 @@ namespace Clc.Polaris.Api.Tests
             await client.ExecutePapiAsync<PapiResponseCommon>(request);
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             var finalRequest = handler.CapturedRequests.Single(capturedRequest => !capturedRequest.IsStaffAuthenticationRequest);
             Assert.IsTrue(finalRequest.Headers.TryGetValue("X-PAPI-AccessToken", out var accessToken));
             Assert.AreEqual("override-token", accessToken);
@@ -400,7 +400,7 @@ namespace Clc.Polaris.Api.Tests
             await client.ExecutePapiAsync<PapiResponseCommon>(request);
 
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
-            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             var finalRequest = handler.CapturedRequests.Single();
             Assert.IsFalse(finalRequest.Headers.ContainsKey("X-PAPI-AccessToken"));
             AssertAuthorizationHash(finalRequest, string.Empty, client.AccessKey, client.AccessID);
@@ -437,7 +437,7 @@ namespace Clc.Polaris.Api.Tests
             await Task.WhenAll(requests);
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(8, handler.ProtectedRequestCount);
+            Assert.AreEqual(8, handler.NonAuthenticationRequestCount);
             Assert.IsNotNull(client.Token);
             Assert.AreEqual("protected-token", client.Token.AccessToken);
         }
@@ -458,7 +458,7 @@ namespace Clc.Polaris.Api.Tests
             await Task.WhenAll(clients.Select((client, index) => client.PatronSearchAsync($"name=shared-{index}")));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(clients.Length, handler.ProtectedRequestCount);
+            Assert.AreEqual(clients.Length, handler.NonAuthenticationRequestCount);
             Assert.IsTrue(clients.All(client => client.Token?.AccessToken == "shared-token"));
             var finalRequests = handler.CapturedRequests.Where(request => !request.IsStaffAuthenticationRequest).ToArray();
             Assert.AreEqual(clients.Length, finalRequests.Length);
@@ -515,7 +515,7 @@ namespace Clc.Polaris.Api.Tests
                 clients[3].PatronSearchAsync("name=bravo-1"));
 
             Assert.AreEqual(2, handler.AuthenticationRequestCount);
-            Assert.AreEqual(4, handler.ProtectedRequestCount);
+            Assert.AreEqual(4, handler.NonAuthenticationRequestCount);
             Assert.AreEqual("token-for-password-a", clients[0].Token?.AccessToken);
             Assert.AreEqual("token-for-password-b", clients[1].Token?.AccessToken);
             Assert.AreEqual("token-for-password-a", clients[2].Token?.AccessToken);
@@ -531,7 +531,7 @@ namespace Clc.Polaris.Api.Tests
                 passwordBReuseClient.PatronSearchAsync("name=reuse-b"));
 
             Assert.AreEqual(2, handler.AuthenticationRequestCount);
-            Assert.AreEqual(6, handler.ProtectedRequestCount);
+            Assert.AreEqual(6, handler.NonAuthenticationRequestCount);
             Assert.AreEqual("token-for-password-a", passwordAReuseClient.Token?.AccessToken);
             Assert.AreEqual("token-for-password-b", passwordBReuseClient.Token?.AccessToken);
             AssertFinalRequestsUseExpectedToken(handler, "reuse-a", "token-for-password-a", "secret-for-password-a");
@@ -556,7 +556,7 @@ namespace Clc.Polaris.Api.Tests
             await client.PatronSearchAsync("name=Smith");
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             Assert.AreEqual("fresh-token", client.Token?.AccessToken);
             var finalRequest = handler.CapturedRequests.Single(request => !request.IsStaffAuthenticationRequest);
             StringAssert.Contains(finalRequest.Path, "/protected/v1/1033/100/1/fresh-token/search/patrons/Boolean");
@@ -582,7 +582,7 @@ namespace Clc.Polaris.Api.Tests
             await client.PatronSearchAsync("name=Smith");
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             Assert.AreEqual("new-protected-token", client.Token?.AccessToken);
             var finalRequest = handler.CapturedRequests.Single(request => !request.IsStaffAuthenticationRequest);
             StringAssert.Contains(finalRequest.Path, "/protected/v1/1033/100/1/new-protected-token/search/patrons/Boolean");
@@ -627,7 +627,7 @@ namespace Clc.Polaris.Api.Tests
             await client.PatronSearchAsync("name=Smith");
 
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
-            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             Assert.AreEqual("cached-token", client.Token?.AccessToken);
         }
 
@@ -765,7 +765,7 @@ namespace Clc.Polaris.Api.Tests
             await client.PatronSearchAsync("name=Smith");
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             Assert.AreEqual("new-token", client.Token?.AccessToken);
             Assert.AreNotEqual(" ", client.Token?.AccessToken);
             Assert.IsTrue(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out var cachedToken));
@@ -790,7 +790,7 @@ namespace Clc.Polaris.Api.Tests
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
             Assert.IsNull(client.Token);
         }
@@ -830,7 +830,7 @@ namespace Clc.Polaris.Api.Tests
             await clientA.PatronSearchAsync("name=Smith");
 
             Assert.AreEqual(1, handlerA.AuthenticationRequestCount);
-            Assert.AreEqual(1, handlerA.ProtectedRequestCount);
+            Assert.AreEqual(1, handlerA.NonAuthenticationRequestCount);
             Assert.AreEqual("token-a", clientA.Token?.AccessToken);
             Assert.IsTrue(TryGetCachedToken(hostname, "access-a", clientA.AccessKey, staff, out var cachedTokenA));
             Assert.IsNotNull(cachedTokenA);
@@ -847,7 +847,7 @@ namespace Clc.Polaris.Api.Tests
             await clientB.PatronSearchAsync("name=Jones");
 
             Assert.AreEqual(1, handlerB.AuthenticationRequestCount);
-            Assert.AreEqual(1, handlerB.ProtectedRequestCount);
+            Assert.AreEqual(1, handlerB.NonAuthenticationRequestCount);
             Assert.AreEqual("token-b", clientB.Token?.AccessToken);
             Assert.IsTrue(TryGetCachedToken(hostname, "access-b", clientB.AccessKey, staff, out var cachedTokenB));
             Assert.IsNotNull(cachedTokenB);
@@ -867,7 +867,7 @@ namespace Clc.Polaris.Api.Tests
             await client.PatronSearchAsync("name=Smith");
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             Assert.IsNotNull(client.Token);
             Assert.AreEqual("protected-token", client.Token.AccessToken);
             var paths = handler.RequestPaths;
@@ -889,7 +889,7 @@ namespace Clc.Polaris.Api.Tests
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
@@ -903,7 +903,7 @@ namespace Clc.Polaris.Api.Tests
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
@@ -923,7 +923,7 @@ namespace Clc.Polaris.Api.Tests
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
@@ -943,7 +943,7 @@ namespace Clc.Polaris.Api.Tests
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
@@ -966,7 +966,7 @@ namespace Clc.Polaris.Api.Tests
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
@@ -981,7 +981,7 @@ namespace Clc.Polaris.Api.Tests
 
             StringAssert.Contains(exception.Message, "Staff authentication did not succeed");
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
         }
 
         [TestMethod]
@@ -994,7 +994,7 @@ namespace Clc.Polaris.Api.Tests
 
             StringAssert.Contains(exception.Message, "did not return a usable protected access token");
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
         }
 
         [TestMethod]
@@ -1008,7 +1008,7 @@ namespace Clc.Polaris.Api.Tests
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
         }
 
         [TestMethod]
@@ -1022,7 +1022,7 @@ namespace Clc.Polaris.Api.Tests
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
         }
 
         [TestMethod]
@@ -1036,7 +1036,7 @@ namespace Clc.Polaris.Api.Tests
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
         }
 
         [TestMethod]
@@ -1060,7 +1060,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsFalse(exception.Message.Contains(returnedToken.AccessToken, StringComparison.Ordinal));
             Assert.IsFalse(exception.Message.Contains(returnedToken.AccessSecret, StringComparison.Ordinal));
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
             Assert.IsFalse(handler.RequestPaths.Any(path => path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal)));
         }
 
@@ -1074,7 +1074,7 @@ namespace Clc.Polaris.Api.Tests
 
             StringAssert.Contains(exception.Message, "Staff authentication did not succeed");
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
         }
 
         [TestMethod]
@@ -1089,7 +1089,7 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.IsNotNull(response);
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
-            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             StringAssert.Contains(handler.RequestPaths.Single(), "/public/v1/1033/100/1/patron/ABC123/account/outstanding");
         }
 
@@ -1103,7 +1103,7 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.IsNotNull(response);
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
-            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             StringAssert.Contains(handler.RequestPaths.Single(), "/public/v1/1033/100/1/patron/ABC123/account/outstanding");
         }
 
@@ -1124,7 +1124,7 @@ namespace Clc.Polaris.Api.Tests
             }
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(0, handler.ProtectedRequestCount);
+            Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
         }
 
 
@@ -1395,12 +1395,12 @@ namespace Clc.Polaris.Api.Tests
             private readonly string _authenticationResponseJson;
             private readonly Func<CapturedPapiRequest, (HttpStatusCode StatusCode, string ResponseJson)>? _authenticationResponseFactory;
             private int _authenticationRequestCount;
-            private int _protectedRequestCount;
+            private int _nonAuthenticationRequestCount;
             private readonly ConcurrentQueue<string> _requestPaths = new ConcurrentQueue<string>();
             private readonly ConcurrentQueue<CapturedPapiRequest> _capturedRequests = new ConcurrentQueue<CapturedPapiRequest>();
 
             public int AuthenticationRequestCount => _authenticationRequestCount;
-            public int ProtectedRequestCount => _protectedRequestCount;
+            public int NonAuthenticationRequestCount => _nonAuthenticationRequestCount;
             public string[] RequestPaths => _requestPaths.ToArray();
             public CapturedPapiRequest[] CapturedRequests => _capturedRequests.ToArray();
 
@@ -1434,7 +1434,7 @@ namespace Clc.Polaris.Api.Tests
                     };
                 }
 
-                Interlocked.Increment(ref _protectedRequestCount);
+                Interlocked.Increment(ref _nonAuthenticationRequestCount);
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -245,6 +245,168 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod]
+        public void ExecutePapiAsync_IsPublicOnPapiClientOnly()
+        {
+            var papiClientMethod = typeof(PapiClient)
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                .SingleOrDefault(method => method.Name == nameof(PapiClient.ExecutePapiAsync) && method.IsGenericMethodDefinition);
+            var interfaceMethod = typeof(IPapiClient)
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                .SingleOrDefault(method => method.Name == nameof(PapiClient.ExecutePapiAsync));
+
+            Assert.IsNotNull(papiClientMethod);
+            Assert.IsNull(interfaceMethod);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_NullRequest_ThrowsBeforeSendingHttpRequest()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => client.ExecutePapiAsync<PapiResponseCommon>(null!));
+
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("   ")]
+        public async Task ExecutePapiAsync_NullEmptyOrWhitespacePath_ThrowsBeforeSendingHttpRequest(string? path)
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/custom");
+            request.Path = path!;
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() => client.ExecutePapiAsync<PapiResponseCommon>(request));
+
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        [DataRow("https://example.com/PAPIService/REST/public/v1/1033/100/1/custom")]
+        [DataRow("//example.com/foo")]
+        [DataRow("public/v1/1033/100/1/custom")]
+        public async Task ExecutePapiAsync_InvalidCustomPath_ThrowsBeforeSendingHttpRequest(string path)
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get(path);
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() => client.ExecutePapiAsync<PapiResponseCommon>(request));
+
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_AuthenticatedPathOutsidePublicOrProtected_ThrowsBeforeSendingHttpRequest()
+        {
+            var handler = new CapturingHttpMessageHandler();
+            var client = CreateClient(handler);
+            var request = PapiRestRequest.Get("/other/v1/1033/100/1/custom");
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() => client.ExecutePapiAsync<PapiResponseCommon>(request));
+
+            Assert.AreEqual(0, handler.RequestCount);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_CustomPublicGet_SendsThroughPapiPipelineWithDateAndAuthorizationHeaders()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateProtectedClient(handler);
+            client.StaffOverrideAccount = null;
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/custom/unsupported");
+
+            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            Assert.AreEqual(0, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            var finalRequest = handler.CapturedRequests.Single();
+            Assert.AreEqual("GET", finalRequest.Method);
+            StringAssert.Contains(finalRequest.Path, "/public/v1/1033/100/1/custom/unsupported");
+            AssertAuthorizationHash(finalRequest, string.Empty, client.AccessKey, client.AccessID);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_CustomPublicPost_SerializesBodyAndSignsRequest()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateProtectedClient(handler);
+            client.StaffOverrideAccount = null;
+            var request = PapiRestRequest.Post(
+                "/public/v1/1033/100/1/custom/unsupported",
+                body: new { Message = "custom-body", Count = 3 });
+
+            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            Assert.AreEqual(0, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            var finalRequest = handler.CapturedRequests.Single();
+            Assert.AreEqual("POST", finalRequest.Method);
+            StringAssert.Contains(finalRequest.Body, "custom-body");
+            StringAssert.Contains(finalRequest.Body, "3");
+            AssertAuthorizationHash(finalRequest, string.Empty, client.AccessKey, client.AccessID);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_CustomProtectedRequestWithPlaceholder_AcquiresAndReplacesProtectedToken()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("custom-placeholder-token", "custom-placeholder-secret", DateTime.Now.AddHours(1)));
+            var client = CreateProtectedClient(handler);
+            var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
+
+            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            var finalRequest = handler.CapturedRequests.Single(capturedRequest => !capturedRequest.IsStaffAuthenticationRequest);
+            StringAssert.Contains(finalRequest.Path, "/protected/v1/1033/100/1/custom-placeholder-token/custom/unsupported");
+            Assert.IsFalse(finalRequest.Path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
+            AssertAuthorizationHash(finalRequest, "custom-placeholder-secret", client.AccessKey, client.AccessID);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_CustomPublicRequest_UsesStaffOverrideTokenWhenAllowed()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("override-token", "override-secret", DateTime.Now.AddHours(1)));
+            var client = CreateProtectedClient(handler);
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/custom/unsupported");
+
+            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            var finalRequest = handler.CapturedRequests.Single(capturedRequest => !capturedRequest.IsStaffAuthenticationRequest);
+            Assert.IsTrue(finalRequest.Headers.TryGetValue("X-PAPI-AccessToken", out var accessToken));
+            Assert.AreEqual("override-token", accessToken);
+            AssertAuthorizationHash(finalRequest, "override-secret", client.AccessKey, client.AccessID);
+        }
+
+        [TestMethod]
+        public async Task ExecutePapiAsync_CustomPublicRequestWithBlockStaffOverride_DoesNotSendStaffOverrideToken()
+        {
+            var handler = new ProtectedTokenHttpMessageHandler();
+            var client = CreateProtectedClient(handler);
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/custom/unsupported");
+            request.BlockStaffOverride = true;
+
+            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            Assert.AreEqual(0, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.ProtectedRequestCount);
+            var finalRequest = handler.CapturedRequests.Single();
+            Assert.IsFalse(finalRequest.Headers.ContainsKey("X-PAPI-AccessToken"));
+            AssertAuthorizationHash(finalRequest, string.Empty, client.AccessKey, client.AccessID);
+        }
+
+        [TestMethod]
         public void IsStaffAuthenticatorRequest_InvalidOrMissingPath_ReturnsFalse()
         {
             Assert.IsFalse(InvokeIsStaffAuthenticatorRequest(null));
@@ -1057,12 +1219,7 @@ namespace Clc.Polaris.Api.Tests
 
         private static async Task ExecuteRawPapiRequestAsync(PapiClient client, PapiRestRequest request)
         {
-            var executePapiAsync = typeof(PapiClient)
-                .GetMethod("ExecutePapiAsync", BindingFlags.Instance | BindingFlags.NonPublic)!
-                .MakeGenericMethod(typeof(PapiResponseCommon));
-
-            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None })!;
-            await task.ConfigureAwait(false);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request).ConfigureAwait(false);
         }
 
         private static bool InvokeIsStaffAuthenticatorRequest(PapiRestRequest? request)

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -1089,11 +1089,7 @@ namespace Clc.Polaris.Api.Tests
 
         private static async Task ExecuteRawPapiRequestAsync(PapiClient client, PapiRestRequest request)
         {
-            var executePapiAsync = typeof(PapiClient)
-                .GetMethod("ExecutePapiAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
-                .MakeGenericMethod(typeof(PapiResponseCommon));
-            var task = (Task)executePapiAsync.Invoke(client, new object[] { request, CancellationToken.None })!;
-            await task.ConfigureAwait(false);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request).ConfigureAwait(false);
         }
 
         private static void AssertAuthorizationHashesSentUri(HttpRequestMessage request, string password)


### PR DESCRIPTION
### Motivation
- Allow callers to execute custom/unsupported PAPI endpoints by exposing `ExecutePapiAsync<T>` on `PapiClient` without changing `IPapiClient`.
- Prevent misuse by validating caller-supplied `PapiRestRequest` paths early and rejecting absolute/protocol-relative URLs or otherwise-invalid paths.
- Preserve the existing PAPI pipeline behavior (protected-token acquisition, `ProtectedToken.Placeholder` replacement, staff override behavior, `PolarisDate`, signing, and URL construction). 

### Description
- Changed `PapiClient.ExecutePapiAsync<T>` from private to public and added XML documentation describing it as an escape hatch and enumerating accepted relative paths and pipeline behaviors. (`src/polaris-api-csharp/PapiClient.cs`)
- Added `ValidateCustomPapiRequest(PapiRestRequest)` as a private static guard that throws `ArgumentNullException` or `ArgumentException` for null requests, null/empty/whitespace `Path`, absolute URLs (`://`), protocol-relative URLs (`//`), missing leading `/`, and authenticated custom paths not starting with `/public/` or `/protected/`.
- Kept the existing execution flow intact: validation now runs before the existing logic that checks/replaces `ProtectedToken.Placeholder`, acquires protected tokens, and delegates to `ExecuteAsync<T>` (no signing, preformatting, or token logic duplicated or bypassed).
- Updated tests and test helpers to exercise the new public surface and validation: added tests that assert the method is public on `PapiClient` but not present on `IPapiClient`, that invalid requests throw before any HTTP request is made, and that valid custom GET/POST/protected requests flow through the normal PAPI pipeline (including staff override and placeholder replacement). Also replaced prior reflection-based invocations with direct calls to the now-public method. (files under `src/polaris-api-csharpTests/`)

### Testing
- Ran the unit test suite with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --no-restore` and `dotnet test src/polaris-api-csharp.sln --no-restore`; all tests passed (`Passed: 162, Failed: 0, Skipped: 69, Total: 231`).
- Verified new/modified tests cover visibility, validation-before-send, public GET/POST signing behavior, protected placeholder acquisition/replacement, staff-override behavior, and `BlockStaffOverride` behavior; these tests passed as part of the suite run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a24d64629f88323aba6a6a0a834f925)