### PR TITLE
Simplify protected token acquisition flow

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -145,7 +145,9 @@ namespace Clc.Polaris.Api
         /// <returns>The REST response returned by the PAPI endpoint.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="request"/> has an invalid custom PAPI path.</exception>
-        public async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
+        public async Task<IRestResponse<T>> ExecutePapiAsync<T>(
+            PapiRestRequest request,
+            CancellationToken cancellationToken = default)
         {
             ValidateCustomPapiRequest(request);
 
@@ -153,7 +155,9 @@ namespace Clc.Polaris.Api
             var requiresProtectedToken = RequiresProtectedToken(request, pathContainsProtectedTokenPlaceholder);
 
             var protectedToken = requiresProtectedToken
-                ? await GetProtectedTokenOrThrowAsync(pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false)
+                ? await GetProtectedTokenOrThrowAsync(
+                    pathContainsProtectedTokenPlaceholder,
+                    cancellationToken).ConfigureAwait(false)
                 : null;
 
             var originalPath = request.Path;
@@ -269,71 +273,46 @@ namespace Clc.Polaris.Api
                 path.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) < 0;
         }
 
-        private static InvalidOperationException CreateProtectedTokenRequiredException(string reason, bool pathContainsProtectedTokenPlaceholder)
+        private static InvalidOperationException CreateProtectedTokenRequiredException(
+            string reason,
+            bool pathContainsProtectedTokenPlaceholder)
         {
             var placeholderReason = pathContainsProtectedTokenPlaceholder
                 ? " ProtectedToken.Placeholder cannot be replaced without a valid protected access token."
                 : string.Empty;
 
-            return new InvalidOperationException($"A valid protected access token is required for this request. {reason}{placeholderReason}");
+            return new InvalidOperationException(
+                $"A valid protected access token is required for this request. {reason}{placeholderReason}");
         }
 
         private static bool RequestPathContainsProtectedTokenPlaceholder(PapiRestRequest request)
         {
-            return request?.Path?.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) >= 0;
+            return request.Path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal);
         }
 
         private static void ReplaceProtectedTokenPlaceholderInPath(PapiRestRequest request, ProtectedToken token)
         {
             if (!IsProtectedTokenUsable(token))
             {
-                throw new InvalidOperationException("A valid protected access token is required to replace ProtectedToken.Placeholder in the request path.");
+                throw new InvalidOperationException(
+                    "A valid protected access token is required to replace " +
+                    "ProtectedToken.Placeholder in the request path.");
             }
 
-            request.Path = request.Path.Replace(ProtectedToken.Placeholder, token.AccessToken, StringComparison.Ordinal);
+            request.Path = request.Path.Replace(
+                ProtectedToken.Placeholder,
+                token.AccessToken,
+                StringComparison.Ordinal);
         }
 
-        private async Task<ProtectedToken> GetProtectedTokenOrThrowAsync(bool pathContainsProtectedTokenPlaceholder, CancellationToken cancellationToken = default)
+        private async Task<ProtectedToken> GetProtectedTokenOrThrowAsync(
+            bool pathContainsProtectedTokenPlaceholder,
+            CancellationToken cancellationToken = default)
         {
-            var cacheKey = BuildProtectedTokenCacheKey();
-            if (TryUseCurrentOrCachedProtectedToken(cacheKey, out var token))
-            {
-                return token!;
-            }
-
-            if (StaffOverrideAccount == null)
-            {
-                throw CreateProtectedTokenRequiredException("No staff override credentials are configured.", pathContainsProtectedTokenPlaceholder);
-            }
-
-            if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
-            {
-                return await AuthenticateAndLoadProtectedTokenOrThrowAsync(null, pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false);
-            }
-
-            var cacheLock = ProtectedTokenCacheLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
-            await cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-            try
-            {
-                if (TryUseCurrentOrCachedProtectedToken(cacheKey, out token))
-                {
-                    return token!;
-                }
-
-                return await AuthenticateAndLoadProtectedTokenOrThrowAsync(cacheKey, pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false);
-            }
-            finally
-            {
-                cacheLock.Release();
-            }
-        }
-
-        private bool TryUseCurrentOrCachedProtectedToken(string? cacheKey, out ProtectedToken? token)
-        {
-            token = Token;
+            var token = Token;
             if (IsProtectedTokenUsable(token))
             {
-                return true;
+                return token!;
             }
 
             if (token != null)
@@ -341,14 +320,59 @@ namespace Clc.Polaris.Api
                 _token = null;
             }
 
-            if (TryLoadProtectedTokenFromCache(cacheKey))
+            if (StaffOverrideAccount == null)
             {
-                token = _token;
-                return true;
+                throw CreateProtectedTokenRequiredException(
+                    "No staff override credentials are configured.",
+                    pathContainsProtectedTokenPlaceholder);
             }
 
-            token = null;
-            return false;
+            var cacheKey = BuildProtectedTokenCacheKey();
+
+            if (TryLoadProtectedTokenFromCache(cacheKey))
+            {
+                token = Token;
+                return token!;
+            }
+
+            if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
+            {
+                return await AuthenticateAndLoadProtectedTokenOrThrowAsync(
+                    null,
+                    pathContainsProtectedTokenPlaceholder,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            var cacheLock = ProtectedTokenCacheLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
+            await cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                token = Token;
+                if (IsProtectedTokenUsable(token))
+                {
+                    return token!;
+                }
+
+                if (token != null)
+                {
+                    _token = null;
+                }
+
+                if (TryLoadProtectedTokenFromCache(cacheKey))
+                {
+                    token = Token;
+                    return token!;
+                }
+
+                return await AuthenticateAndLoadProtectedTokenOrThrowAsync(
+                    cacheKey,
+                    pathContainsProtectedTokenPlaceholder,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                cacheLock.Release();
+            }
         }
 
         private string? BuildProtectedTokenCacheKey()
@@ -409,37 +433,49 @@ namespace Clc.Polaris.Api
             return true;
         }
 
