### PR TITLE
Extract shared PAPI signature helper and remove duplicated test signing logic

### DIFF
--- a/src/polaris-api-csharp/AssemblyInfo.cs
+++ b/src/polaris-api-csharp/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Clc.Polaris.Api.Tests")]

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -122,7 +122,7 @@ namespace Clc.Polaris.Api
 
                 var date = DateTime.Now.ToUniversalTime().ToString("R");
                 var requestUri = BuildRequestUri(papiRequest);
-                var hash = GetPAPIHash(papiRequest.Method.ToString(), date, requestUri.AbsoluteUri, password);
+                var hash = PapiSignature.ComputeHash(AccessKey, papiRequest.Method.ToString(), requestUri.AbsoluteUri, date, password);
                 papiRequest.Headers["PolarisDate"] = date;
                 papiRequest.Headers["Authorization"] = string.Format("PWS {0}:{1}", AccessID, hash);
             }
@@ -453,14 +453,6 @@ namespace Clc.Polaris.Api
             }
 
             _token = null;
-        }
-
-        private string GetPAPIHash(string httpMethod, string date, string uri, string password)
-        {
-            var hashString = httpMethod + uri + date + password;
-            using var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(AccessKey));
-            byte[] computedHash = hmac.ComputeHash(Encoding.UTF8.GetBytes(hashString));
-            return Convert.ToBase64String(computedHash);
         }
     }
 }

--- a/src/polaris-api-csharp/PapiSignature.cs
+++ b/src/polaris-api-csharp/PapiSignature.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Clc.Polaris.Api
+{
+    internal static class PapiSignature
+    {
+        internal static string ComputeHash(
+            string accessKey,
+            string httpMethod,
+            string uri,
+            string date,
+            string password)
+        {
+            var hashString = httpMethod + uri + date + password;
+
+            using var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(accessKey));
+            var computedHash = hmac.ComputeHash(Encoding.UTF8.GetBytes(hashString));
+
+            return Convert.ToBase64String(computedHash);
+        }
+    }
+}

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -4,9 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Reflection;
-using System.Security.Cryptography;
 using System.Text;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Clc.Polaris.Api;
@@ -1145,8 +1144,8 @@ namespace Clc.Polaris.Api.Tests
 
             var date = formatted.Headers["PolarisDate"].ToString();
             var uri = client.BuildRequestUri(formatted).AbsoluteUri;
-            Assert.AreEqual($"PWS access-id:{ComputePapiHash("GET", uri, date, string.Empty, "access-key")}", formatted.Headers["Authorization"]);
-            Assert.AreNotEqual($"PWS access-id:{ComputePapiHash("GET", uri, date, "expired-secret", "access-key")}", formatted.Headers["Authorization"]);
+            Assert.AreEqual($"PWS access-id:{PapiSignature.ComputeHash("access-key", "GET", uri, date, string.Empty)}", formatted.Headers["Authorization"]);
+            Assert.AreNotEqual($"PWS access-id:{PapiSignature.ComputeHash("access-key", "GET", uri, date, "expired-secret")}", formatted.Headers["Authorization"]);
             Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
             Assert.IsNull(client.Token);
         }
@@ -1171,8 +1170,8 @@ namespace Clc.Polaris.Api.Tests
             var date = formatted.Headers["PolarisDate"].ToString();
             var uri = client.BuildRequestUri(formatted).AbsoluteUri;
             var authorization = formatted.Headers["Authorization"];
-            Assert.AreEqual($"PWS access-id:{ComputePapiHash("GET", uri, date, string.Empty, "access-key")}", authorization);
-            Assert.AreNotEqual($"PWS access-id:{ComputePapiHash("GET", uri, date, "expired-secret", "access-key")}", authorization);
+            Assert.AreEqual($"PWS access-id:{PapiSignature.ComputeHash("access-key", "GET", uri, date, string.Empty)}", authorization);
+            Assert.AreNotEqual($"PWS access-id:{PapiSignature.ComputeHash("access-key", "GET", uri, date, "expired-secret")}", authorization);
             Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
             Assert.IsNull(client.Token);
         }
