### PR TITLE
Improve barcode route encoding and test cleanup

### DIFF
--- a/.github/workflows/build-test-publish.yaml
+++ b/.github/workflows/build-test-publish.yaml
@@ -146,7 +146,11 @@ jobs:
     needs: build-test-pack
     if: startsWith(github.ref, 'refs/tags/v')
     timeout-minutes: 10
-
+    environment: nuget-production
+    permissions:
+      contents: read
+      id-token: write
+      
     steps:
       - name: Download package artifacts
         uses: actions/download-artifact@v8
@@ -158,10 +162,16 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+          
+      - name: Login to NuGet
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: clcdpc
 
       - name: Publish package to nuget.org
         run: >
           dotnet nuget push "$PACKAGE_OUTPUT_DIR/*.nupkg"
-          --api-key "${{ secrets.NUGET_API_KEY }}"
+          --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY  }}"
           --source "$NUGET_SOURCE"
           --skip-duplicate

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -2,3 +2,6 @@
 
 # CA1707: Identifiers should not contain underscores
 dotnet_diagnostic.CA1707.severity = none
+
+# IDE0130: Namespace does not match folder structure
+dotnet_diagnostic.IDE0130.severity = none

--- a/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
+++ b/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<CreatePatronBlocksResult>> CreatePatronBlocksAsync(string barcode, BlockType blockType, string blockValue, int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {
-            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/blocks";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{EncodeBarcodePathSegment(barcode)}/blocks";
             var body = new CreatePatronBlocksRequest((int)blockType, blockValue);
             var request = PapiRestRequest.Post(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/HoldRequestCancel.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestCancel.cs
@@ -9,7 +9,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<HoldRequestCancelResult>> HoldRequestCancelAsync(string barcode, int requestId, string password = "", int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/cancelled";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/holdrequests/{requestId}/cancelled";
             var request = PapiRestRequest.Put(url, password: password);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);

--- a/src/polaris-api-csharp/Methods/HoldRequestReactivate.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestReactivate.cs
@@ -12,7 +12,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<HoldRequestActivationResult>> HoldRequestReactivateAsync(string barcode, string password, int requestId, DateTime activationDate, int? userId = null, CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/active";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/holdrequests/{requestId}/active";
             var body = new { HoldRequestActivationData = new { UserId = userId ?? UserId, activationDate } };
             var request = PapiRestRequest.Put(url, body: body, password: password);
             return await ExecutePapiAsync<HoldRequestActivationResult>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/HoldRequestSuspend.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestSuspend.cs
@@ -13,7 +13,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<HoldRequestActivationResult>> HoldRequestSuspendAsync(string barcode, int requestId, DateTime activationDate, string password = "", int? userId = null, CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/inactive";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/holdrequests/{requestId}/inactive";
             var json = new { HoldRequestActivationData = new { UserId = userId ?? UserId, activationDate } };
             var request = PapiRestRequest.Put(url, body: json, password: password);
             return await ExecutePapiAsync<HoldRequestActivationResult>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/ItemRenew.cs
+++ b/src/polaris-api-csharp/Methods/ItemRenew.cs
@@ -11,7 +11,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<ItemRenewResultWrapper>> ItemRenewAsync(string barcode, int itemId, string password = "", ItemRenewOptions? renewOptions = null, CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/itemsout/{itemId}";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/itemsout/{itemId}";
             var request = PapiRestRequest.Put(url, body: renewOptions ?? new ItemRenewOptions(), password: password);
             return await ExecutePapiAsync<ItemRenewResultWrapper>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
+++ b/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
@@ -2,10 +2,10 @@ using Clc.Polaris.Api.Models;
 using Clc.Polaris.Api.Validation;
 using Clc.Rest;
 using System;
+using System.Globalization;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 
 namespace Clc.Polaris.Api
 {
@@ -20,7 +20,12 @@ namespace Clc.Polaris.Api
 
             if (itemRecordId is int itemRecordIdentifier)
             {
-                itemIdentifier = itemRecordIdentifier.ToString();
+                if (itemRecordIdentifier <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(itemRecordId));
+                }
+
+                itemIdentifier = itemRecordIdentifier.ToString(CultureInfo.InvariantCulture);
             }
             else
             {

--- a/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
+++ b/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
@@ -1,10 +1,11 @@
+using Clc.Polaris.Api.Models;
+using Clc.Polaris.Api.Validation;
+using Clc.Rest;
 using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using Clc.Polaris.Api.Models;
 
 namespace Clc.Polaris.Api
 {
@@ -12,15 +13,38 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<PapiResponseCommon>> ItemUpdateBarcodeAsync(string newBarcode, int? itemRecordId = null, int? transactionBranchId = null, string oldBarcode = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/cataloging/items/{(itemRecordId.HasValue ? itemRecordId.Value.ToString() : oldBarcode)}/barcode";
-            var body = new ItemUpdateBarcodeData { ItemBarcode = newBarcode, TransactionBranchId = transactionBranchId ?? OrganizationId };
+            Require.Argument(newBarcode);
+
+            string itemIdentifier;
+            var isBarcodeLookup = false;
+
+            if (itemRecordId is int itemRecordIdentifier)
+            {
+                itemIdentifier = itemRecordIdentifier.ToString();
+            }
+            else
+            {
+                Require.Argument(oldBarcode);
+                itemIdentifier = WebUtility.UrlEncode(oldBarcode);
+                isBarcodeLookup = true;
+            }
+
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/cataloging/items/{itemIdentifier}/barcode";
+            var body = new ItemUpdateBarcodeData
+            {
+                ItemBarcode = newBarcode,
+                TransactionBranchId = transactionBranchId ?? OrganizationId
+            };
+
             var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", transactionBranchId ?? WorkstationId);
-            if (!string.IsNullOrWhiteSpace(oldBarcode)) { request.QueryParameters.Add("isBarcode", 1); }
+
+            if (isBarcodeLookup)
+            {
+                request.QueryParameters.Add("isBarcode", 1);
+            }
+
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }
-
-
-
     }
 }

--- a/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
+++ b/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
@@ -30,7 +30,7 @@ namespace Clc.Polaris.Api
             else
             {
                 Require.Argument(oldBarcode);
-                itemIdentifier = WebUtility.UrlEncode(oldBarcode);
+                itemIdentifier = EncodeBarcodePathSegment(oldBarcode);
                 isBarcodeLookup = true;
             }
 

--- a/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountCreateCreditAsync(string barcode, double txnAmount, PaymentMethod paymentMethod, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/createcredit";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{EncodeBarcodePathSegment(barcode)}/account/createcredit";
             var body = new PatronAccountCreateCreditData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountCreateTitleList.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountCreateTitleList.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountCreateTitleListAsync(string barcode, string listName, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patronaccountcreatetitlelist";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/patronaccountcreatetitlelist";
             var body = new PatronAccountCreateTitleListData { RecordStoreName = listName };
             var request = PapiRestRequest.Post(url, body: body, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronAccountDeleteTitleList.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDeleteTitleList.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountDeleteTitleListAsync(string barcode, int listId, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patronaccountdeletetitlelist";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/patronaccountdeletetitlelist";
             var request = PapiRestRequest.Delete(url, password: password);
             request.QueryParameters.Add("list", listId);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountDepositCreditAsync(string barcode, double txnAmount, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumdepositcredit";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{EncodeBarcodePathSegment(barcode)}/account/lumpsumdepositcredit";
             var body = new PatronAccountDepositCreditData { TxnAmount = txnAmount, FreeTextNote = note };
             var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountGet.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronAccountGetResult>> PatronAccountGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/account/outstanding";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/account/outstanding";
             var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronAccountGetResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronAccountGetTitleLists.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountGetTitleLists.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronAccountGetTitleListsResult>> PatronAccountGetTitleListsAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patronaccountgettitlelists";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/patronaccountgettitlelists";
             var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronAccountGetTitleListsResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronAccountPay.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPay.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountPayAsync(string barcode, int txnId, double txnAmount, PaymentMethod paymentMethod, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/{txnId}/pay";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{EncodeBarcodePathSegment(barcode)}/account/{txnId}/pay";
             var body = new PatronAccountPayData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountPayAllAsync(string barcode, double txnAmount, PaymentMethod paymentMethod, int? workstationId = 1, int? userId = 1, string note = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumpayment";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{EncodeBarcodePathSegment(barcode)}/account/lumpsumpayment";
             var body = new PatronAccountPayData { TxnAmount = txnAmount, PaymentMethodId = paymentMethod, FreeTextNote = note };
             var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountRefundCreditAsync(string barcode, double txnAmount, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/lumpsumrefundcredit";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{EncodeBarcodePathSegment(barcode)}/account/lumpsumrefundcredit";
             var body = new PatronAccountRefundCreditData { TxnAmount = txnAmount, FreeTextNote = note };
             var request = PapiRestRequest.Put(url, body: body);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronAccountVoidAsync(string barcode, int paymentTxnId, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/account/{paymentTxnId}/void/payment";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{EncodeBarcodePathSegment(barcode)}/account/{paymentTxnId}/void/payment";
             var request = PapiRestRequest.Delete(url);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);
             request.QueryParameters.Add("userid", userId ?? UserId);

--- a/src/polaris-api-csharp/Methods/PatronBasicDataGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronBasicDataGet.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronBasicDataGetResult>> PatronBasicDataGetAsync(string barcode, string password = "", bool addresses = false, bool notes = false, CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/basicdata";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/basicdata";
             var request = PapiRestRequest.Get(url, password: password);
             request.QueryParameters.Add("addresses", Convert.ToInt32(addresses));
             request.QueryParameters.Add("notes", Convert.ToInt32(notes));

--- a/src/polaris-api-csharp/Methods/PatronCirculateBlocksGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronCirculateBlocksGet.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronCirculateBlocksResult>> PatronCirculateBlocksGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/circulationblocks";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/circulationblocks";
             var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronCirculateBlocksResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronHoldRequestsGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronHoldRequestsGet.cs
@@ -12,7 +12,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronHoldRequestsGetResult>> PatronHoldRequestsGetAsync(string barcode, PatronHoldStatus status = PatronHoldStatus.all, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{status}";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/holdrequests/{status}";
             var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronHoldRequestsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronILLRequestsGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronILLRequestsGet.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronILLRequestsGetResult>> PatronILLRequestsGetAsync(string barcode, ILLStatus status = ILLStatus.All, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/illrequests/{status}";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/illrequests/{status}";
             var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronILLRequestsGetResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronItemsOutGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronItemsOutGet.cs
@@ -11,7 +11,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronItemsOutGetResult>> PatronItemsOutGetAsync(string barcode, PatronItemsOutGetStatus status = PatronItemsOutGetStatus.All, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/itemsout/{status}";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/itemsout/{status}";
             var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronItemsOutGetResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronMessageDelete.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessageDelete.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronMessageDeleteAsync(string barcode, PatronMessageType messageType, int messageId, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/messages/{messageType}/{messageId}";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/messages/{messageType}/{messageId}";
             var request = PapiRestRequest.Delete(url, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronMessageUpdateStatus.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessageUpdateStatus.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronMessageUpdateStatusAsync(string barcode, PatronMessageType messageType, int messageId, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/messages/{messageType}/{messageId}";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/messages/{messageType}/{messageId}";
             var request = PapiRestRequest.Put(url, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronMessagesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessagesGet.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronMessagesGetResult>> PatronMessagesGetAsync(string barcode, bool unreadOnly = false, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/messages";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/messages";
             var request = PapiRestRequest.Get(url, password: password);
             request.QueryParameters.Add("unreadonly", unreadOnly ? 1 : 0);
             return await ExecutePapiAsync<PatronMessagesGetResult>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronPreferencesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronPreferencesGet.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronPreferencesGetResult>> PatronPreferencesGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/preferences";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/preferences";
             var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronPreferencesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
+++ b/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<PapiResponseCommon>> PatronReadingHistoryClearAsync(string barcode, string? password, IEnumerable<int> ids, CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/readinghistory";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/readinghistory";
             var request = PapiRestRequest.Delete(url, password: password ?? string.Empty);
             var idList = ids?.ToArray() ?? Array.Empty<int>();
             if (idList.Length > 0)

--- a/src/polaris-api-csharp/Methods/PatronReadingHistoryGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronReadingHistoryGet.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronReadingHistoryGetResult>> PatronReadingHistoryGetAsync(string barcode, int page = 1, int rowsPerPage = 50, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/readinghistory";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/readinghistory";
             var request = PapiRestRequest.Get(url, password: password);
             request.QueryParameters.Add("page", page);
             request.QueryParameters.Add("rowsperpage", rowsPerPage);

--- a/src/polaris-api-csharp/Methods/PatronSavedSearchesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronSavedSearchesGet.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronSavedSearchesGetResult>> PatronSavedSearchesGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/savedsearches";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/savedsearches";
             var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronSavedSearchesGetResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronTitleListAddTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListAddTitle.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronTitleListAddTitleResult>> PatronTitleListAddTitleAsync(string barcode, int recordStoreId, int localControlNumber, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistaddtitle/";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/patrontitlelistaddtitle/";
             var body = new PatronTitleListAddTitleData { RecordStoreId = recordStoreId, LocalControlNumber = localControlNumber };
             var request = PapiRestRequest.Post(url, body: body, password: password);
             return await ExecutePapiAsync<PatronTitleListAddTitleResult>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronTitleListCopyAllTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListCopyAllTitles.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronTitleListCopyAllTitlesAsync(string barcode, int fromRecordStoreId, int toRecordStoreId, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistcopyalltitles/";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/patrontitlelistcopyalltitles/";
             var body = new PatronTitleListCopyAllTitlesData { FromRecordStoreId = fromRecordStoreId, ToRecordStoreId = toRecordStoreId };
             var request = PapiRestRequest.Post(url, body: body, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronTitleListCopyTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListCopyTitle.cs
@@ -23,7 +23,7 @@ namespace Clc.Polaris.Api
         /// <returns></returns>
         public async Task<IRestResponse<PapiResponseCommon>> PatronTitleListCopyTitleAsync(string barcode, int fromRecordStoreId, int fromPosition, int toRecordStoreId, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistcopytitle/";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/patrontitlelistcopytitle/";
             var body = new PatronTitleListCopyTitleData { FromRecordStoreId = fromRecordStoreId, FromPosition = fromPosition, ToRecordStoreId = toRecordStoreId };
             var request = PapiRestRequest.Post(url, body: body, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronTitleListDeleteAllTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListDeleteAllTitles.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronTitleListDeleteAllTitlesAsync(string barcode, int listId, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistdeletealltitles";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/patrontitlelistdeletealltitles";
             var request = PapiRestRequest.Delete(url, password: password);
             request.QueryParameters.Add("list", listId);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs
@@ -25,7 +25,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronTitleListDeleteTitleAsync(string barcode, int listId, int position, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistdeletetitle";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/patrontitlelistdeletetitle";
             var request = PapiRestRequest.Delete(url, password: password);
             request.QueryParameters.Add("list", listId);
             request.QueryParameters.Add("position", position);

--- a/src/polaris-api-csharp/Methods/PatronTitleListGetTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListGetTitles.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronTitleListGetTitlesResult>> PatronTitleListGetTitlesAsync(string barcode, int listId, int startPosition = 1, int endPosition = 100, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistgettitles";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/patrontitlelistgettitles";
             var request = PapiRestRequest.Get(url, password: password);
             request.QueryParameters.Add("list", listId);
             request.QueryParameters.Add("startPosition", startPosition);

--- a/src/polaris-api-csharp/Methods/PatronTitleListMoveTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListMoveTitle.cs
@@ -26,7 +26,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronTitleListMoveTitleAsync(string barcode, int fromRecordStoreId, int fromPosition, int toRecordStoreId, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/patrontitlelistmovetitle/";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/patrontitlelistmovetitle/";
             var body = new PatronTitleListMoveTitleData { FromRecordStoreId = fromRecordStoreId, FromPosition = fromPosition, ToRecordStoreId = toRecordStoreId };
             var request = PapiRestRequest.Post(url, body: body, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronUpdate.cs
+++ b/src/polaris-api-csharp/Methods/PatronUpdate.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronUpdateResult>> PatronUpdateAsync(string barcode, PatronUpdateParams updateParams, string password = "", bool ignoresa = true, CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}";
             var request = PapiRestRequest.Put(url, body: updateParams, password: password);
             request.QueryParameters.Add("ignoresa", ignoresa);
             return await ExecutePapiAsync<PatronUpdateResult>(request, cancellationToken).ConfigureAwait(false);

--- a/src/polaris-api-csharp/Methods/PatronUpdateUserName.cs
+++ b/src/polaris-api-csharp/Methods/PatronUpdateUserName.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> PatronUpdateUserNameAsync(string barcode, string newUsername, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/username/{WebUtility.UrlEncode(newUsername)}";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/username/{WebUtility.UrlEncode(newUsername)}";
             var request = PapiRestRequest.Put(url, password: password);
             return await ExecutePapiAsync<PapiResponseCommon>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/PatronValidate.cs
+++ b/src/polaris-api-csharp/Methods/PatronValidate.cs
@@ -11,7 +11,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PatronValidateResult>> PatronValidateAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}";
             var request = PapiRestRequest.Get(url, password: password);
             return await ExecutePapiAsync<PatronValidateResult>(request, cancellationToken).ConfigureAwait(false);
         }

--- a/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
     {
         public async Task<IRestResponse<PapiResponseCommon>> UpdatePatronNotesDataAsync(string barcode, string? nonBlockingNote = null, string? blockingNote = null, UpdateNoteMode updateMode = UpdateNoteMode.Prepend, int? workstationId = null, CancellationToken cancellationToken = default)
         {
-            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{WebUtility.UrlEncode(barcode)}/notes";
+            var url = $"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/{EncodeBarcodePathSegment(barcode)}/notes";
             var body = new UpdatePatronNotesData();
 
             if (!string.IsNullOrWhiteSpace(nonBlockingNote))

--- a/src/polaris-api-csharp/Methods/UpdatePickupBranchID.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePickupBranchID.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api
 
         public async Task<IRestResponse<PapiResponseCommon>> UpdatePickupBranchIDAsync(string barcode, int requestId, int pickupBranchId, string password = "", int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {
-            var url = $"/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/pickupbranch";
+            var url = $"/public/v1/1033/100/1/patron/{EncodeBarcodePathSegment(barcode)}/holdrequests/{requestId}/pickupbranch";
             var request = PapiRestRequest.Put(url, password: password);
             request.QueryParameters.Add("userid", userId ?? UserId);
             request.QueryParameters.Add("wsid", workstationId ?? WorkstationId);

--- a/src/polaris-api-csharp/Models/PapiRestRequest.cs
+++ b/src/polaris-api-csharp/Models/PapiRestRequest.cs
@@ -16,19 +16,19 @@ namespace Clc.Polaris.Api.Models
         public bool IsProtectedMethod => Path.StartsWith("/protected", StringComparison.OrdinalIgnoreCase);
 
         public static PapiRestRequest Get(string path, string password = "", object? body = null) =>
-            new PapiRestRequest(HttpMethod.Get, path, password, body);
+            new(HttpMethod.Get, path, password, body);
 
         public static PapiRestRequest Delete(string path, string password = "", object? body = null) =>
-            new PapiRestRequest(HttpMethod.Delete, path, password, body);
+            new(HttpMethod.Delete, path, password, body);
 
         public static PapiRestRequest Post(string path, object? body = null, string password = "") =>
-            new PapiRestRequest(HttpMethod.Post, path, password, body);
+            new(HttpMethod.Post, path, password, body);
 
         public static PapiRestRequest Put(string path, object? body = null, string password = "") =>
-            new PapiRestRequest(HttpMethod.Put, path, password, body);
+            new(HttpMethod.Put, path, password, body);
 
         public static PapiRestRequest Create(HttpMethod method, string path, object? body = null, string password = "") =>
-            new PapiRestRequest(method, path, password, body);
+            new(method, path, password, body);
 
         public PapiRestRequest()
         {

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -1,12 +1,13 @@
-﻿using Clc.Rest.Models;
-using Clc.Polaris.Api.Configuration;
+﻿using Clc.Polaris.Api.Configuration;
 using Clc.Polaris.Api.Models;
 using Clc.Rest;
+using Clc.Rest.Models;
 using System;
+using System.Collections.Concurrent;
+using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
-using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -527,5 +528,6 @@ namespace Clc.Polaris.Api
             _token = null;
         }
 
+        private static string EncodeBarcodePathSegment(string barcode) => EncodeBarcodePathSegment(barcode);
     }
 }

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -200,10 +200,7 @@ namespace Clc.Polaris.Api
 
         private static void ValidateCustomPapiRequest(PapiRestRequest request)
         {
-            if (request == null)
-            {
-                throw new ArgumentNullException(nameof(request));
-            }
+            ArgumentNullException.ThrowIfNull(request);
 
             if (string.IsNullOrWhiteSpace(request.Path))
             {
@@ -220,7 +217,7 @@ namespace Clc.Polaris.Api
                 throw new ArgumentException("PAPI request path must not be a protocol-relative URL.", nameof(request));
             }
 
-            if (!request.Path.StartsWith("/", StringComparison.Ordinal))
+            if (!request.Path.StartsWith('/'))
             {
                 throw new ArgumentException("PAPI request path must begin with '/'.", nameof(request));
             }
@@ -493,12 +490,7 @@ namespace Clc.Polaris.Api
 
         private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenOrThrowAsync(string? cacheKey, bool pathContainsProtectedTokenPlaceholder, CancellationToken cancellationToken)
         {
-            var staffOverrideAccount = StaffOverrideAccount;
-            if (staffOverrideAccount == null)
-            {
-                throw CreateProtectedTokenRequiredException("No staff override credentials are configured.", pathContainsProtectedTokenPlaceholder);
-            }
-
+            var staffOverrideAccount = StaffOverrideAccount ?? throw CreateProtectedTokenRequiredException("No staff override credentials are configured.", pathContainsProtectedTokenPlaceholder);
             var response = await AuthenticateStaffUserAsync(staffOverrideAccount, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             var responseData = response?.Data;

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -528,6 +528,6 @@ namespace Clc.Polaris.Api
             _token = null;
         }
 
-        private static string EncodeBarcodePathSegment(string barcode) => EncodeBarcodePathSegment(barcode);
+        private static string EncodeBarcodePathSegment(string barcode) => WebUtility.UrlEncode(barcode);
     }
 }

--- a/src/polaris-api-csharpTests/Methods/ApiKeyValidateTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ApiKeyValidateTests.cs
@@ -9,8 +9,10 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task ApiKeyValidateTest()
         {
-            var response = await Papi.ApiKeyValidateAsync();
+            var response = await Papi.ApiKeyValidateAsync(TestContext.CancellationToken);
             Assert.AreEqual(0, response.Data.PAPIErrorCode);
         }
+
+        public TestContext TestContext { get; set; }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/ApiVersionGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ApiVersionGetTests.cs
@@ -9,9 +9,11 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task ApiVersionGetTest()
         {
-            var response = await Papi.ApiVersionGetAsync();
+            var response = await Papi.ApiVersionGetAsync(TestContext.CancellationToken);
             Assert.AreEqual(0, response.Data.PAPIErrorCode);
             Assert.IsFalse(string.IsNullOrWhiteSpace(response.Data.ToString()));
         }
+
+        public TestContext TestContext { get; set; }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/AuthenticateStaffUserTests.cs
+++ b/src/polaris-api-csharpTests/Methods/AuthenticateStaffUserTests.cs
@@ -1,3 +1,4 @@
+using Clc.Polaris.Api.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Clc.Polaris.Api.Tests
@@ -9,13 +10,15 @@ namespace Clc.Polaris.Api.Tests
         [ProtectedReadOnlyIntegrationTest]
         public async Task AuthenticateStaffUserTest()
         {
-            var staffOverrideAccount = Papi.StaffOverrideAccount;
+            PolarisUser? staffOverrideAccount = Papi.StaffOverrideAccount;
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.AuthenticateStaffUserAsync(staffOverrideAccount!);
+            var response = await Papi.AuthenticateStaffUserAsync(staffOverrideAccount!, TestContext.CancellationToken);
             Assert.AreEqual(0, response.Data.PAPIErrorCode);
             Assert.IsFalse(string.IsNullOrWhiteSpace(response.Data.AccessSecret));
             Assert.IsFalse(string.IsNullOrWhiteSpace(response.Data.AccessToken));
         }
+
+        public TestContext TestContext { get; set; }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/BibGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/BibGetTests.cs
@@ -9,20 +9,22 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task BibGetTest()
         {
-            var response = await Papi.BibGetAsync(478907);
+            var response = await Papi.BibGetAsync(478907, cancellationToken: TestContext.CancellationToken);
             Assert.AreEqual(0, response.Data.PAPIErrorCode);
             Assert.IsFalse(string.IsNullOrWhiteSpace(response.Data.Title));
-            Assert.IsTrue(response.Response.RequestMessage.RequestUri.ToString().Contains("100/1/bib"));
+            Assert.Contains("100/1/bib", response.Response.RequestMessage.RequestUri.ToString());
         }
 
         [TestMethod]
         [ReadOnlyIntegrationTest]
         public async Task BibGetTest_PassBranchId()
         {
-            var response = await Papi.BibGetAsync(478907, 7);
+            var response = await Papi.BibGetAsync(478907, 7, TestContext.CancellationToken);
             Assert.AreEqual(0, response.Data.PAPIErrorCode);
             Assert.IsFalse(string.IsNullOrWhiteSpace(response.Data.Title));
-            Assert.IsTrue(response.Response.RequestMessage.RequestUri.ToString().Contains("100/7/bib"));
+            Assert.Contains("100/7/bib", response.Response.RequestMessage.RequestUri.ToString());
         }
+
+        public TestContext TestContext { get; set; }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/Cancellation/PatronSearchProtectedTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/Cancellation/PatronSearchProtectedTokenTests.cs
@@ -23,19 +23,6 @@ namespace Clc.Polaris.Api.Tests.Methods.Cancellation
             ClearProtectedTokenState();
         }
 
-        private static async Task AssertOperationCanceledAsync(Func<Task> action)
-        {
-            try
-            {
-                await action().ConfigureAwait(false);
-                Assert.Fail("Expected cancellation to propagate.");
-            }
-            catch (OperationCanceledException)
-            {
-                // Expected. TaskCanceledException also derives from OperationCanceledException.
-            }
-        }
-
         [TestMethod]
         public async Task PatronSearchAsync_CancellationDuringProtectedTokenAuthentication_PropagatesCancellation()
         {
@@ -49,11 +36,11 @@ namespace Clc.Polaris.Api.Tests.Methods.Cancellation
 
             var request = client.PatronSearchAsync("name=Smith", cancellationToken: cancellationTokenSource.Token);
 
-            await handler.AuthenticationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await handler.AuthenticationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
 
             cancellationTokenSource.Cancel();
 
-            await AssertOperationCanceledAsync(async () => await request.ConfigureAwait(false));
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await request.ConfigureAwait(false));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
@@ -68,23 +55,23 @@ namespace Clc.Polaris.Api.Tests.Methods.Cancellation
             var secondClient = CreateClientWithProtectedCache(handler, cacheUsername);
             var thirdClient = CreateClientWithProtectedCache(handler, cacheUsername);
 
-            var firstRequest = firstClient.PatronSearchAsync("name=First", orgId: 9);
+            var firstRequest = firstClient.PatronSearchAsync("name=First", orgId: 9, cancellationToken: TestContext.CancellationToken);
             await handler.AuthenticationStarted.Task.ConfigureAwait(false);
             using var secondCts = new CancellationTokenSource();
             var secondRequest = secondClient.PatronSearchAsync("name=Second", orgId: 9, cancellationToken: secondCts.Token);
 
             secondCts.Cancel();
-            await AssertOperationCanceledAsync(async () => await secondRequest.ConfigureAwait(false));
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await secondRequest.ConfigureAwait(false));
 
             handler.CompleteAuthentication.SetResult();
             await firstRequest.ConfigureAwait(false);
 
-            var laterResponse = await thirdClient.PatronSearchAsync("name=Later", orgId: 9);
+            var laterResponse = await thirdClient.PatronSearchAsync("name=Later", orgId: 9, cancellationToken: TestContext.CancellationToken);
 
             Assert.IsNotNull(laterResponse);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
-            Assert.AreEqual(2, handler.ProtectedRequests.Count);
-            StringAssert.Contains(handler.ProtectedRequests[1].RequestUri!.AbsolutePath, "/protected/v1/1033/100/9/blocked-token/search/patrons/Boolean");
+            Assert.HasCount(2, handler.ProtectedRequests);
+            Assert.Contains("/protected/v1/1033/100/9/blocked-token/search/patrons/Boolean", handler.ProtectedRequests[1].RequestUri!.AbsolutePath);
             Assert.IsFalse(handler.ProtectedRequests[1].RequestUri!.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
         }
 
@@ -96,7 +83,7 @@ namespace Clc.Polaris.Api.Tests.Methods.Cancellation
             public TaskCompletionSource AuthenticationStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
             public TaskCompletionSource CompleteAuthentication { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
             public int AuthenticationRequestCount => _authenticationRequestCount;
-            public List<HttpRequestMessage> ProtectedRequests { get; } = new();
+            public List<HttpRequestMessage> ProtectedRequests { get; } = [];
 
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
@@ -155,5 +142,7 @@ namespace Clc.Polaris.Api.Tests.Methods.Cancellation
                 };
             }
         }
+
+        public TestContext TestContext { get; set; }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/Cancellation/PatronSearchTests.cs
+++ b/src/polaris-api-csharpTests/Methods/Cancellation/PatronSearchTests.cs
@@ -29,11 +29,11 @@ namespace Clc.Polaris.Api.Tests.Methods.Cancellation
             var response = await client.PatronSearchAsync("name=Smith", cancellationToken: cts.Token);
 
             Assert.IsNotNull(response);
-            Assert.AreEqual(2, handler.Requests.Count);
-            StringAssert.Contains(handler.Requests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
+            Assert.HasCount(2, handler.Requests);
+            Assert.Contains("/protected/v1/1033/100/1/authenticator/staff", handler.Requests[0].RequestUri!.AbsolutePath);
             Assert.AreEqual(HttpMethod.Post, handler.Requests[0].Method);
             Assert.IsTrue(handler.CancellationTokens[0].CanBeCanceled);
-            StringAssert.Contains(handler.Requests[1].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
+            Assert.Contains("/protected/v1/1033/100/1/protected-token/search/patrons/Boolean", handler.Requests[1].RequestUri!.AbsolutePath);
             Assert.IsTrue(handler.CancellationTokens[1].CanBeCanceled);
         }
     }

--- a/src/polaris-api-csharpTests/Methods/ItemUpdateBarcodeTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ItemUpdateBarcodeTests.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Clc.Polaris.Api.Configuration;
+using Clc.Polaris.Api.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Clc.Polaris.Api.Tests
+{
+    [TestClass]
+    [UnitTest]
+    public sealed class ItemUpdateBarcodeTests
+    {
+        [TestMethod]
+        public async Task ItemUpdateBarcodeAsync_WhenUsingOldBarcode_EncodesBarcodeAndAddsIsBarcodeQueryParameter()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var papi = CreateClient(handler);
+            var oldBarcode = "OLD/BARCODE";
+
+            await papi.ItemUpdateBarcodeAsync("NEW-BARCODE", oldBarcode: oldBarcode, cancellationToken: TestContext.CancellationToken);
+
+            var requestUri = handler.Request?.RequestUri
+                ?? throw new AssertFailedException("Expected an HTTP request to be sent.");
+
+            Assert.Contains($"/cataloging/items/{WebUtility.UrlEncode(oldBarcode)}/barcode", requestUri.AbsoluteUri);
+            Assert.Contains("wsid=9", requestUri.Query);
+            Assert.Contains("isBarcode=1", requestUri.Query);
+
+            Assert.IsFalse(
+                requestUri.AbsoluteUri.Contains("/cataloging/items/OLD/BARCODE/barcode", StringComparison.Ordinal),
+                "Old barcode should be URL encoded before being inserted into the route.");
+
+            Assert.IsFalse(
+                requestUri.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal),
+                "ProtectedToken.Placeholder should be replaced before the request is sent.");
+        }
+
+        [TestMethod]
+        public async Task ItemUpdateBarcodeAsync_WhenUsingItemRecordId_DoesNotAddIsBarcodeQueryParameter()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var papi = CreateClient(handler);
+
+            await papi.ItemUpdateBarcodeAsync("NEW-BARCODE", itemRecordId: 12345, oldBarcode: "OLD/BARCODE", cancellationToken: TestContext.CancellationToken);
+
+            var requestUri = handler.Request?.RequestUri
+                ?? throw new AssertFailedException("Expected an HTTP request to be sent.");
+
+            Assert.Contains("/cataloging/items/12345/barcode", requestUri.AbsoluteUri);
+
+            Assert.IsFalse(
+                requestUri.Query.Contains("isBarcode=", StringComparison.Ordinal),
+                "isBarcode should only be sent when the item identifier is an old barcode.");
+        }
+
+        [TestMethod]
+        public async Task ItemUpdateBarcodeAsync_WhenItemRecordIdAndOldBarcodeAreMissing_ThrowsBeforeSendingRequest()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var papi = CreateClient(handler);
+
+            await Assert.ThrowsExactlyAsync<ArgumentException>(
+                () => papi.ItemUpdateBarcodeAsync("NEW-BARCODE", cancellationToken: TestContext.CancellationToken));
+
+            Assert.AreEqual(0, handler.CallCount);
+        }
+
+        [TestMethod]
+        public async Task ItemUpdateBarcodeAsync_WhenNewBarcodeIsWhitespace_ThrowsBeforeSendingRequest()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var papi = CreateClient(handler);
+
+            await Assert.ThrowsExactlyAsync<ArgumentException>(
+                () => papi.ItemUpdateBarcodeAsync(" ", itemRecordId: 12345, cancellationToken: TestContext.CancellationToken));
+
+            Assert.AreEqual(0, handler.CallCount);
+        }
+
+        private static PapiClient CreateClient(RecordingHttpMessageHandler handler)
+        {
+            var settings = new PapiSettings
+            {
+                Hostname = "https://example.test",
+                AccessId = "access-id",
+                AccessKey = "access-key",
+                OrganizationId = 7,
+                UserId = 8,
+                WorkstationId = 9
+            };
+
+            return new PapiClient(new HttpClient(handler), settings)
+            {
+                Token = new ProtectedToken
+                {
+                    AccessToken = "protected-token",
+                    AccessSecret = "protected-secret",
+                    ExpirationDate = DateTime.UtcNow.AddHours(1)
+                },
+                UseProtectedTokenCache = false
+            };
+        }
+
+        private sealed class RecordingHttpMessageHandler : HttpMessageHandler
+        {
+            public HttpRequestMessage? Request { get; private set; }
+            public int CallCount { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Request = request;
+                CallCount++;
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{}")
+                });
+            }
+        }
+
+        public TestContext TestContext { get; set; }
+    }
+}

--- a/src/polaris-api-csharpTests/Methods/PatronAccountCreateTitleListTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronAccountCreateTitleListTests.cs
@@ -13,16 +13,18 @@ namespace Clc.Polaris.Api.Tests
         {
             var listName = CreateUniqueTestArtifactText(Settings.PatronListName);
 
-            var createResponse = await Papi.PatronAccountCreateTitleListAsync(Settings.PatronBarcode, listName, Settings.PatronPin);
+            var createResponse = await Papi.PatronAccountCreateTitleListAsync(Settings.PatronBarcode, listName, Settings.PatronPin, TestContext.CancellationToken);
             Assert.AreEqual(0, createResponse.Data.PAPIErrorCode);
 
-            var getResponse = await Papi.PatronAccountGetTitleListsAsync(Settings.PatronBarcode, Settings.PatronPin);
+            var getResponse = await Papi.PatronAccountGetTitleListsAsync(Settings.PatronBarcode, Settings.PatronPin, TestContext.CancellationToken);
             var list = getResponse.Data.PatronAccountTitleListsRows.FirstOrDefault(l => l.RecordStoreName == listName);
 
             Assert.IsNotNull(list, $"Expected to find uniquely named title list '{listName}'.");
 
-            var deleteResponse = await Papi.PatronAccountDeleteTitleListAsync(Settings.PatronBarcode, list.RecordStoreId, Settings.PatronPin);
-            Assert.IsTrue(deleteResponse.Data.PAPIErrorCode == 0);
+            var deleteResponse = await Papi.PatronAccountDeleteTitleListAsync(Settings.PatronBarcode, list.RecordStoreId, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(0, deleteResponse.Data.PAPIErrorCode);
         }
+
+        public TestContext TestContext { get; set; }
     }
 }

--- a/src/polaris-api-csharpTests/Models/BibGetResultTests.cs
+++ b/src/polaris-api-csharpTests/Models/BibGetResultTests.cs
@@ -15,14 +15,14 @@ namespace Clc.Polaris.Api.Tests.Models
         {
             var sut = new BibGetResult
             {
-                BibGetRows = new List<BibGetRow>
-                {
-                    new BibGetRow { ElementID = 7, Value = "70" },
-                    new BibGetRow { ElementID = 8, Value = "80" },
-                    new BibGetRow { ElementID = 11, Value = "110" },
-                    new BibGetRow { ElementID = 15, Value = "150" },
-                    new BibGetRow { ElementID = 16, Value = "160" }
-                }
+                BibGetRows =
+                [
+                    new() { ElementID = 7, Value = "70" },
+                    new() { ElementID = 8, Value = "80" },
+                    new() { ElementID = 11, Value = "110" },
+                    new() { ElementID = 15, Value = "150" },
+                    new() { ElementID = 16, Value = "160" }
+                ]
             };
 
             Assert.AreEqual(70, sut.SystemItemsTotal);
@@ -63,10 +63,10 @@ namespace Clc.Polaris.Api.Tests.Models
         {
             var sut = new BibGetResult
             {
-                BibGetRows = new List<BibGetRow>
-                {
-                    new BibGetRow { ElementID = 8, Value = "42" }
-                }
+                BibGetRows =
+                [
+                    new() { ElementID = 8, Value = "42" }
+                ]
             };
 
             Assert.IsNull(sut.SystemItemsTotal);

--- a/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs
@@ -36,7 +36,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             Assert.AreEqual("route-token", client.Token?.AccessToken);
             var finalRequest = handler.CapturedRequests.Single(capturedRequest => !capturedRequest.IsStaffAuthenticationRequest);
-            StringAssert.EndsWith(finalRequest.Path, "/protected/v1/1033/100/1/patron/ABC123/account/outstanding");
+            Assert.EndsWith("/protected/v1/1033/100/1/patron/ABC123/account/outstanding", finalRequest.Path);
             AssertAuthorizationHash(finalRequest, "route-secret", client.AccessKey, client.AccessID);
         }
 
@@ -55,7 +55,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             Assert.AreEqual("malformed-token", client.Token?.AccessToken);
             var finalRequest = handler.CapturedRequests.Single(capturedRequest => !capturedRequest.IsStaffAuthenticationRequest);
-            StringAssert.EndsWith(finalRequest.Path, "/protected/v1/1033/100/1/authenticator/staff/extra");
+            Assert.EndsWith("/protected/v1/1033/100/1/authenticator/staff/extra", finalRequest.Path);
             AssertAuthorizationHash(finalRequest, "malformed-secret", client.AccessKey, client.AccessID);
         }
 
@@ -65,7 +65,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var handler = new CapturingHttpMessageHandler();
             var client = CreateClient(handler);
 
-            await Assert.ThrowsExactlyAsync<ArgumentNullException>(() => client.ExecutePapiAsync<PapiResponseCommon>(null!));
+            await Assert.ThrowsExactlyAsync<ArgumentNullException>(() => client.ExecutePapiAsync<PapiResponseCommon>(null!, TestContext.CancellationToken));
 
             Assert.AreEqual(0, handler.RequestCount);
         }
@@ -81,7 +81,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var request = PapiRestRequest.Get("/public/v1/1033/100/1/custom");
             request.Path = path!;
 
-            await Assert.ThrowsExactlyAsync<ArgumentException>(() => client.ExecutePapiAsync<PapiResponseCommon>(request));
+            await Assert.ThrowsExactlyAsync<ArgumentException>(() => client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken));
 
             Assert.AreEqual(0, handler.RequestCount);
         }
@@ -96,7 +96,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var client = CreateClient(handler);
             var request = PapiRestRequest.Get(path);
 
-            await Assert.ThrowsExactlyAsync<ArgumentException>(() => client.ExecutePapiAsync<PapiResponseCommon>(request));
+            await Assert.ThrowsExactlyAsync<ArgumentException>(() => client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken));
 
             Assert.AreEqual(0, handler.RequestCount);
         }
@@ -108,7 +108,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var client = CreateClient(handler);
             var request = PapiRestRequest.Get("/other/v1/1033/100/1/custom");
 
-            await Assert.ThrowsExactlyAsync<ArgumentException>(() => client.ExecutePapiAsync<PapiResponseCommon>(request));
+            await Assert.ThrowsExactlyAsync<ArgumentException>(() => client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken));
 
             Assert.AreEqual(0, handler.RequestCount);
         }
@@ -121,13 +121,13 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             client.StaffOverrideAccount = null;
             var request = PapiRestRequest.Get("/public/v1/1033/100/1/custom/unsupported");
 
-            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             var finalRequest = handler.CapturedRequests.Single();
             Assert.AreEqual("GET", finalRequest.Method);
-            StringAssert.Contains(finalRequest.Path, "/public/v1/1033/100/1/custom/unsupported");
+            Assert.Contains("/public/v1/1033/100/1/custom/unsupported", finalRequest.Path);
             AssertAuthorizationHash(finalRequest, string.Empty, client.AccessKey, client.AccessID);
         }
 
@@ -141,14 +141,14 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
                 "/public/v1/1033/100/1/custom/unsupported",
                 body: new { Message = "custom-body", Count = 3 });
 
-            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             var finalRequest = handler.CapturedRequests.Single();
             Assert.AreEqual("POST", finalRequest.Method);
-            StringAssert.Contains(finalRequest.Body, "custom-body");
-            StringAssert.Contains(finalRequest.Body, "3");
+            Assert.Contains("custom-body", finalRequest.Body);
+            Assert.Contains("3", finalRequest.Body);
             AssertAuthorizationHash(finalRequest, string.Empty, client.AccessKey, client.AccessID);
         }
 
@@ -161,12 +161,12 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
 
-            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             var finalRequest = handler.CapturedRequests.Single(capturedRequest => !capturedRequest.IsStaffAuthenticationRequest);
-            StringAssert.Contains(finalRequest.Path, "/protected/v1/1033/100/1/custom-placeholder-token/custom/unsupported");
+            Assert.Contains("/protected/v1/1033/100/1/custom-placeholder-token/custom/unsupported", finalRequest.Path);
             Assert.IsFalse(finalRequest.Path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
             AssertAuthorizationHash(finalRequest, "custom-placeholder-secret", client.AccessKey, client.AccessID);
         }
@@ -181,7 +181,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
             var originalPath = request.Path;
 
-            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
             Assert.AreEqual(originalPath, request.Path);
         }
@@ -198,13 +198,13 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
             var originalPath = request.Path;
 
-            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
             Assert.AreEqual(originalPath, request.Path);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             var finalRequest = handler.CapturedRequests.Single(request => !request.IsStaffAuthenticationRequest);
-            StringAssert.Contains(finalRequest.Path, "/protected/v1/1033/100/1/error-path-token/custom/unsupported");
+            Assert.Contains("/protected/v1/1033/100/1/error-path-token/custom/unsupported", finalRequest.Path);
         }
 
         [TestMethod]
@@ -216,7 +216,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get("/public/v1/1033/100/1/patron/ABC123/basicdata");
 
-            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
@@ -234,7 +234,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var request = PapiRestRequest.Get("/public/v1/1033/100/1/custom/unsupported");
             request.BlockStaffOverride = true;
 
-            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
@@ -252,7 +252,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get("/public/v1/1033/100/1/api");
 
-            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
@@ -273,7 +273,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
                 "/public/v1/1033/100/1/patron/ABC123/basicdata",
                 password: "patron-password");
 
-            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
@@ -292,7 +292,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get("/public/v1/1033/100/1/patronlanguages");
 
-            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
@@ -302,5 +302,6 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             AssertAuthorizationHash(finalRequest, string.Empty, client.AccessKey, client.AccessID);
         }
 
+        public TestContext TestContext { get; set; }
     }
 }

--- a/src/polaris-api-csharpTests/PapiClientBehavior/ProtectedTokenCacheTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/ProtectedTokenCacheTests.cs
@@ -32,10 +32,10 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             Assert.IsNotNull(cacheKey);
             Assert.IsFalse(cacheKey!.Contains(client.StaffOverrideAccount.Password, StringComparison.Ordinal), "Cache key exposed secret material.");
             Assert.IsFalse(cacheKey.Contains(client.AccessKey, StringComparison.Ordinal), "Cache key exposed secret material.");
-            StringAssert.Contains(cacheKey, client.Hostname.Trim());
-            StringAssert.Contains(cacheKey, client.AccessID.Trim());
-            StringAssert.Contains(cacheKey, client.StaffOverrideAccount.Domain.Trim());
-            StringAssert.Contains(cacheKey, client.StaffOverrideAccount.Username.Trim());
+            Assert.Contains(client.Hostname.Trim(), cacheKey);
+            Assert.Contains(client.AccessID.Trim(), cacheKey);
+            Assert.Contains(client.StaffOverrideAccount.Domain.Trim(), cacheKey);
+            Assert.Contains(client.StaffOverrideAccount.Username.Trim(), cacheKey);
         }
 
         [TestMethod]
@@ -52,7 +52,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             clientA.AccessID = "access-a";
             clientA.StaffOverrideAccount = staff;
 
-            await clientA.PatronSearchAsync("name=Smith");
+            await clientA.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken);
 
             Assert.AreEqual(1, handlerA.AuthenticationRequestCount);
             Assert.AreEqual(1, handlerA.NonAuthenticationRequestCount);
@@ -69,7 +69,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             clientB.AccessID = "access-b";
             clientB.StaffOverrideAccount = staff;
 
-            await clientB.PatronSearchAsync("name=Jones");
+            await clientB.PatronSearchAsync("name=Jones", cancellationToken: TestContext.CancellationToken);
 
             Assert.AreEqual(1, handlerB.AuthenticationRequestCount);
             Assert.AreEqual(1, handlerB.NonAuthenticationRequestCount);
@@ -89,16 +89,16 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var handler = new ProtectedTokenHttpMessageHandler();
             var client = CreateProtectedClient(handler);
 
-            await client.PatronSearchAsync("name=Smith");
+            await client.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken);
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             Assert.IsNotNull(client.Token);
             Assert.AreEqual("protected-token", client.Token.AccessToken);
             var paths = handler.RequestPaths;
-            Assert.AreEqual(2, paths.Length);
-            StringAssert.Contains(paths[0], "/protected/v1/1033/100/1/authenticator/staff");
-            StringAssert.Contains(paths[1], "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
+            Assert.HasCount(2, paths);
+            Assert.Contains("/protected/v1/1033/100/1/authenticator/staff", paths[0]);
+            Assert.Contains("/protected/v1/1033/100/1/protected-token/search/patrons/Boolean", paths[1]);
             Assert.IsTrue(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out var cachedToken));
             Assert.IsNotNull(cachedToken);
             Assert.AreEqual("protected-token", cachedToken.AccessToken);
@@ -126,7 +126,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             cacheDisabledClient.UseProtectedTokenCache = false;
 
             await Assert.ThrowsExactlyAsync<InvalidOperationException>(
-                async () => await cacheDisabledClient.PatronSearchAsync("name=Failure").ConfigureAwait(false));
+                async () => await cacheDisabledClient.PatronSearchAsync("name=Failure", cancellationToken: TestContext.CancellationToken).ConfigureAwait(false));
 
             Assert.AreEqual(1, failingHandler.AuthenticationRequestCount);
             Assert.AreEqual(0, failingHandler.NonAuthenticationRequestCount);
@@ -137,15 +137,17 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var cacheEnabledHandler = new ProtectedTokenHttpMessageHandler();
             var cacheEnabledClient = CreateProtectedClient(cacheEnabledHandler, hostname, staff);
 
-            var response = await cacheEnabledClient.PatronSearchAsync("name=Cached").ConfigureAwait(false);
+            var response = await cacheEnabledClient.PatronSearchAsync("name=Cached", cancellationToken: TestContext.CancellationToken).ConfigureAwait(false);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(0, cacheEnabledHandler.AuthenticationRequestCount);
             Assert.AreEqual(1, cacheEnabledHandler.NonAuthenticationRequestCount);
             Assert.AreEqual("cached-token", cacheEnabledClient.Token?.AccessToken);
-            StringAssert.Contains(
-                cacheEnabledHandler.CapturedRequests.Single(request => !request.IsStaffAuthenticationRequest).Path,
-                "/protected/v1/1033/100/1/cached-token/search/patrons/Boolean");
+            Assert.Contains(
+                "/protected/v1/1033/100/1/cached-token/search/patrons/Boolean",
+                cacheEnabledHandler.CapturedRequests.Single(request => !request.IsStaffAuthenticationRequest).Path);
         }
+
+        public TestContext TestContext { get; set; }
     }
 }

--- a/src/polaris-api-csharpTests/Validation/RequireTests.cs
+++ b/src/polaris-api-csharpTests/Validation/RequireTests.cs
@@ -22,7 +22,7 @@ namespace Clc.Polaris.Api.Validation.Tests
         [TestMethod]
         public void Argument_NonNullObject_DoesNotThrow()
         {
-            object notNullValue = new object();
+            object notNullValue = new();
 
             Require.Argument(notNullValue);
         }


### PR DESCRIPTION
## Summary

- Add a shared barcode path-segment encoder for patron and item barcode routes
- Update item barcode changes to encode old barcode values before inserting them into the route
- Validate `ItemUpdateBarcodeAsync` inputs before sending requests
- Ensure `isBarcode=1` is only sent when the item identifier is an old barcode
- Add item barcode update unit tests for route encoding and validation behavior
- Pass `TestContext.CancellationToken` through updated async tests
- Apply general test and code cleanup
- Update NuGet publish workflow to use trusted publishing login

## Notes

The barcode encoding change prevents barcode values containing route-sensitive characters, such as `/`, from being interpreted as additional route segments.

## Testing

- GitHub Actions `build-test-publish` passed