-        private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenOrThrowAsync(string? cacheKey, bool pathContainsProtectedTokenPlaceholder, CancellationToken cancellationToken)
+        private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenOrThrowAsync(
+            string? cacheKey,
+            bool pathContainsProtectedTokenPlaceholder,
+            CancellationToken cancellationToken)
         {
             var staffOverrideAccount = StaffOverrideAccount;
             if (staffOverrideAccount == null)
             {
-                throw CreateProtectedTokenRequiredException("No staff override credentials are configured.", pathContainsProtectedTokenPlaceholder);
+                throw CreateProtectedTokenRequiredException(
+                    "No staff override credentials are configured.",
+                    pathContainsProtectedTokenPlaceholder);
             }
 
-            var response = await AuthenticateStaffUserAsync(staffOverrideAccount, cancellationToken).ConfigureAwait(false);
+            var response = await AuthenticateStaffUserAsync(
+                staffOverrideAccount,
+                cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             var responseData = response?.Data;
             if (response?.Response == null || !response.Response.IsSuccessStatusCode)
             {
                 ClearFailedProtectedToken(cacheKey);
-                throw CreateProtectedTokenRequiredException("Staff authentication did not succeed.", pathContainsProtectedTokenPlaceholder);
+                throw CreateProtectedTokenRequiredException(
+                    "Staff authentication did not succeed.",
+                    pathContainsProtectedTokenPlaceholder);
             }
 
             if (!IsProtectedTokenUsable(responseData))
             {
                 ClearFailedProtectedToken(cacheKey);
-                throw CreateProtectedTokenRequiredException("Staff authentication did not return a usable protected access token.", pathContainsProtectedTokenPlaceholder);
+                throw CreateProtectedTokenRequiredException(
+                    "Staff authentication did not return a usable protected access token.",
+                    pathContainsProtectedTokenPlaceholder);
             }
 
-            _token = responseData;
+            var protectedToken = responseData!;
+            _token = protectedToken;
 
             if (UseProtectedTokenCache && !string.IsNullOrWhiteSpace(cacheKey))
             {
-                ProtectedTokenCache[cacheKey] = new ProtectedToken(responseData!);
+                ProtectedTokenCache[cacheKey] = new ProtectedToken(protectedToken);
             }
 
-            return _token!;
+            return protectedToken;
         }
 
         private void ClearFailedProtectedToken(string? cacheKey)

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -313,10 +313,9 @@ namespace Clc.Polaris.Api
 
             var cacheKey = BuildProtectedTokenCacheKey();
 
-            if (TryLoadProtectedTokenFromCache(cacheKey))
+            if (TryLoadProtectedTokenFromCache(cacheKey, out var cachedToken))
             {
-                token = Token;
-                return token!;
+                return cachedToken!;
             }
 
             if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
@@ -339,10 +338,9 @@ namespace Clc.Polaris.Api
                     _token = null;
                 }
 
-                if (TryLoadProtectedTokenFromCache(cacheKey))
+                if (TryLoadProtectedTokenFromCache(cacheKey, out cachedToken))
                 {
-                    token = Token;
-                    return token!;
+                    return cachedToken!;
                 }
 
                 return await AuthenticateAndLoadProtectedTokenOrThrowAsync(cacheKey, pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false);
@@ -388,8 +386,10 @@ namespace Clc.Polaris.Api
                 !string.IsNullOrWhiteSpace(token.AccessSecret);
         }
 
-        private bool TryLoadProtectedTokenFromCache(string? cacheKey)
+        private bool TryLoadProtectedTokenFromCache(string? cacheKey, out ProtectedToken? protectedToken)
         {
+            protectedToken = null;
+
             if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
             {
                 return false;
@@ -407,7 +407,8 @@ namespace Clc.Polaris.Api
                 return false;
             }
 
-            _token = new ProtectedToken(cachedToken);
+            protectedToken = new ProtectedToken(cachedToken);
+            _token = protectedToken;
             return true;
         }
 

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -145,9 +145,7 @@ namespace Clc.Polaris.Api
         /// <returns>The REST response returned by the PAPI endpoint.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="request"/> has an invalid custom PAPI path.</exception>
-        public async Task<IRestResponse<T>> ExecutePapiAsync<T>(
-            PapiRestRequest request,
-            CancellationToken cancellationToken = default)
+        public async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
         {
             ValidateCustomPapiRequest(request);
 
@@ -155,9 +153,7 @@ namespace Clc.Polaris.Api
             var requiresProtectedToken = RequiresProtectedToken(request, pathContainsProtectedTokenPlaceholder);
 
             var protectedToken = requiresProtectedToken
-                ? await GetProtectedTokenOrThrowAsync(
-                    pathContainsProtectedTokenPlaceholder,
-                    cancellationToken).ConfigureAwait(false)
+                ? await GetProtectedTokenOrThrowAsync(pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false)
                 : null;
 
             var originalPath = request.Path;
@@ -273,16 +269,13 @@ namespace Clc.Polaris.Api
                 path.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) < 0;
         }
 