@@ -1324,21 +1323,14 @@ namespace Clc.Polaris.Api.Tests
         {
             Assert.IsTrue(request.Headers.TryGetValue("PolarisDate", out var date), "The request did not include a PolarisDate header.");
             Assert.IsTrue(request.Headers.TryGetValue("Authorization", out var authorization), "The request did not include an Authorization header.");
-            Assert.AreEqual($"PWS {accessId}:{ComputePapiHash(request.Method, absoluteUri ?? request.AbsoluteUri, date, secret, accessKey)}", authorization);
+            Assert.AreEqual($"PWS {accessId}:{PapiSignature.ComputeHash(accessKey, request.Method, absoluteUri ?? request.AbsoluteUri, date, secret)}", authorization);
         }
 
         private static void AssertAuthorizationHashDoesNotMatch(CapturedPapiRequest request, string secret, string accessKey, string accessId, string? absoluteUri = null)
         {
             Assert.IsTrue(request.Headers.TryGetValue("PolarisDate", out var date), "The request did not include a PolarisDate header.");
             Assert.IsTrue(request.Headers.TryGetValue("Authorization", out var authorization), "The request did not include an Authorization header.");
-            Assert.AreNotEqual($"PWS {accessId}:{ComputePapiHash(request.Method, absoluteUri ?? request.AbsoluteUri, date, secret, accessKey)}", authorization);
-        }
-
-        private static string ComputePapiHash(string httpMethod, string uri, string date, string password, string accessKey)
-        {
-            var hashString = httpMethod + uri + date + password;
-            var computedHash = HMACSHA1.HashData(Encoding.UTF8.GetBytes(accessKey), Encoding.UTF8.GetBytes(hashString));
-            return Convert.ToBase64String(computedHash);
+            Assert.AreNotEqual($"PWS {accessId}:{PapiSignature.ComputeHash(accessKey, request.Method, absoluteUri ?? request.AbsoluteUri, date, secret)}", authorization);
         }
 
         private sealed class CapturingHttpMessageHandler : HttpMessageHandler

--- a/src/polaris-api-csharpTests/PapiSignatureTests.cs
+++ b/src/polaris-api-csharpTests/PapiSignatureTests.cs
@@ -1,0 +1,22 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Clc.Polaris.Api.Tests
+{
+    [TestClass]
+    [TestCategory("Unit")]
+    public class PapiSignatureTests
+    {
+        [TestMethod]
+        public void ComputeHash_ReturnsExpectedPapiSignature_ForKnownVector()
+        {
+            var hash = PapiSignature.ComputeHash(
+                "access-key",
+                "GET",
+                "https://example.test/PAPIService/REST/public/v1/1033/100/1/custom",
+                "Mon, 01 Jan 2024 00:00:00 GMT",
+                string.Empty);
+
+            Assert.AreEqual("6s8zdodfxSEnTlU6LUU+P8nSb9s=", hash);
+        }
+    }
+}

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -103,7 +102,7 @@ namespace Clc.Polaris.Api.Tests
 
             var date = formatted.Headers["PolarisDate"];
             var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate";
-            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
+            var expectedHash = PapiSignature.ComputeHash("access-key", "GET", expectedUri, date, string.Empty);
             Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
             Assert.AreSame(request.Body, formatted.Body);
         }
@@ -124,7 +123,7 @@ namespace Clc.Polaris.Api.Tests
 
             var date = formatted.Headers["PolarisDate"];
             var expectedUri = "https://example.test/PAPIService/REST/protected/v1/1033/100/1/protected-token/search/patrons/Boolean";
-            var expectedHash = ComputePapiHash("GET", expectedUri, date, "protected-secret", "access-key");
+            var expectedHash = PapiSignature.ComputeHash("access-key", "GET", expectedUri, date, "protected-secret");
             Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
             Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
         }
@@ -141,7 +140,7 @@ namespace Clc.Polaris.Api.Tests
 
             var date = formatted.Headers["PolarisDate"];
             var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&limit=branch%3A1";
-            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
+            var expectedHash = PapiSignature.ComputeHash("access-key", "GET", expectedUri, date, string.Empty);
             Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
         }
 
@@ -157,7 +156,7 @@ namespace Clc.Polaris.Api.Tests
 
             var date = formatted.Headers["PolarisDate"];
             var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/patron/ABC123?ignoresa=True";
-            var expectedHash = ComputePapiHash("PUT", expectedUri, date, "1234", "access-key");
+            var expectedHash = PapiSignature.ComputeHash("access-key", "PUT", expectedUri, date, "1234");
             Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
             Assert.AreSame(body, formatted.Body);
         }
