### PR TITLE
Use custom MSTest category attributes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
           dotnet test "$TEST_PROJECT" \
             --configuration "$CONFIGURATION" \
             --no-build \
-            --filter "TestCategory!=Integration" \
+            --filter "TestCategory=Unit" \
             --logger "trx;LogFileName=unit-tests.trx" \
             --results-directory "$TEST_RESULTS_DIR"
 

--- a/README.md
+++ b/README.md
@@ -63,46 +63,46 @@ Protected-token-in-path endpoints use `ProtectedToken.Placeholder` internally. M
 
 ## Local tests
 
-Run non-live/unit tests from the repository root:
+Run unit tests from the repository root:
 
 ```bash
-dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory!=Integration"
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Unit"
 ```
 
 Integration tests require a live Polaris dev environment plus local dev credentials and test data in `src/polaris-api-csharpTests/appsettings.Test.json`, so they are not run by default in CI. Keep this file local only: do not commit real secrets, and remember that `appsettings.Test.json` is ignored by git.
 
-The live-test categories are:
+The live-test categories are intentionally mutually exclusive so each live test appears under exactly one trait in Visual Studio Test Explorer:
 
-- `Integration`: any test that requires a live Polaris/API environment.
 - `ReadOnlyIntegration`: live test that only reads/returns data and does not mutate Polaris state.
-- `ProtectedIntegration`: live test that requires staff/protected credentials.
+- `ProtectedReadOnlyIntegration`: read-only live test that requires staff/protected credentials.
 - `MutatingIntegration`: live test that creates, updates, cancels, deletes, clears, pays, voids, moves, renews, submits, or otherwise changes Polaris state.
+- `ProtectedMutatingIntegration`: mutating live test that requires staff/protected credentials.
 
 Run read-only integration tests that do not require staff credentials when you have local Polaris dev settings configured:
-
-```bash
-dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ReadOnlyIntegration&TestCategory!=ProtectedIntegration"
-```
-
-Run protected read-only integration tests only when `PapiSettings.PolarisOverrideAccount` is configured with staff override credentials:
-
-```bash
-dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ReadOnlyIntegration&TestCategory=ProtectedIntegration"
-```
-
-Run all read-only integration tests when both standard and staff/protected local credentials are available:
 
 ```bash
 dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ReadOnlyIntegration"
 ```
 
+Run protected read-only integration tests only when `PapiSettings.PolarisOverrideAccount` is configured with staff override credentials:
+
+```bash
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ProtectedReadOnlyIntegration"
+```
+
+Run all read-only integration tests when both standard and staff/protected local credentials are available:
+
+```bash
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ReadOnlyIntegration|TestCategory=ProtectedReadOnlyIntegration"
+```
+
 Run mutating/destructive integration tests only against a disposable Polaris dev environment that is refreshed nightly or otherwise safe to dirty:
 
 ```bash
-dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=MutatingIntegration"
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=MutatingIntegration|TestCategory=ProtectedMutatingIntegration"
 ```
 
-`MutatingIntegration` tests may create or modify patron blocks, title lists, account entries, record-set entries, notes, or similar artifacts in Polaris. These artifacts may be left behind; cleanup is not guaranteed. Same-day collision avoidance is handled by unique test names and notes, not by assuming prior artifacts were removed.
+`MutatingIntegration` and `ProtectedMutatingIntegration` tests may create or modify patron blocks, title lists, account entries, record-set entries, notes, or similar artifacts in Polaris. These artifacts may be left behind; cleanup is not guaranteed. Same-day collision avoidance is handled by unique test names and notes, not by assuming prior artifacts were removed.
 
 A local `appsettings.Test.json` follows this shape:
 