-        private static InvalidOperationException CreateProtectedTokenRequiredException(
-            string reason,
-            bool pathContainsProtectedTokenPlaceholder)
+        private static InvalidOperationException CreateProtectedTokenRequiredException(string reason, bool pathContainsProtectedTokenPlaceholder)
         {
             var placeholderReason = pathContainsProtectedTokenPlaceholder
                 ? " ProtectedToken.Placeholder cannot be replaced without a valid protected access token."
                 : string.Empty;
 
-            return new InvalidOperationException(
-                $"A valid protected access token is required for this request. {reason}{placeholderReason}");
+            return new InvalidOperationException($"A valid protected access token is required for this request. {reason}{placeholderReason}");
         }
 
         private static bool RequestPathContainsProtectedTokenPlaceholder(PapiRestRequest request)
@@ -294,20 +287,13 @@ namespace Clc.Polaris.Api
         {
             if (!IsProtectedTokenUsable(token))
             {
-                throw new InvalidOperationException(
-                    "A valid protected access token is required to replace " +
-                    "ProtectedToken.Placeholder in the request path.");
+                throw new InvalidOperationException("A valid protected access token is required to replace ProtectedToken.Placeholder in the request path.");
             }
 
-            request.Path = request.Path.Replace(
-                ProtectedToken.Placeholder,
-                token.AccessToken,
-                StringComparison.Ordinal);
+            request.Path = request.Path.Replace(ProtectedToken.Placeholder, token.AccessToken, StringComparison.Ordinal);
         }
 
-        private async Task<ProtectedToken> GetProtectedTokenOrThrowAsync(
-            bool pathContainsProtectedTokenPlaceholder,
-            CancellationToken cancellationToken = default)
+        private async Task<ProtectedToken> GetProtectedTokenOrThrowAsync(bool pathContainsProtectedTokenPlaceholder, CancellationToken cancellationToken = default)
         {
             var token = Token;
             if (IsProtectedTokenUsable(token))
@@ -322,9 +308,7 @@ namespace Clc.Polaris.Api
 
             if (StaffOverrideAccount == null)
             {
-                throw CreateProtectedTokenRequiredException(
-                    "No staff override credentials are configured.",
-                    pathContainsProtectedTokenPlaceholder);
+                throw CreateProtectedTokenRequiredException("No staff override credentials are configured.", pathContainsProtectedTokenPlaceholder);
             }
 
             var cacheKey = BuildProtectedTokenCacheKey();
@@ -337,10 +321,7 @@ namespace Clc.Polaris.Api
 
             if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
             {
-                return await AuthenticateAndLoadProtectedTokenOrThrowAsync(
-                    null,
-                    pathContainsProtectedTokenPlaceholder,
-                    cancellationToken).ConfigureAwait(false);
+                return await AuthenticateAndLoadProtectedTokenOrThrowAsync(null, pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false);
             }
 
             var cacheLock = ProtectedTokenCacheLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
@@ -364,10 +345,7 @@ namespace Clc.Polaris.Api
                     return token!;
                 }
 
-                return await AuthenticateAndLoadProtectedTokenOrThrowAsync(
-                    cacheKey,
-                    pathContainsProtectedTokenPlaceholder,
-                    cancellationToken).ConfigureAwait(false);
+                return await AuthenticateAndLoadProtectedTokenOrThrowAsync(cacheKey, pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -433,38 +411,27 @@ namespace Clc.Polaris.Api
             return true;
         }
 
-        private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenOrThrowAsync(
-            string? cacheKey,
-            bool pathContainsProtectedTokenPlaceholder,
-            CancellationToken cancellationToken)
+        private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenOrThrowAsync(string? cacheKey, bool pathContainsProtectedTokenPlaceholder, CancellationToken cancellationToken)
         {
             var staffOverrideAccount = StaffOverrideAccount;
             if (staffOverrideAccount == null)
             {
-                throw CreateProtectedTokenRequiredException(
-                    "No staff override credentials are configured.",
-                    pathContainsProtectedTokenPlaceholder);
+                throw CreateProtectedTokenRequiredException("No staff override credentials are configured.", pathContainsProtectedTokenPlaceholder);
             }
 
-            var response = await AuthenticateStaffUserAsync(
-                staffOverrideAccount,
-                cancellationToken).ConfigureAwait(false);
+            var response = await AuthenticateStaffUserAsync(staffOverrideAccount, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             var responseData = response?.Data;
             if (response?.Response == null || !response.Response.IsSuccessStatusCode)
             {
                 ClearFailedProtectedToken(cacheKey);
-                throw CreateProtectedTokenRequiredException(
-                    "Staff authentication did not succeed.",
-                    pathContainsProtectedTokenPlaceholder);
+                throw CreateProtectedTokenRequiredException("Staff authentication did not succeed.", pathContainsProtectedTokenPlaceholder);
             }
 
             if (!IsProtectedTokenUsable(responseData))
             {
                 ClearFailedProtectedToken(cacheKey);
-                throw CreateProtectedTokenRequiredException(
-                    "Staff authentication did not return a usable protected access token.",
-                    pathContainsProtectedTokenPlaceholder);
+                throw CreateProtectedTokenRequiredException("Staff authentication did not return a usable protected access token.", pathContainsProtectedTokenPlaceholder);
             }
 
             var protectedToken = responseData!;

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -130,28 +130,6 @@ namespace Clc.Polaris.Api
             return papiRequest;
         }
 
-        private enum ProtectedTokenAcquisitionStatus
-        {
-            ValidTokenAvailable,
-            NoTokenNeeded,
-            NoStaffCredentialsConfigured,
-            StaffAuthenticationFailed,
-            InvalidTokenReturned
-        }
-
-        private sealed class ProtectedTokenAcquisitionResult
-        {
-            public ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus status, ProtectedToken? token = null)
-            {
-                Status = status;
-                Token = token;
-            }
-
-            public ProtectedTokenAcquisitionStatus Status { get; }
-            public ProtectedToken? Token { get; }
-            public bool HasValidToken => Status == ProtectedTokenAcquisitionStatus.ValidTokenAvailable && IsProtectedTokenUsable(Token);
-        }
-
         /// <summary>
         /// Executes a caller-supplied <see cref="PapiRestRequest"/> through the normal PAPI pipeline as an
         /// escape hatch for unsupported or custom PAPI endpoints. Callers must pass a PAPI request whose
