### PR TITLE
Update docs and package metadata for 4.0 beta

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,10 @@
 # 4.0 Async API Migration
 
-Version `4.0.0-alpha.1` is an async-first, async-only release. It intentionally removes the synchronous compatibility wrappers from the 3.x client API.
+Version 4.0 starts the async-first, async-only release line. The beta package is `4.0.0-beta.1`. It intentionally removes the synchronous compatibility wrappers from the 3.x client API.
+
+## Target framework
+
+`Clc.Polaris.Api` 4.0 targets `net8.0`. Consumer applications must run on .NET 8 or later.
 
 ## Public client methods are async-only
 
@@ -60,10 +64,18 @@ var response = await client.PatronReadingHistoryClearAsync(
     cancellationToken);
 ```
 
+## Staff override behavior
+
+Staff override token acquisition is client-managed through `StaffOverrideAccount`. Staff override applies to protected methods and public patron-account methods that support staff override. General public methods are signed normally and should not receive staff override credentials.
+
+## Protected token ownership
+
+`PapiClient.Token` is readable for diagnostics and inspection. External callers should not assign protected tokens directly. Configure `StaffOverrideAccount` and let the client acquire, cache, expire, and refresh protected tokens automatically.
+
 ## Protected-token path requests
 
 Some protected PAPI endpoints include the protected access token in the URL path. In 4.0, the built-in client methods for those endpoints use `ProtectedToken.Placeholder` internally for the protected-token URL path segment.
 
 `ExecutePapiAsync` replaces the placeholder with the active protected access token before the request is sent and before PAPI hash formatting occurs. This allows the final URL and authorization hash to use the same tokenized path.
 
-Consumers generally should not need to use `ProtectedToken.Placeholder` directly unless they are constructing a `PapiRestRequest` manually.
+Consumers generally should not need to use `ProtectedToken.Placeholder` directly unless they are constructing a `PapiRestRequest` manually for execution through `ExecutePapiAsync`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```bash
-dotnet add package Clc.Polaris.Api --version 4.0.0-alpha.1
+dotnet add package Clc.Polaris.Api --version 4.0.0-beta.1
 ```
 
 ## Configure `PapiClient`
@@ -34,7 +34,7 @@ var settings = new PapiSettings
 var client = new PapiClient(settings);
 ```
 
-`PapiSettings.PolarisOverrideAccount` is copied to `PapiClient.StaffOverrideAccount`. When `StaffOverrideAccount` is configured, protected requests and supported staff-override requests can acquire protected tokens automatically.
+`PapiSettings.PolarisOverrideAccount` is copied to `PapiClient.StaffOverrideAccount`. When configured, the client can acquire protected tokens automatically for protected methods and public patron-account methods that support staff override. General public methods continue to use normal PAPI signing and do not receive staff override credentials.
 
 ## Basic async usage
 

--- a/src/polaris-api-csharp/Clc.Polaris.Api.csproj
+++ b/src/polaris-api-csharp/Clc.Polaris.Api.csproj
@@ -15,6 +15,7 @@
 		<RepositoryUrl>https://github.com/clcdpc/polaris-api-csharp</RepositoryUrl>
 		<IncludeSymbols>True</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<PackageReleaseNotes>Upgrade to RestClient 3.x; move to net8.0; make public client APIs async-only with CancellationToken support; add protected-token acquisition and caching for staff override requests; support custom PAPI request execution through ExecutePapiAsync; restrict public staff override behavior to patron-account routes.</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
### Motivation

- Prepare the repository for the 4.0 beta release by replacing alpha/RC wording with beta-safe language and updating package metadata. 
- Clarify staff-override and protected-token behavior so callers know to configure `StaffOverrideAccount` and let the client manage protected tokens. 
- Explicitly document the target framework requirement (NET 8) and provide concise release notes for consumers.

### Description

- Update `README.md` to change the install command to `4.0.0-beta.1` and rewrite the staff-override paragraph to state that `PapiSettings.PolarisOverrideAccount` is copied to `PapiClient.StaffOverrideAccount`, that the client can acquire protected tokens automatically for protected methods and public patron-account methods that support staff override, and that general public methods remain normally signed. 
- Update `MIGRATION.md` to use beta-safe 4.0 wording, add a `Target framework` section declaring `Clc.Polaris.Api` 4.0 targets `net8.0`, add `Staff override behavior` and `Protected token ownership` sections, and clarify `ProtectedToken.Placeholder` usage in conjunction with `ExecutePapiAsync`. 
- Update `src/polaris-api-csharp/Clc.Polaris.Api.csproj` to add a concise `<PackageReleaseNotes>` entry describing the key changes (RestClient 3.x upgrade, move to `net8.0`, async-only public APIs with `CancellationToken`, protected-token acquisition/caching for staff override, support for `ExecutePapiAsync`, and restricting public staff-override to patron-account routes). 
- No production code API or dependency versions were changed beyond adding metadata and documentation text.

### Testing

- Ran `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Unit"`, which restored projects and passed all unit tests (165 passed). 
- Ran `dotnet pack src/polaris-api-csharp/Clc.Polaris.Api.csproj -c Release`, which succeeded and produced `/src/polaris-api-csharp/bin/Release/Clc.Polaris.Api.4.0.0-beta.1.nupkg` and the corresponding `.snupkg` with a non-fatal package-readme warning. 
- Changed files: `README.md`, `MIGRATION.md`, and `src/polaris-api-csharp/Clc.Polaris.Api.csproj`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a264684d0688323b820b7e2dae2244a)