--- a/src/polaris-api-csharpTests/Methods/AuthenticatePatronTests.cs
+++ b/src/polaris-api-csharpTests/Methods/AuthenticatePatronTests.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Clc.Polaris.Api.Tests
 {
     [TestClass]
-    [TestCategory("Unit")]
+    [UnitCategory]
     public class AuthenticatePatronTests
     {
         private sealed class CaptureHttpMessageHandler : HttpMessageHandler

--- a/src/polaris-api-csharpTests/Methods/PapiClientTestCategoryTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTestCategoryTests.cs
@@ -6,63 +6,36 @@ using System.Text.RegularExpressions;
 namespace Clc.Polaris.Api.Tests
 {
     [TestClass]
-    [TestCategory("Unit")]
+    [UnitCategory]
     public class PapiClientTestCategoryTests
     {
-        private const string IntegrationCategory = "Integration";
-        private const string ReadOnlyIntegrationCategory = "ReadOnlyIntegration";
-        private const string ProtectedIntegrationCategory = "ProtectedIntegration";
-        private const string MutatingIntegrationCategory = "MutatingIntegration";
+        private const string LegacyIntegrationCategory = "Integration";
+        private const string LegacyProtectedIntegrationCategory = "ProtectedIntegration";
 
-        private static readonly string[] KnownReadOnlyIntegrationTests =
+        private static readonly string[] IntegrationCategories =
         {
-            nameof(PapiClientTests.ApiKeyValidateTest),
-            nameof(PapiClientTests.ApiVersionGetTest),
-            nameof(PapiClientTests.BibGetTest),
-            nameof(PapiClientTests.BibGetTest_PassBranchId),
-            nameof(PapiClientTests.BibSearchTest),
-            nameof(PapiClientTests.CollectionsGetTest),
-            nameof(PapiClientTests.DatesClosedGetTest),
-            nameof(PapiClientTests.HoldingsGetTest),
-            nameof(PapiClientTests.ItemStatusesGetAsyncTest),
-            nameof(PapiClientTests.LimitFiltersGetTest),
-            nameof(PapiClientTests.MARCTypeOfMaterialsGetAsyncTest),
-            nameof(PapiClientTests.OrganizationsGetTest),
-            nameof(PapiClientTests.PatronAccountGetTest),
-            nameof(PapiClientTests.PatronBasicDataGetTest),
-            nameof(PapiClientTests.PatronCirculateBlocksGetTest),
-            nameof(PapiClientTests.PatronCodesGetTest),
-            nameof(PapiClientTests.PatronHoldRequestsGetTest),
-            nameof(PapiClientTests.PatronILLRequestsGetTest),
-            nameof(PapiClientTests.PatronItemsOutGetTest),
-            nameof(PapiClientTests.PatronMessagesGetTest),
-            nameof(PapiClientTests.PatronPreferencesGetTest),
-            nameof(PapiClientTests.PatronReadingHistoryGetTest),
-            nameof(PapiClientTests.PatronSavedSearchesGetTest),
-            nameof(PapiClientTests.PatronTitleListGetTitlesTest),
-            nameof(PapiClientTests.PatronValidateTest),
-            nameof(PapiClientTests.PickupBranchesGetTest),
-            nameof(PapiClientTests.ShelfLocationsGetTest),
-            nameof(PapiClientTests.AuthenticateStaffUserTest),
-            nameof(PapiClientTests.HoldRequestGetListTest),
-            nameof(PapiClientTests.Patron_GetBarcodeFromIdTest),
-            nameof(PapiClientTests.PatronRenewBlocksGetTest),
-            nameof(PapiClientTests.PatronSearchTest),
-            nameof(PapiClientTests.RecordSetRecordsGetTest),
-            nameof(PapiClientTests.SA_GetValueByOrgTest),
-            nameof(PapiClientTests.Synch_BibsByIdGetTest),
+            TestCategories.ReadOnlyIntegration,
+            TestCategories.ProtectedReadOnlyIntegration,
+            TestCategories.MutatingIntegration,
+            TestCategories.ProtectedMutatingIntegration,
         };
 
-        private static readonly string[] KnownProtectedIntegrationTests =
+        private static readonly string[] ProtectedIntegrationCategories =
         {
-            nameof(PapiClientTests.AuthenticateStaffUserTest),
-            nameof(PapiClientTests.HoldRequestGetListTest),
-            nameof(PapiClientTests.Patron_GetBarcodeFromIdTest),
-            nameof(PapiClientTests.PatronRenewBlocksGetTest),
-            nameof(PapiClientTests.PatronSearchTest),
-            nameof(PapiClientTests.RecordSetRecordsGetTest),
-            nameof(PapiClientTests.SA_GetValueByOrgTest),
-            nameof(PapiClientTests.Synch_BibsByIdGetTest),
+            TestCategories.ProtectedReadOnlyIntegration,
+            TestCategories.ProtectedMutatingIntegration,
+        };
+
+        private static readonly string[] MutatingIntegrationCategories =
+        {
+            TestCategories.MutatingIntegration,
+            TestCategories.ProtectedMutatingIntegration,
+        };
+
+        private static readonly string[] ReadOnlyIntegrationCategories =
+        {
+            TestCategories.ReadOnlyIntegration,
+            TestCategories.ProtectedReadOnlyIntegration,
         };
 
         private static readonly string[] KnownMutatingIntegrationTests =
@@ -103,68 +76,48 @@ namespace Clc.Polaris.Api.Tests
         };
 
         [TestMethod]
-        public void AllPapiClientIntegrationTestsAreClassifiedOrDocumentedExceptions()
+        public void LivePapiClientTestsHaveExactlyOneIntegrationCategoryOrDocumentedException()
         {
             var documentedExceptions = new[]
             {
+                // This test currently only documents the not-yet-implemented method and does not issue a live request.
                 nameof(PapiClientTests.HeadingsSearchTest),
             };
 
-            var unclassified = GetPapiClientTestMethods()
+            var incorrectlyClassified = GetPapiClientTestMethods()
                 .Where(method => !documentedExceptions.Contains(method.Name))
-                .Where(method => MethodOrClassHasCategory(method, IntegrationCategory))
-                .Where(method => !MethodHasCategory(method, ReadOnlyIntegrationCategory))
-                .Where(method => !MethodHasCategory(method, MutatingIntegrationCategory))
-                .Select(method => method.Name)
+                .Select(method => new
+                {
+                    Method = method,
+                    Categories = MethodCategories(method).Where(IntegrationCategories.Contains).ToArray(),
+                })
+                .Where(method => method.Categories.Length != 1)
+                .Select(method => $"{method.Method.Name} ({string.Join(", ", method.Categories.DefaultIfEmpty("no integration category"))})")
                 .ToArray();
 
             Assert.IsFalse(
-                unclassified.Any(),
-                $@"Expected all PapiClient integration tests to be marked with TestCategory(""{ReadOnlyIntegrationCategory}""), TestCategory(""{MutatingIntegrationCategory}""), or documented in {nameof(documentedExceptions)}: {string.Join(", ", unclassified)}");
+                incorrectlyClassified.Any(),
+                $"Expected every live {nameof(PapiClientTests)} method to have exactly one integration category: {string.Join(", ", incorrectlyClassified)}");
         }
 
         [TestMethod]
-        public void SpecializedIntegrationCategoriesRequireIntegrationCategory()
+        public void PapiClientTestsDoNotUseLegacyIntegrationCategories()
         {
-            var missingIntegration = GetPapiClientTestMethods()
-                .Where(method =>
-                    (MethodHasCategory(method, ReadOnlyIntegrationCategory)
-                        || MethodHasCategory(method, ProtectedIntegrationCategory)
-                        || MethodHasCategory(method, MutatingIntegrationCategory))
-                    && !MethodOrClassHasCategory(method, IntegrationCategory))
-                .Select(method => method.Name)
+            var legacyCategoryMethods = GetPapiClientTestMethods()
+                .Select(method => new
+                {
+                    Method = method,
+                    Categories = MethodCategories(method)
+                        .Where(category => category is LegacyIntegrationCategory or LegacyProtectedIntegrationCategory)
+                        .ToArray(),
+                })
+                .Where(method => method.Categories.Any())
+                .Select(method => $"{method.Method.Name} ({string.Join(", ", method.Categories)})")
                 .ToArray();
 
             Assert.IsFalse(
-                missingIntegration.Any(),
-                $"Expected specialized integration tests to also be marked with TestCategory(\"{IntegrationCategory}\") at method or class level: {string.Join(", ", missingIntegration)}");
-        }
-
-        [TestMethod]
-        public void ReadOnlyAndMutatingIntegrationCategoriesAreMutuallyExclusive()
-        {
-            var conflictingMethods = GetPapiClientTestMethods()
-                .Where(method => MethodHasCategory(method, ReadOnlyIntegrationCategory) && MethodHasCategory(method, MutatingIntegrationCategory))
-                .Select(method => method.Name)
-                .ToArray();
-
-            Assert.IsFalse(
-                conflictingMethods.Any(),
-                $"Expected no test to have both TestCategory(\"{ReadOnlyIntegrationCategory}\") and TestCategory(\"{MutatingIntegrationCategory}\"): {string.Join(", ", conflictingMethods)}");
-        }
-
-        [TestMethod]
-        public void MutatingIntegrationTestsAreNotParallelized()
-        {
-            var missingDoNotParallelize = GetPapiClientTestMethods()
-                .Where(method => MethodHasCategory(method, MutatingIntegrationCategory))
-                .Where(method => !method.GetCustomAttributes<DoNotParallelizeAttribute>(inherit: false).Any())
-                .Select(method => method.Name)
-                .ToArray();
-
-            Assert.IsFalse(
-                missingDoNotParallelize.Any(),
-                $"Expected mutating integration tests to be marked with {nameof(DoNotParallelizeAttribute)} unless a documented exception is added to this test: {string.Join(", ", missingDoNotParallelize)}");
+                legacyCategoryMethods.Any(),
+                $"Expected no {nameof(PapiClientTests)} methods to use legacy raw integration categories: {string.Join(", ", legacyCategoryMethods)}");
         }
 
         [TestMethod]
@@ -175,37 +128,56 @@ namespace Clc.Polaris.Api.Tests
                 .Select(method => method.Key)
                 .ToArray();
 
-            AssertMethodsHaveCategory(methodsRequiringStaffOverride, ProtectedIntegrationCategory);
+            var missingProtectedCategory = methodsRequiringStaffOverride
+                .Where(methodName => !MethodHasAnyCategory(methodName, ProtectedIntegrationCategories))
+                .ToArray();
+
+            Assert.IsFalse(
+                missingProtectedCategory.Any(),
+                $"Expected tests that call {nameof(IntegrationTestRequirements.RequireStaffOverrideAccount)} to use either {TestCategories.ProtectedReadOnlyIntegration} or {TestCategories.ProtectedMutatingIntegration}: {string.Join(", ", missingProtectedCategory)}");
         }
 
         [TestMethod]