@@ -174,15 +152,9 @@ namespace Clc.Polaris.Api
             var pathContainsProtectedTokenPlaceholder = RequestPathContainsProtectedTokenPlaceholder(request);
             var requiresProtectedToken = RequiresProtectedToken(request, pathContainsProtectedTokenPlaceholder);
 
-            if (requiresProtectedToken)
-            {
-                var tokenResult = await EnsureProtectedTokenAsync(cancellationToken).ConfigureAwait(false);
-                cancellationToken.ThrowIfCancellationRequested();
-                if (!tokenResult.HasValidToken)
-                {
-                    ThrowProtectedTokenRequired(tokenResult.Status, pathContainsProtectedTokenPlaceholder);
-                }
-            }
+            var protectedToken = requiresProtectedToken
+                ? await GetProtectedTokenOrThrowAsync(pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false)
+                : null;
 
             var originalPath = request.Path;
 
@@ -190,7 +162,7 @@ namespace Clc.Polaris.Api
             {
                 if (pathContainsProtectedTokenPlaceholder)
                 {
-                    ReplaceProtectedTokenPlaceholderInPath(request);
+                    ReplaceProtectedTokenPlaceholderInPath(request, protectedToken!);
                 }
 
                 return await ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
@@ -297,21 +269,13 @@ namespace Clc.Polaris.Api
                 path.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) < 0;
         }
 
-        private static void ThrowProtectedTokenRequired(ProtectedTokenAcquisitionStatus status, bool pathContainsProtectedTokenPlaceholder)
+        private static InvalidOperationException CreateProtectedTokenRequiredException(string reason, bool pathContainsProtectedTokenPlaceholder)
         {
-            var reason = status switch
-            {
-                ProtectedTokenAcquisitionStatus.NoStaffCredentialsConfigured => "No staff override credentials are configured.",
-                ProtectedTokenAcquisitionStatus.StaffAuthenticationFailed => "Staff authentication did not succeed.",
-                ProtectedTokenAcquisitionStatus.InvalidTokenReturned => "Staff authentication did not return a usable protected access token.",
-                _ => "A usable protected access token is not available."
-            };
-
             var placeholderReason = pathContainsProtectedTokenPlaceholder
                 ? " ProtectedToken.Placeholder cannot be replaced without a valid protected access token."
                 : string.Empty;
 
-            throw new InvalidOperationException($"A valid protected access token is required for this request. {reason}{placeholderReason}");
+            return new InvalidOperationException($"A valid protected access token is required for this request. {reason}{placeholderReason}");
         }
 
         private static bool RequestPathContainsProtectedTokenPlaceholder(PapiRestRequest request)
@@ -319,24 +283,57 @@ namespace Clc.Polaris.Api
             return request?.Path?.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) >= 0;
         }
 
-        private void ReplaceProtectedTokenPlaceholderInPath(PapiRestRequest request)
+        private static void ReplaceProtectedTokenPlaceholderInPath(PapiRestRequest request, ProtectedToken token)
         {
-            var token = Token;
-            var accessToken = token?.AccessToken;
-            if (IsProtectedTokenMissingOrExpired(token) || string.IsNullOrWhiteSpace(accessToken))
+            if (!IsProtectedTokenUsable(token))
             {
                 throw new InvalidOperationException("A valid protected access token is required to replace ProtectedToken.Placeholder in the request path.");
             }
 
-            request.Path = request.Path.Replace(ProtectedToken.Placeholder, accessToken, StringComparison.Ordinal);
+            request.Path = request.Path.Replace(ProtectedToken.Placeholder, token.AccessToken, StringComparison.Ordinal);
         }
 
-        private async Task<ProtectedTokenAcquisitionResult> EnsureProtectedTokenAsync(CancellationToken cancellationToken = default)
+        private async Task<ProtectedToken> GetProtectedTokenOrThrowAsync(bool pathContainsProtectedTokenPlaceholder, CancellationToken cancellationToken = default)
         {
-            var token = Token;
+            var cacheKey = BuildProtectedTokenCacheKey();
+            if (TryUseCurrentOrCachedProtectedToken(cacheKey, out var token))
+            {
+                return token!;
+            }
+
+            if (StaffOverrideAccount == null)
+            {
+                throw CreateProtectedTokenRequiredException("No staff override credentials are configured.", pathContainsProtectedTokenPlaceholder);
+            }
+
+            if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
+            {
+                return await AuthenticateAndLoadProtectedTokenOrThrowAsync(null, pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false);
+            }
+
+            var cacheLock = ProtectedTokenCacheLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
+            await cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (TryUseCurrentOrCachedProtectedToken(cacheKey, out token))
+                {
+                    return token!;
+                }
+
+                return await AuthenticateAndLoadProtectedTokenOrThrowAsync(cacheKey, pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                cacheLock.Release();
+            }
+        }
+
+        private bool TryUseCurrentOrCachedProtectedToken(string? cacheKey, out ProtectedToken? token)
+        {
+            token = Token;
             if (IsProtectedTokenUsable(token))
             {
-                return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.ValidTokenAvailable, token);
+                return true;
             }
 
             if (token != null)