@@ -175,7 +174,7 @@ namespace Clc.Polaris.Api.Tests
 
             var date = formatted.Headers["PolarisDate"];
             var expectedUri = "https://example.test/PAPIService/REST/protected/v1/1033/100/1/token/patron/123/account/payment?wsid=7&userid=8";
-            var expectedHash = ComputePapiHash("POST", expectedUri, date, "protected-secret", "access-key");
+            var expectedHash = PapiSignature.ComputeHash("access-key", "POST", expectedUri, date, "protected-secret");
             Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
             Assert.AreSame(body, formatted.Body);
         }
@@ -199,7 +198,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual("staff-token", formatted.Headers["X-PAPI-AccessToken"]);
             var date = formatted.Headers["PolarisDate"];
             var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate";
-            var expectedHash = ComputePapiHash("GET", expectedUri, date, "staff-secret", "access-key");
+            var expectedHash = PapiSignature.ComputeHash("access-key", "GET", expectedUri, date, "staff-secret");
             Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
         }
 
@@ -224,7 +223,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
             var date = formatted.Headers["PolarisDate"];
             var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate";
-            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
+            var expectedHash = PapiSignature.ComputeHash("access-key", "GET", expectedUri, date, string.Empty);
             Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
         }
 
@@ -246,7 +245,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsFalse(formatted.Headers.ContainsKey("X-PAPI-AccessToken"));
             var date = formatted.Headers["PolarisDate"];
             var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate";
-            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
+            var expectedHash = PapiSignature.ComputeHash("access-key", "GET", expectedUri, date, string.Empty);
             Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
         }
 
@@ -273,7 +272,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsFalse(second.Headers.ContainsKey("X-PAPI-AccessToken"));
             var date = second.Headers["PolarisDate"];
             var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/apikeyvalidate";
-            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
+            var expectedHash = PapiSignature.ComputeHash("access-key", "GET", expectedUri, date, string.Empty);
             Assert.AreEqual($"PWS access-id:{expectedHash}", second.Headers["Authorization"]);
         }
 
@@ -298,7 +297,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual(1, second.Headers.Keys.Count(key => key == "Authorization"));
             var date = second.Headers["PolarisDate"];
             var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/patron/ABC123?ignoresa=False";
-            var expectedHash = ComputePapiHash("PUT", expectedUri, date, "1234", "access-key");
+            var expectedHash = PapiSignature.ComputeHash("access-key", "PUT", expectedUri, date, "1234");
             Assert.AreEqual($"PWS access-id:{expectedHash}", second.Headers["Authorization"]);
         }
 
@@ -316,8 +315,8 @@ namespace Clc.Polaris.Api.Tests
 
             var firstDate = firstFormatted.Headers["PolarisDate"];
             var secondDate = secondFormatted.Headers["PolarisDate"];
-            var firstExpectedHash = ComputePapiHash("GET", "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter", firstDate, string.Empty, "access-key");
-            var secondExpectedHash = ComputePapiHash("GET", "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=lord%20of%20the%20rings", secondDate, string.Empty, "access-key");
+            var firstExpectedHash = PapiSignature.ComputeHash("access-key", "GET", "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter", firstDate, string.Empty);
+            var secondExpectedHash = PapiSignature.ComputeHash("access-key", "GET", "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=lord%20of%20the%20rings", secondDate, string.Empty);
             Assert.AreEqual($"PWS access-id:{firstExpectedHash}", firstFormatted.Headers["Authorization"]);
             Assert.AreEqual($"PWS access-id:{secondExpectedHash}", secondFormatted.Headers["Authorization"]);
             Assert.AreNotEqual(firstFormatted.Headers["Authorization"], secondFormatted.Headers["Authorization"]);
@@ -408,9 +407,9 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsNotNull(handler.LastRequest);
             var date = handler.LastRequest!.Headers.GetValues("PolarisDate").Single();
             var expectedUri = "https://example.test/PAPIService/REST/protected/v1/1033/100/9/hash-token/search/patrons/Boolean?q=name%3DSmith&patronsperpage=10&page=1&sort=PATN";
-            var expectedHash = ComputePapiHash("GET", expectedUri, date, "hash-secret", "access-key");
+            var expectedHash = PapiSignature.ComputeHash("access-key", "GET", expectedUri, date, "hash-secret");
             var placeholderUri = expectedUri.Replace("hash-token", ProtectedToken.Placeholder, StringComparison.Ordinal);