-        public void KnownReadOnlyTestsHaveReadOnlyIntegrationCategory()
+        public void MutatingIntegrationTestsAreNotParallelized()
         {
-            AssertMethodsHaveCategory(KnownReadOnlyIntegrationTests, ReadOnlyIntegrationCategory);
+            var missingDoNotParallelize = GetPapiClientTestMethods()
+                .Where(method => MethodHasAnyCategory(method, MutatingIntegrationCategories))
+                .Where(method => !method.GetCustomAttributes<DoNotParallelizeAttribute>(inherit: false).Any())
+                .Select(method => method.Name)
+                .ToArray();
+
+            Assert.IsFalse(
+                missingDoNotParallelize.Any(),
+                $"Expected mutating integration tests to be marked with {nameof(DoNotParallelizeAttribute)}: {string.Join(", ", missingDoNotParallelize)}");
         }
 
         [TestMethod]
-        public void KnownStaffRequiredReadOnlyTestsHaveProtectedIntegrationCategory()
+        public void ReadOnlyIntegrationTestsAreParallelizableUnlessDocumented()
         {
-            AssertMethodsHaveCategory(KnownProtectedIntegrationTests, ProtectedIntegrationCategory);
+            var documentedDoNotParallelizeReadOnlyTests = Array.Empty<string>();
+
+            var unexpectedlyNonParallelized = GetPapiClientTestMethods()
+                .Where(method => !documentedDoNotParallelizeReadOnlyTests.Contains(method.Name))
+                .Where(method => MethodHasAnyCategory(method, ReadOnlyIntegrationCategories))
+                .Where(method => method.GetCustomAttributes<DoNotParallelizeAttribute>(inherit: false).Any())
+                .Select(method => method.Name)
+                .ToArray();
+
+            Assert.IsFalse(
+                unexpectedlyNonParallelized.Any(),
+                $"Expected read-only integration tests not to be marked with {nameof(DoNotParallelizeAttribute)} unless documented in {nameof(documentedDoNotParallelizeReadOnlyTests)}: {string.Join(", ", unexpectedlyNonParallelized)}");
         }
 
         [TestMethod]
         public void KnownMutatingTestsHaveMutatingIntegrationCategory()
         {
-            AssertMethodsHaveCategory(KnownMutatingIntegrationTests, MutatingIntegrationCategory);
-        }
-
-        [TestMethod]
-        public void KnownMutatingTestsDoNotHaveReadOnlyIntegrationCategory()
-        {
-            var incorrectlyReadOnly = KnownMutatingIntegrationTests
-                .Where(methodName => MethodHasCategory(methodName, ReadOnlyIntegrationCategory))
+            var missingCategory = KnownMutatingIntegrationTests
+                .Where(methodName => !MethodHasAnyCategory(methodName, MutatingIntegrationCategories))
                 .ToArray();
 
             Assert.IsFalse(
-                incorrectlyReadOnly.Any(),
-                $"Expected known mutating tests not to be marked with TestCategory(\"{ReadOnlyIntegrationCategory}\"): {string.Join(", ", incorrectlyReadOnly)}");
+                missingCategory.Any(),
+                $"Expected known mutating tests to use either {TestCategories.MutatingIntegration} or {TestCategories.ProtectedMutatingIntegration}: {string.Join(", ", missingCategory)}");
         }
 
         private static IEnumerable<MethodInfo> GetPapiClientTestMethods()