@@ -344,48 +341,14 @@ namespace Clc.Polaris.Api
                 _token = null;
             }
 
-            if (StaffOverrideAccount == null)
-            {
-                return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.NoStaffCredentialsConfigured);
-            }
-
-            var cacheKey = BuildProtectedTokenCacheKey();
             if (TryLoadProtectedTokenFromCache(cacheKey))
             {
-                return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.ValidTokenAvailable, _token);
+                token = _token;
+                return true;
             }
 
-            if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
-            {
-                return await AuthenticateAndLoadProtectedTokenAsync(null, cancellationToken).ConfigureAwait(false);
-            }
-
-            var cacheLock = ProtectedTokenCacheLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
-            await cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-            try
-            {
-                token = Token;
-                if (IsProtectedTokenUsable(token))
-                {
-                    return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.ValidTokenAvailable, token);
-                }
-
-                if (token != null)
-                {
-                    _token = null;
-                }
-
-                if (TryLoadProtectedTokenFromCache(cacheKey))
-                {
-                    return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.ValidTokenAvailable, _token);
-                }
-
-                return await AuthenticateAndLoadProtectedTokenAsync(cacheKey, cancellationToken).ConfigureAwait(false);
-            }
-            finally
-            {
-                cacheLock.Release();
-            }
+            token = null;
+            return false;
         }
 
         private string? BuildProtectedTokenCacheKey()
@@ -446,12 +409,12 @@ namespace Clc.Polaris.Api
             return true;
         }
 
-        private async Task<ProtectedTokenAcquisitionResult> AuthenticateAndLoadProtectedTokenAsync(string? cacheKey, CancellationToken cancellationToken)
+        private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenOrThrowAsync(string? cacheKey, bool pathContainsProtectedTokenPlaceholder, CancellationToken cancellationToken)
         {
             var staffOverrideAccount = StaffOverrideAccount;
             if (staffOverrideAccount == null)
             {
-                return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.NoStaffCredentialsConfigured);
+                throw CreateProtectedTokenRequiredException("No staff override credentials are configured.", pathContainsProtectedTokenPlaceholder);
             }
 
             var response = await AuthenticateStaffUserAsync(staffOverrideAccount, cancellationToken).ConfigureAwait(false);
@@ -460,13 +423,13 @@ namespace Clc.Polaris.Api
             if (response?.Response == null || !response.Response.IsSuccessStatusCode)
             {
                 ClearFailedProtectedToken(cacheKey);
-                return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.StaffAuthenticationFailed);
+                throw CreateProtectedTokenRequiredException("Staff authentication did not succeed.", pathContainsProtectedTokenPlaceholder);
             }
 
             if (!IsProtectedTokenUsable(responseData))
             {
                 ClearFailedProtectedToken(cacheKey);
-                return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.InvalidTokenReturned);
+                throw CreateProtectedTokenRequiredException("Staff authentication did not return a usable protected access token.", pathContainsProtectedTokenPlaceholder);
             }
 
             _token = responseData;
@@ -476,7 +439,7 @@ namespace Clc.Polaris.Api
                 ProtectedTokenCache[cacheKey] = new ProtectedToken(responseData!);
             }
 
-            return new ProtectedTokenAcquisitionResult(ProtectedTokenAcquisitionStatus.ValidTokenAvailable, _token);
+            return _token!;
         }
 
         private void ClearFailedProtectedToken(string? cacheKey)

--- a/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs
@@ -160,16 +160,22 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         {
             var handler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.OK,
-                CreateProtectedTokenJson("custom-placeholder-token", "custom-placeholder-secret", DateTime.Now.AddHours(1)));
+                CreateProtectedTokenJson(
+                    "custom-placeholder-token",
+                    "custom-placeholder-secret",
+                    DateTime.Now.AddHours(1)));
             var client = CreateProtectedClient(handler);
-            var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
+            var request = PapiRestRequest.Get(
+                $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
 
             await client.ExecutePapiAsync<PapiResponseCommon>(request);
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             var finalRequest = handler.CapturedRequests.Single(capturedRequest => !capturedRequest.IsStaffAuthenticationRequest);
-            StringAssert.Contains(finalRequest.Path, "/protected/v1/1033/100/1/custom-placeholder-token/custom/unsupported");
+            StringAssert.Contains(
+                finalRequest.Path,
+                "/protected/v1/1033/100/1/custom-placeholder-token/custom/unsupported");
             Assert.IsFalse(finalRequest.Path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
             AssertAuthorizationHash(finalRequest, "custom-placeholder-secret", client.AccessKey, client.AccessID);
         }
@@ -179,9 +185,13 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         {
             var handler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.OK,
-                CreateProtectedTokenJson("custom-placeholder-token", "custom-placeholder-secret", DateTime.Now.AddHours(1)));
+                CreateProtectedTokenJson(
+                    "custom-placeholder-token",
+                    "custom-placeholder-secret",
+                    DateTime.Now.AddHours(1)));
             var client = CreateProtectedClient(handler);
-            var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
+            var request = PapiRestRequest.Get(
+                $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
             var originalPath = request.Path;
 
             await client.ExecutePapiAsync<PapiResponseCommon>(request);
@@ -190,11 +200,13 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         }
 
         [TestMethod]