-            var placeholderHash = ComputePapiHash("GET", placeholderUri, date, "hash-secret", "access-key");
+            var placeholderHash = PapiSignature.ComputeHash("access-key", "GET", placeholderUri, date, "hash-secret");
             Assert.AreEqual($"PWS access-id:{expectedHash}", handler.LastRequest.Headers.GetValues("Authorization").Single());
             Assert.AreNotEqual($"PWS access-id:{placeholderHash}", handler.LastRequest.Headers.GetValues("Authorization").Single());
         }
@@ -1056,7 +1055,7 @@ namespace Clc.Polaris.Api.Tests
 
             var date = formatted.Headers["PolarisDate"].ToString();
             var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone";
-            var expectedHash = ComputePapiHash("GET", expectedUri, date, string.Empty, "access-key");
+            var expectedHash = PapiSignature.ComputeHash("access-key", "GET", expectedUri, date, string.Empty);
             Assert.AreEqual($"PWS access-id:{expectedHash}", formatted.Headers["Authorization"]);
         }
 
@@ -1095,7 +1094,7 @@ namespace Clc.Polaris.Api.Tests
         private static void AssertAuthorizationHashesSentUri(HttpRequestMessage request, string password)
         {
             var date = request.Headers.GetValues("PolarisDate").Single();
-            var expectedHash = ComputePapiHash(request.Method.Method, request.RequestUri!.AbsoluteUri, date, password, "access-key");
+            var expectedHash = PapiSignature.ComputeHash("access-key", request.Method.Method, request.RequestUri!.AbsoluteUri, date, password);
             Assert.AreEqual($"PWS access-id:{expectedHash}", request.Headers.GetValues("Authorization").Single());
         }
 
@@ -1106,13 +1105,6 @@ namespace Clc.Polaris.Api.Tests
                 .Split('&', StringSplitOptions.RemoveEmptyEntries)
                 .Select(part => part.Split('=', 2))
                 .ToDictionary(parts => WebUtility.UrlDecode(parts[0]), parts => parts.Length > 1 ? WebUtility.UrlDecode(parts[1]) : string.Empty);
-        }
-
-        private static string ComputePapiHash(string httpMethod, string uri, string date, string password, string accessKey)
-        {
-            var hashString = httpMethod + uri + date + password;
-            var computedHash = HMACSHA1.HashData(Encoding.UTF8.GetBytes(accessKey), Encoding.UTF8.GetBytes(hashString));
-            return Convert.ToBase64String(computedHash);
         }
 
         private sealed class TestPapiSettings : IPapiSettings


### PR DESCRIPTION
### Motivation
- Remove duplicated PAPI HMAC-SHA1 signing logic from characterization and token tests and reuse the production implementation to ensure consistency.
- Make the signing helper available to the test assembly without changing any public API or signing behavior.

### Description
- Add an internal `PapiSignature` helper with `ComputeHash(string accessKey, string httpMethod, string uri, string date, string password)` that performs the PAPI HMAC-SHA1 base64 signature using the production `HMACSHA1` pattern (`src/polaris-api-csharp/PapiSignature.cs`).
- Update `PapiClient` to call `PapiSignature.ComputeHash` for Authorization header signing and remove the old private `GetPAPIHash` implementation (`src/polaris-api-csharp/PapiClient.cs`).
- Expose internals to the test assembly by adding `[assembly: InternalsVisibleTo("Clc.Polaris.Api.Tests")]` (`src/polaris-api-csharp/AssemblyInfo.cs`).
- Replace duplicated `ComputePapiHash` implementations in characterization and token tests with calls to `PapiSignature.ComputeHash` and remove the local helper implementations (`src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs`, `src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs`).
- Add a focused test-vector unit test that asserts a hard-coded expected hash for fixed inputs to validate `PapiSignature.ComputeHash` (`src/polaris-api-csharpTests/PapiSignatureTests.cs`).

### Testing
- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj` and all tests passed (Passed: 163, Failed: 0, Skipped: 69, Total: 232). 
- Searched the test tree for remaining duplicated signing logic with ripgrep and confirmed no remaining `ComputePapiHash`/HMAC implementations in the test project. 
- Ran `git diff --check` to verify no whitespace or merge issues were introduced and found none.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a24da9f9edc8323b8e99314b2c7a634)