@@ -215,41 +187,26 @@ namespace Clc.Polaris.Api.Tests
                 .Where(method => method.GetCustomAttributes<TestMethodAttribute>(inherit: false).Any());
         }
 
-        private static void AssertMethodsHaveCategory(IEnumerable<string> methodNames, string expectedCategory)
-        {
-            var missingCategory = methodNames
-                .Where(methodName => !MethodHasCategory(methodName, expectedCategory))
-                .ToArray();
-
-            Assert.IsFalse(
-                missingCategory.Any(),
-                $"Expected these {nameof(PapiClientTests)} methods to be marked with TestCategory(\"{expectedCategory}\"): {string.Join(", ", missingCategory)}");
-        }
-
-        private static bool MethodHasCategory(string methodName, string expectedCategory)
+        private static bool MethodHasAnyCategory(string methodName, IEnumerable<string> expectedCategories)
         {
             var method = typeof(PapiClientTests).GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public);
 
             Assert.IsNotNull(method, $"Expected to find public test method {nameof(PapiClientTests)}.{methodName}.");
 
-            return MethodHasCategory(method, expectedCategory);
+            return MethodHasAnyCategory(method, expectedCategories);
         }
 
-        private static bool MethodHasCategory(MethodInfo method, string expectedCategory)
+        private static bool MethodHasAnyCategory(MethodInfo method, IEnumerable<string> expectedCategories)
+        {
+            return MethodCategories(method).Intersect(expectedCategories).Any();
+        }
+
+        private static string[] MethodCategories(MethodInfo method)
         {
             return method
-                .GetCustomAttributes<TestCategoryAttribute>(inherit: false)
+                .GetCustomAttributes<TestCategoryBaseAttribute>(inherit: false)
                 .SelectMany(attribute => attribute.TestCategories)
-                .Contains(expectedCategory);
-        }
-
-        private static bool MethodOrClassHasCategory(MethodInfo method, string expectedCategory)
-        {
-            return MethodHasCategory(method, expectedCategory)
-                || typeof(PapiClientTests)
-                    .GetCustomAttributes<TestCategoryAttribute>(inherit: false)
-                    .SelectMany(attribute => attribute.TestCategories)
-                    .Contains(expectedCategory);
+                .ToArray();
         }
 
         private static Dictionary<string, string> PapiClientTestSourceMethods([CallerFilePath] string categoryTestSourcePath = "")