-        public async Task ExecutePapiAsync_CustomProtectedRequestWithPlaceholder_RestoresOriginalPathAfterErrorResponse()
+        public async Task
+            ExecutePapiAsync_CustomProtectedRequestWithPlaceholder_RestoresOriginalPathAfterErrorResponse()
         {
             var handler = new ErrorProtectedRequestHttpMessageHandler(HttpStatusCode.InternalServerError);
             var client = CreateClientWithProtectedCache(handler, $"error-response-{Guid.NewGuid():N}");
-            var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
+            var request = PapiRestRequest.Get(
+                $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
             var originalPath = request.Path;
 
             await client.ExecutePapiAsync<PapiResponseCommon>(request);
@@ -202,6 +214,9 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             Assert.AreEqual(originalPath, request.Path);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
+            StringAssert.Contains(
+                handler.FinalRequestPath!,
+                "/protected/v1/1033/100/1/error-path-token/custom/unsupported");
         }
 
         [TestMethod]
@@ -304,24 +319,36 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             private readonly HttpStatusCode _protectedRequestStatusCode;
             public int AuthenticationRequestCount { get; private set; }
             public int NonAuthenticationRequestCount { get; private set; }
+            public string? FinalRequestPath { get; private set; }
 
             public ErrorProtectedRequestHttpMessageHandler(HttpStatusCode protectedRequestStatusCode)
             {
                 _protectedRequestStatusCode = protectedRequestStatusCode;
             }
 
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
             {
-                if (request.RequestUri!.AbsolutePath.EndsWith("/authenticator/staff", StringComparison.OrdinalIgnoreCase))
+                if (request.RequestUri!.AbsolutePath.EndsWith(
+                    "/authenticator/staff",
+                    StringComparison.OrdinalIgnoreCase))
                 {
                     AuthenticationRequestCount++;
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent(CreateProtectedTokenJson("error-path-token", "error-path-secret", DateTime.Now.AddHours(1)), Encoding.UTF8, "application/json")
+                        Content = new StringContent(
+                            CreateProtectedTokenJson(
+                                "error-path-token",
+                                "error-path-secret",
+                                DateTime.Now.AddHours(1)),
+                            Encoding.UTF8,
+                            "application/json")
                     });
                 }
 
                 NonAuthenticationRequestCount++;
+                FinalRequestPath = request.RequestUri.AbsolutePath;
                 return Task.FromResult(new HttpResponseMessage(_protectedRequestStatusCode)
                 {
                     Content = new StringContent("{\"PAPIErrorCode\":1}", Encoding.UTF8, "application/json")

--- a/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Clc.Polaris.Api.Models;
 using Clc.Polaris.Api.Tests;
@@ -188,6 +190,21 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         }
 
         [TestMethod]
+        public async Task ExecutePapiAsync_CustomProtectedRequestWithPlaceholder_RestoresOriginalPathAfterErrorResponse()
+        {
+            var handler = new ErrorProtectedRequestHttpMessageHandler(HttpStatusCode.InternalServerError);
+            var client = CreateClientWithProtectedCache(handler, $"error-response-{Guid.NewGuid():N}");
+            var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
+            var originalPath = request.Path;
+
+            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+
+            Assert.AreEqual(originalPath, request.Path);
+            Assert.AreEqual(1, handler.AuthenticationRequestCount);
+            Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
+        }
+
+        [TestMethod]
         public async Task ExecutePapiAsync_CustomPublicPatronRequest_UsesStaffOverrideTokenWhenAllowed()
         {
             var handler = new ProtectedTokenHttpMessageHandler(
@@ -280,6 +297,36 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var finalRequest = handler.CapturedRequests.Single();
             Assert.IsFalse(finalRequest.Headers.ContainsKey("X-PAPI-AccessToken"));
             AssertAuthorizationHash(finalRequest, string.Empty, client.AccessKey, client.AccessID);
+        }
+
+        private sealed class ErrorProtectedRequestHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly HttpStatusCode _protectedRequestStatusCode;
+            public int AuthenticationRequestCount { get; private set; }
+            public int NonAuthenticationRequestCount { get; private set; }
+
+            public ErrorProtectedRequestHttpMessageHandler(HttpStatusCode protectedRequestStatusCode)
+            {
+                _protectedRequestStatusCode = protectedRequestStatusCode;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (request.RequestUri!.AbsolutePath.EndsWith("/authenticator/staff", StringComparison.OrdinalIgnoreCase))
+                {
+                    AuthenticationRequestCount++;
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(CreateProtectedTokenJson("error-path-token", "error-path-secret", DateTime.Now.AddHours(1)), Encoding.UTF8, "application/json")
+                    });
+                }
+
+                NonAuthenticationRequestCount++;
+                return Task.FromResult(new HttpResponseMessage(_protectedRequestStatusCode)
+                {
+                    Content = new StringContent("{\"PAPIErrorCode\":1}", Encoding.UTF8, "application/json")
+                });
+            }
         }
     }
 }

--- a/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs
@@ -160,22 +160,16 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         {
             var handler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.OK,
-                CreateProtectedTokenJson(
-                    "custom-placeholder-token",
-                    "custom-placeholder-secret",
-                    DateTime.Now.AddHours(1)));
+                CreateProtectedTokenJson("custom-placeholder-token", "custom-placeholder-secret", DateTime.Now.AddHours(1)));
             var client = CreateProtectedClient(handler);
-            var request = PapiRestRequest.Get(
-                $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
+            var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
 
             await client.ExecutePapiAsync<PapiResponseCommon>(request);
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             var finalRequest = handler.CapturedRequests.Single(capturedRequest => !capturedRequest.IsStaffAuthenticationRequest);
-            StringAssert.Contains(
-                finalRequest.Path,
-                "/protected/v1/1033/100/1/custom-placeholder-token/custom/unsupported");
+            StringAssert.Contains(finalRequest.Path, "/protected/v1/1033/100/1/custom-placeholder-token/custom/unsupported");
             Assert.IsFalse(finalRequest.Path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
             AssertAuthorizationHash(finalRequest, "custom-placeholder-secret", client.AccessKey, client.AccessID);
         }
@@ -185,13 +179,9 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         {
             var handler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.OK,
-                CreateProtectedTokenJson(
-                    "custom-placeholder-token",
-                    "custom-placeholder-secret",
-                    DateTime.Now.AddHours(1)));
+                CreateProtectedTokenJson("custom-placeholder-token", "custom-placeholder-secret", DateTime.Now.AddHours(1)));
             var client = CreateProtectedClient(handler);
-            var request = PapiRestRequest.Get(
-                $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
+            var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
             var originalPath = request.Path;
 
             await client.ExecutePapiAsync<PapiResponseCommon>(request);
@@ -200,13 +190,11 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         }
 
         [TestMethod]
-        public async Task
-            ExecutePapiAsync_CustomProtectedRequestWithPlaceholder_RestoresOriginalPathAfterErrorResponse()
+        public async Task ExecutePapiAsync_CustomProtectedRequestWithPlaceholder_RestoresOriginalPathAfterErrorResponse()
         {
             var handler = new ErrorProtectedRequestHttpMessageHandler(HttpStatusCode.InternalServerError);
             var client = CreateClientWithProtectedCache(handler, $"error-response-{Guid.NewGuid():N}");
-            var request = PapiRestRequest.Get(
-                $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
+            var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
             var originalPath = request.Path;
 
             await client.ExecutePapiAsync<PapiResponseCommon>(request);
@@ -326,24 +314,14 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
                 _protectedRequestStatusCode = protectedRequestStatusCode;
             }
 
-            protected override Task<HttpResponseMessage> SendAsync(
-                HttpRequestMessage request,
-                CancellationToken cancellationToken)
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
-                if (request.RequestUri!.AbsolutePath.EndsWith(
-                    "/authenticator/staff",
-                    StringComparison.OrdinalIgnoreCase))
+                if (request.RequestUri!.AbsolutePath.EndsWith("/authenticator/staff", StringComparison.OrdinalIgnoreCase))
                 {
                     AuthenticationRequestCount++;
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent(
-                            CreateProtectedTokenJson(
-                                "error-path-token",
-                                "error-path-secret",
-                                DateTime.Now.AddHours(1)),
-                            Encoding.UTF8,
-                            "application/json")
+                        Content = new StringContent(CreateProtectedTokenJson("error-path-token", "error-path-secret", DateTime.Now.AddHours(1)), Encoding.UTF8, "application/json")
                     });
                 }
 

--- a/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Clc.Polaris.Api.Models;
 using Clc.Polaris.Api.Tests;
@@ -192,8 +189,12 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_CustomProtectedRequestWithPlaceholder_RestoresOriginalPathAfterErrorResponse()
         {
-            var handler = new ErrorProtectedRequestHttpMessageHandler(HttpStatusCode.InternalServerError);
-            var client = CreateClientWithProtectedCache(handler, $"error-response-{Guid.NewGuid():N}");
+            var handler = new ProtectedTokenHttpMessageHandler(
+                HttpStatusCode.OK,
+                CreateProtectedTokenJson("error-path-token", "error-path-secret", DateTime.Now.AddHours(1)),
+                HttpStatusCode.InternalServerError,
+                "{\"PAPIErrorCode\":1}");
+            var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
             var originalPath = request.Path;
 
@@ -202,9 +203,8 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             Assert.AreEqual(originalPath, request.Path);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
-            StringAssert.Contains(
-                handler.FinalRequestPath!,
-                "/protected/v1/1033/100/1/error-path-token/custom/unsupported");
+            var finalRequest = handler.CapturedRequests.Single(request => !request.IsStaffAuthenticationRequest);
+            StringAssert.Contains(finalRequest.Path, "/protected/v1/1033/100/1/error-path-token/custom/unsupported");
         }
 
         [TestMethod]
@@ -302,36 +302,5 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             AssertAuthorizationHash(finalRequest, string.Empty, client.AccessKey, client.AccessID);
         }
 
-        private sealed class ErrorProtectedRequestHttpMessageHandler : HttpMessageHandler
-        {
-            private readonly HttpStatusCode _protectedRequestStatusCode;
-            public int AuthenticationRequestCount { get; private set; }
-            public int NonAuthenticationRequestCount { get; private set; }
-            public string? FinalRequestPath { get; private set; }
-
-            public ErrorProtectedRequestHttpMessageHandler(HttpStatusCode protectedRequestStatusCode)
-            {
-                _protectedRequestStatusCode = protectedRequestStatusCode;
-            }
-
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                if (request.RequestUri!.AbsolutePath.EndsWith("/authenticator/staff", StringComparison.OrdinalIgnoreCase))
-                {
-                    AuthenticationRequestCount++;
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = new StringContent(CreateProtectedTokenJson("error-path-token", "error-path-secret", DateTime.Now.AddHours(1)), Encoding.UTF8, "application/json")
-                    });
-                }
-
-                NonAuthenticationRequestCount++;
-                FinalRequestPath = request.RequestUri.AbsolutePath;
-                return Task.FromResult(new HttpResponseMessage(_protectedRequestStatusCode)
-                {
-                    Content = new StringContent("{\"PAPIErrorCode\":1}", Encoding.UTF8, "application/json")
-                });
-            }
-        }
     }
 }