@@ -298,6 +255,5 @@ namespace Clc.Polaris.Api.Tests
             Assert.Fail($"Expected to find closing brace matching character index {openingBraceIndex}.");
             return -1;
         }
-
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTests.cs
@@ -17,7 +17,6 @@ namespace Clc.Polaris.Api.Tests
 {
 
     [TestClass()]
-    [TestCategory("Integration")]
     public class PapiClientTests
     {
         private const string TestArtifactPrefix = "PAPI_TEST_";
@@ -100,8 +99,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task ApiKeyValidateTest()
         {
             var response = await papi.ApiKeyValidateAsync();
@@ -109,8 +107,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task ApiVersionGetTest()
         {
             var response = await papi.ApiVersionGetAsync();
@@ -119,9 +116,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
-        [TestCategory("ProtectedIntegration")]
+        [ProtectedReadOnlyIntegrationCategory]
         public async Task AuthenticateStaffUserTest()
         {
             var staffOverrideAccount = papi.StaffOverrideAccount;
@@ -134,8 +129,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task BibGetTest()
         {
             var response = await papi.BibGetAsync(478907);
@@ -146,8 +140,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task BibGetTest_PassBranchId()
         {
             var response = await papi.BibGetAsync(bibId, 7);
@@ -157,8 +150,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task BibSearchTest()
         {
             var response = await papi.BibSearchAsync(new BibSearchOptions { Term = "dogs", PageSize = 10 });
@@ -168,8 +160,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task CollectionsGetTest()
         {
             var response = await papi.CollectionsGetAsync();
@@ -179,9 +170,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ProtectedIntegration")]
-        [TestCategory("MutatingIntegration")]
+        [ProtectedMutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task CreatePatronBlocksTest_FreeTextBlock()
         {
@@ -193,9 +182,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ProtectedIntegration")]
-        [TestCategory("MutatingIntegration")]
+        [ProtectedMutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task CreatePatronBlocksTest_SystemBlock()
         {
@@ -206,9 +193,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ProtectedIntegration")]
-        [TestCategory("MutatingIntegration")]
+        [ProtectedMutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task CreatePatronBlocksTest_LibraryAssignedBlock()
         {
@@ -219,8 +204,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task DatesClosedGetTest()
         {
             var response = await papi.DatesClosedGetAsync(7);
@@ -234,8 +218,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task HoldingsGetTest()
         {
             var response = await papi.HoldingsGetAsync(bibId);
@@ -243,8 +226,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task HoldRequestCancelTest()
         {
@@ -253,8 +235,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task HoldRequestCreateTest()
         {
@@ -263,8 +244,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task HoldRequestCreateTest2()
         {
@@ -273,9 +253,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
-        [TestCategory("ProtectedIntegration")]
+        [ProtectedReadOnlyIntegrationCategory]
         public async Task HoldRequestGetListTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -285,8 +263,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task HoldRequestReactivateTest()
         {
@@ -295,8 +272,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task HoldRequestReplyTest()
         {
@@ -311,8 +287,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task HoldRequestSuspendTest()
         {
@@ -321,8 +296,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task ItemRenewTest()
         {
@@ -331,8 +305,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task ItemStatusesGetAsyncTest()
         {
             var response = await papi.ItemStatusesGetAsync(7);
@@ -347,8 +320,7 @@ namespace Clc.Polaris.Api.Tests
         //}
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task LimitFiltersGetTest()
         {
             var response = (await papi.LimitFiltersGetAsync()).Data;
@@ -356,8 +328,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task MARCTypeOfMaterialsGetAsyncTest()
         {
             var response = (await papi.MARCTypeOfMaterialsGetAsync()).Data;
@@ -365,9 +336,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ProtectedIntegration")]
-        [TestCategory("MutatingIntegration")]
+        [ProtectedMutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task NotificationUpdateTest()
         {
@@ -378,8 +347,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task OrganizationsGetTest()
         {
             var response = await papi.OrganizationsGetAsync();
@@ -387,9 +355,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
-        [TestCategory("ProtectedIntegration")]
+        [ProtectedReadOnlyIntegrationCategory]
         public async Task Patron_GetBarcodeFromIdTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -399,9 +365,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ProtectedIntegration")]
-        [TestCategory("MutatingIntegration")]
+        [ProtectedMutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronAccountCreateCreditTest()
         {
@@ -412,8 +376,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task TestTitleListCreate_Get_Delete()
         {
@@ -432,9 +395,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ProtectedIntegration")]
-        [TestCategory("MutatingIntegration")]
+        [ProtectedMutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronAccountDepositCreditTest()
         {
@@ -445,8 +406,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task PatronAccountGetTest()
         {
             var response = await papi.PatronAccountGetAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -455,9 +415,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ProtectedIntegration")]
-        [TestCategory("MutatingIntegration")]
+        [ProtectedMutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronAccountPayTest()
         {
@@ -468,9 +426,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ProtectedIntegration")]
-        [TestCategory("MutatingIntegration")]
+        [ProtectedMutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronAccountPayAllTest()
         {
@@ -481,9 +437,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ProtectedIntegration")]
-        [TestCategory("MutatingIntegration")]
+        [ProtectedMutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronAccountRefundCreditTest()
         {
@@ -494,9 +448,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ProtectedIntegration")]
-        [TestCategory("MutatingIntegration")]
+        [ProtectedMutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronAccountVoidTest()
         {
@@ -507,8 +459,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task PatronBasicDataGetTest()
         {
             var response = await papi.PatronBasicDataGetAsync(Settings.PatronBarcode, Settings.PatronPin, true);
@@ -518,8 +469,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task PatronCirculateBlocksGetTest()
         {
             var response = await papi.PatronCirculateBlocksGetAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -527,8 +477,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task PatronCodesGetTest()
         {
             var response = await papi.PatronCodesGetAsync();
@@ -537,8 +486,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task PatronHoldRequestsGetTest()
         {
             var response = await papi.PatronHoldRequestsGetAsync(Settings.PatronBarcode, PatronHoldStatus.all, Settings.PatronPin);
@@ -547,8 +495,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task PatronILLRequestsGetTest()
         {
             var response = await papi.PatronILLRequestsGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
@@ -557,8 +504,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task PatronItemsOutGetTest()
         {
             var response = await papi.PatronItemsOutGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
@@ -567,8 +513,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronMessageDeleteTest()
         {
@@ -577,8 +522,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task PatronMessagesGetTest()
         {
             var response = await papi.PatronMessagesGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
@@ -586,8 +530,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronMessageUpdateStatusTest()
         {
@@ -596,8 +539,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task PatronPreferencesGetTest()
         {
             var response = await papi.PatronPreferencesGetAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -605,8 +547,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronReadingHistoryClearTest()
         {
@@ -615,8 +556,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task PatronReadingHistoryGetTest()
         {
             var response = await papi.PatronReadingHistoryGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
@@ -631,9 +571,7 @@ namespace Clc.Polaris.Api.Tests
         //}
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
-        [TestCategory("ProtectedIntegration")]
+        [ProtectedReadOnlyIntegrationCategory]
         public async Task PatronRenewBlocksGetTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -643,8 +581,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task PatronSavedSearchesGetTest()
         {
             var response = await papi.PatronSavedSearchesGetAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -652,9 +589,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
-        [TestCategory("ProtectedIntegration")]
+        [ProtectedReadOnlyIntegrationCategory]
         public async Task PatronSearchTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -664,8 +599,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronTitleListAddTitleTest()
         {
@@ -674,8 +608,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronTitleListCopyAllTitlesTest()
         {
@@ -684,8 +617,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronTitleListCopyTitleTest()
         {
@@ -694,8 +626,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronTitleListDeleteAllTitlesTest()
         {
@@ -704,8 +635,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronTitleListDeleteTitleTest()
         {
@@ -714,8 +644,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task PatronTitleListGetTitlesTest()
         {
             var response = await papi.PatronTitleListGetTitlesAsync(Settings.PatronBarcode, 1234, password: Settings.PatronPin);
@@ -723,8 +652,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronTitleListMoveTitleTest()
         {
@@ -733,8 +661,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronUpdateTest()
         {
@@ -743,8 +670,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("MutatingIntegration")]
+        [MutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task PatronUpdateUserNameTest()
         {
@@ -753,8 +679,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task PatronValidateTest()
         {
             var response = await papi.PatronValidateAsync(Settings.PatronBarcode, Settings.PatronPin);
@@ -762,8 +687,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task PickupBranchesGetTest()
         {
             var response = await papi.PickupBranchesGetAsync();
@@ -771,9 +695,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ProtectedIntegration")]
-        [TestCategory("MutatingIntegration")]
+        [ProtectedMutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task RecordSetContentAddTest()
         {
@@ -784,9 +706,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ProtectedIntegration")]
-        [TestCategory("MutatingIntegration")]
+        [ProtectedMutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task RecordSetContentAddTest_List()
         {
@@ -797,9 +717,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ProtectedIntegration")]
-        [TestCategory("MutatingIntegration")]
+        [ProtectedMutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task RecordSetContentRemoveTest()
         {
@@ -810,9 +728,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ProtectedIntegration")]
-        [TestCategory("MutatingIntegration")]
+        [ProtectedMutatingIntegrationCategory]
         [DoNotParallelize]
         public async Task RecordSetContentRemoveTest_List()
         {
@@ -823,9 +739,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
-        [TestCategory("ProtectedIntegration")]
+        [ProtectedReadOnlyIntegrationCategory]
         public async Task RecordSetRecordsGetTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -842,9 +756,7 @@ namespace Clc.Polaris.Api.Tests
         //}
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
-        [TestCategory("ProtectedIntegration")]
+        [ProtectedReadOnlyIntegrationCategory]
         public async Task SA_GetValueByOrgTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
@@ -854,8 +766,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
+        [ReadOnlyIntegrationCategory]
         public async Task ShelfLocationsGetTest()
         {
             var response = await papi.ShelfLocationsGetAsync(7);
@@ -863,9 +774,7 @@ namespace Clc.Polaris.Api.Tests
         }
 
         [TestMethod()]
-        [TestCategory("Integration")]
-        [TestCategory("ReadOnlyIntegration")]
-        [TestCategory("ProtectedIntegration")]
+        [ProtectedReadOnlyIntegrationCategory]
         public async Task Synch_BibsByIdGetTest()
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);

--- a/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientTokenTests.cs
@@ -15,8 +15,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Clc.Polaris.Api.Tests
 {
     [TestClass]
+    [UnitCategory]
     [DoNotParallelize]
-    [TestCategory("RestClientMigration")]
     public class PapiClientTokenTests
     {
         [TestInitialize]

--- a/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientUrlEncodingTests.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Clc.Polaris.Api.Tests
 {
     [TestClass]
-    [TestCategory("Unit")]
+    [UnitCategory]
     public class PapiClientUrlEncodingTests
     {
         private sealed class CaptureHttpMessageHandler : HttpMessageHandler

--- a/src/polaris-api-csharpTests/Models/BibGetResultTests.cs
+++ b/src/polaris-api-csharpTests/Models/BibGetResultTests.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Collections.Generic;
+using Clc.Polaris.Api.Tests;
 using Clc.Polaris.Api.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Clc.Polaris.Api.Tests.Models
 {
     [TestClass]
-    [TestCategory("Unit")]
+    [UnitCategory]
     public class BibGetResultTests
     {
         [TestMethod]

--- a/src/polaris-api-csharpTests/Models/PapiRestRequestFactoryTests.cs
+++ b/src/polaris-api-csharpTests/Models/PapiRestRequestFactoryTests.cs
@@ -1,3 +1,4 @@
+using Clc.Polaris.Api.Tests;
 ﻿using Clc.Polaris.Api.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Net.Http;
@@ -5,7 +6,7 @@ using System.Net.Http;
 namespace Clc.Polaris.Api.Tests.Models
 {
     [TestClass]
-    [TestCategory("Unit")]
+    [UnitCategory]
     public class PapiRestRequestFactoryTests
     {
         [TestMethod]

--- a/src/polaris-api-csharpTests/PapiSignatureTests.cs
+++ b/src/polaris-api-csharpTests/PapiSignatureTests.cs
@@ -3,7 +3,7 @@
 namespace Clc.Polaris.Api.Tests
 {
     [TestClass]
-    [TestCategory("Unit")]
+    [UnitCategory]
     public class PapiSignatureTests
     {
         [TestMethod]

--- a/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
+++ b/src/polaris-api-csharpTests/RestClientMigrationCharacterizationTests.cs
@@ -15,8 +15,7 @@ using System.Threading.Tasks;
 namespace Clc.Polaris.Api.Tests
 {
     [TestClass]
-    [TestCategory("Unit")]
-    [TestCategory("RestClientMigration")]
+    [UnitCategory]
     public class RestClientMigrationCharacterizationTests
     {
         [TestMethod]

--- a/src/polaris-api-csharpTests/TestCategoryAttributes.cs
+++ b/src/polaris-api-csharpTests/TestCategoryAttributes.cs
@@ -1,0 +1,45 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+
+namespace Clc.Polaris.Api.Tests
+{
+    public static class TestCategories
+    {
+        public const string Unit = "Unit";
+        public const string ReadOnlyIntegration = "ReadOnlyIntegration";
+        public const string ProtectedReadOnlyIntegration = "ProtectedReadOnlyIntegration";
+        public const string MutatingIntegration = "MutatingIntegration";
+        public const string ProtectedMutatingIntegration = "ProtectedMutatingIntegration";
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class UnitCategoryAttribute : TestCategoryBaseAttribute
+    {
+        public override IList<string> TestCategories => new[] { global::Clc.Polaris.Api.Tests.TestCategories.Unit };
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class ReadOnlyIntegrationCategoryAttribute : TestCategoryBaseAttribute
+    {
+        public override IList<string> TestCategories => new[] { global::Clc.Polaris.Api.Tests.TestCategories.ReadOnlyIntegration };
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class ProtectedReadOnlyIntegrationCategoryAttribute : TestCategoryBaseAttribute
+    {
+        public override IList<string> TestCategories => new[] { global::Clc.Polaris.Api.Tests.TestCategories.ProtectedReadOnlyIntegration };
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class MutatingIntegrationCategoryAttribute : TestCategoryBaseAttribute
+    {
+        public override IList<string> TestCategories => new[] { global::Clc.Polaris.Api.Tests.TestCategories.MutatingIntegration };
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class ProtectedMutatingIntegrationCategoryAttribute : TestCategoryBaseAttribute
+    {
+        public override IList<string> TestCategories => new[] { global::Clc.Polaris.Api.Tests.TestCategories.ProtectedMutatingIntegration };
+    }
+}

--- a/src/polaris-api-csharpTests/Validation/IntegrationTestRequirementsTests.cs
+++ b/src/polaris-api-csharpTests/Validation/IntegrationTestRequirementsTests.cs
@@ -1,3 +1,4 @@
+using Clc.Polaris.Api.Tests;
 using Clc.Polaris.Api.Configuration;
 using Clc.Polaris.Api.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -5,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Clc.Polaris.Api.Tests.Validation
 {
     [TestClass]
-    [TestCategory("Unit")]
+    [UnitCategory]
     public class IntegrationTestRequirementsTests
     {
         [TestMethod]

--- a/src/polaris-api-csharpTests/Validation/RequireTests.cs
+++ b/src/polaris-api-csharpTests/Validation/RequireTests.cs
@@ -1,11 +1,12 @@
 using System;
+using Clc.Polaris.Api.Tests;
 using Clc.Polaris.Api.Validation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Clc.Polaris.Api.Validation.Tests
 {
     [TestClass]
-    [TestCategory("Unit")]
+    [UnitCategory]
     public class RequireTests
     {
         [TestMethod]


### PR DESCRIPTION
### Motivation

- Replace repeated raw `[TestCategory("...")]` combinations with single, named attributes to avoid duplicate entries in Visual Studio Test Explorer and make integration test traits mutually exclusive.
- Ensure mutating integration tests remain non-parallelized and enforce a clear taxonomy for protected vs. read-only integration tests.

### Description

- Added `src/polaris-api-csharpTests/TestCategoryAttributes.cs` which defines `TestCategories` constants and custom MSTest attributes: `UnitCategory`, `ReadOnlyIntegrationCategory`, `ProtectedReadOnlyIntegrationCategory`, `MutatingIntegrationCategory`, and `ProtectedMutatingIntegrationCategory`.
- Replaced raw `TestCategory` usages across the test project so each live integration test has exactly one integration category and local/unit tests use `UnitCategory` at class level where appropriate.
- Kept explicit `[DoNotParallelize]` on mutating tests and ensured those attributes remain separate from category attributes.
- Rewrote `PapiClientTestCategoryTests` to validate the new taxonomy: require exactly one integration category per live PAPI test, reject legacy `Integration`/`ProtectedIntegration` usages, require protected categories for staff-override tests, and enforce `[DoNotParallelize]` on mutating tests.
- Updated `README.md` local test instructions to filter by the new categories and updated `.github/workflows/ci.yaml` to run CI with `--filter "TestCategory=Unit"`.

### Testing

- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Unit"` which passed (160 passed, 0 failed).
- Ran a discovery/build test for integration categories with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=ReadOnlyIntegration|TestCategory=ProtectedReadOnlyIntegration|TestCategory=MutatingIntegration|TestCategory=ProtectedMutatingIntegration"`, which completed successfully and discovered 68 live tests that were skipped due to missing local live-test configuration (expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a24f48d2f3c83238694c85c16b6358a)