--- a/src/polaris-api-csharpTests/TestInfrastructure/PapiClientTestBase.cs
+++ b/src/polaris-api-csharpTests/TestInfrastructure/PapiClientTestBase.cs
@@ -302,6 +302,8 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
             private readonly HttpStatusCode _authenticationStatusCode;
             private readonly string _authenticationResponseJson;
             private readonly Func<CapturedPapiRequest, (HttpStatusCode StatusCode, string ResponseJson)>? _authenticationResponseFactory;
+            private readonly HttpStatusCode _nonAuthenticationStatusCode;
+            private readonly string _nonAuthenticationResponseJson;
             private int _authenticationRequestCount;
             private int _nonAuthenticationRequestCount;
             private readonly ConcurrentQueue<string> _requestPaths = new ConcurrentQueue<string>();
@@ -312,10 +314,16 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
             public string[] RequestPaths => _requestPaths.ToArray();
             public CapturedPapiRequest[] CapturedRequests => _capturedRequests.ToArray();
 
-            public ProtectedTokenHttpMessageHandler(HttpStatusCode authenticationStatusCode = HttpStatusCode.OK, string? authenticationResponseJson = null)
+            public ProtectedTokenHttpMessageHandler(
+                HttpStatusCode authenticationStatusCode = HttpStatusCode.OK,
+                string? authenticationResponseJson = null,
+                HttpStatusCode nonAuthenticationStatusCode = HttpStatusCode.OK,
+                string? nonAuthenticationResponseJson = null)
             {
                 _authenticationStatusCode = authenticationStatusCode;
                 _authenticationResponseJson = authenticationResponseJson ?? CreateProtectedTokenJson("protected-token", "protected-secret", DateTime.Now.AddHours(1));
+                _nonAuthenticationStatusCode = nonAuthenticationStatusCode;
+                _nonAuthenticationResponseJson = nonAuthenticationResponseJson ?? "{\"PAPIErrorCode\":0}";
             }
 
             public ProtectedTokenHttpMessageHandler(Func<CapturedPapiRequest, (HttpStatusCode StatusCode, string ResponseJson)> authenticationResponseFactory)
@@ -343,9 +351,9 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
                 }
 
                 Interlocked.Increment(ref _nonAuthenticationRequestCount);
-                return new HttpResponseMessage(HttpStatusCode.OK)
+                return new HttpResponseMessage(_nonAuthenticationStatusCode)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                    Content = new StringContent(_nonAuthenticationResponseJson, Encoding.UTF8, "application/json")
                 };
             }
         }


### PR DESCRIPTION
### Motivation

- Reduce ceremony and indirection in the PAPI protected-token acquisition flow while preserving existing behavior and public API surface.
- Replace the protected-token status/result-object pattern with a simpler token-or-throw flow.
- Make placeholder replacement deterministic by using the protected token acquired for the current request instead of re-reading `Token` during path replacement.
- Preserve static cross-client protected-token cache behavior, cache locking, staff-override behavior, request path restoration, and cancellation behavior.

### Description

- Removed the `ProtectedTokenAcquisitionResult` and `ProtectedTokenAcquisitionStatus` types.
- Replaced `EnsureProtectedTokenAsync` with `GetProtectedTokenOrThrowAsync`, which returns a usable `ProtectedToken` or throws an `InvalidOperationException` with preserved protected-token failure messaging.
- Replaced `AuthenticateAndLoadProtectedTokenAsync` with `AuthenticateAndLoadProtectedTokenOrThrowAsync`, which throws on missing staff credentials, failed staff authentication, or unusable returned tokens while preserving cache update/clear behavior.
- Simplified `ExecutePapiAsync` so the request flow is now:
  - validate the custom PAPI request;
  - detect whether the path contains `ProtectedToken.Placeholder`;
  - determine whether a protected token is required;
  - acquire a protected token when required;
  - replace `ProtectedToken.Placeholder` before sending;
  - execute the request;
  - restore the original request path in `finally`.
- Updated protected-token cache loading so `TryLoadProtectedTokenFromCache` returns the cloned protected token through an `out` parameter instead of forcing callers to re-read `Token`.
- Preserved the semaphore double-check pattern:
  - check current token/cache before acquiring the cache-key lock;
  - check current token/cache again after acquiring the lock;
  - authenticate only after both checks fail.
- Kept public properties and behavior intact:
  - `AllowStaffOverrideRequests`
  - `StaffOverrideAccount`
  - `UseProtectedTokenCache`
  - `Token`
  - static `ProtectedTokenCache`
  - static `ProtectedTokenCacheLocks`
- Extended `ProtectedTokenHttpMessageHandler` test infrastructure to support configurable non-authentication responses.
- Updated the protected-token placeholder/error-response test to use the shared test handler and assert both:
  - the final outbound request path used the acquired protected token;
  - the original request path was restored afterward.
- Files changed:
  - `src/polaris-api-csharp/PapiClient.cs`
  - `src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs`
  - `src/polaris-api-csharpTests/TestInfrastructure/PapiClientTestBase.cs`

### Testing

- Ran `dotnet build src/polaris-api-csharp.sln`
- Ran `dotnet test src/polaris-api-csharp.sln --no-build`
- Ran `git diff --check`

### Notes

- No public API changes were made.
- No `IAuthenticator` implementations, factories, strategy classes, or service abstractions were introduced.
- Static protected-token cache and lock behavior were preserved.
- Caller-requested cancellation continues to propagate rather than being wrapped or swallowed.