### PR TITLE
Extract ProtectedTokenCache, PapiRequestClassifier, and PapiRequestValidator from PapiClient

### DIFF
--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -3,11 +3,8 @@ using Clc.Polaris.Api.Models;
 using Clc.Rest;
 using Clc.Rest.Models;
 using System;
-using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -43,17 +40,7 @@ namespace Clc.Polaris.Api
 
         public bool UseProtectedTokenCache { get; set; } = true;
 
-        private const int MaxProtectedTokenCacheLockEntries = 1024;
-        private const int TargetProtectedTokenCacheLockEntries = 512;
-
-        private static readonly TimeSpan ProtectedTokenCacheLockIdleLimit = TimeSpan.FromMinutes(10);
-        private static readonly object ProtectedTokenCacheLocksPruneLock = new object();
-
-        private static ConcurrentDictionary<string, ProtectedToken> ProtectedTokenCache { get; } = new ConcurrentDictionary<string, ProtectedToken>();
-        private static ConcurrentDictionary<string, ProtectedTokenCacheLockEntry> ProtectedTokenCacheLocks { get; } = new ConcurrentDictionary<string, ProtectedTokenCacheLockEntry>();
-
         private ProtectedToken? _token;
-        private static readonly TimeSpan ProtectedTokenExpirationSkew = TimeSpan.FromMinutes(1);
 
         /// <summary>
         /// Used for protected methods and public method overrides
@@ -62,7 +49,7 @@ namespace Clc.Polaris.Api
         {
             get
             {
-                if (IsProtectedTokenMissingOrExpired(_token))
+                if (!ProtectedTokenCache.IsUsable(_token))
                 {
                     _token = null;
                     return null;
@@ -114,7 +101,7 @@ namespace Clc.Polaris.Api
                 var accessSecret = token?.AccessSecret;
                 var accessToken = token?.AccessToken;
 
-                if (IsStaffOverridePatronRequest(papiRequest))
+                if (PapiRequestClassifier.IsStaffOverridePatronRequest(papiRequest, AllowStaffOverrideRequests, StaffOverrideAccount))
                 {
                     if (!string.IsNullOrWhiteSpace(accessSecret) && !string.IsNullOrWhiteSpace(accessToken))
                     {
@@ -186,12 +173,16 @@ namespace Clc.Polaris.Api
         /// <exception cref="ArgumentException"><paramref name="request"/> has an invalid custom PAPI path.</exception>
         public async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
         {
-            ValidateCustomPapiRequest(request);
+            PapiRequestValidator.ValidateExecutableRequest(request);
 
             var executionRequest = new PapiRestRequest(request);
 
-            var pathContainsProtectedTokenPlaceholder = RequestPathContainsProtectedTokenPlaceholder(executionRequest);
-            var requiresProtectedToken = RequiresProtectedToken(executionRequest, pathContainsProtectedTokenPlaceholder);
+            var pathContainsProtectedTokenPlaceholder = PapiRequestClassifier.PathContainsProtectedTokenPlaceholder(executionRequest);
+            var requiresProtectedToken = PapiRequestClassifier.RequiresProtectedToken(
+                executionRequest,
+                pathContainsProtectedTokenPlaceholder,
+                AllowStaffOverrideRequests,
+                StaffOverrideAccount);
 
             var protectedToken = requiresProtectedToken
                 ? await GetProtectedTokenOrThrowAsync(pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false)
@@ -205,95 +196,6 @@ namespace Clc.Polaris.Api
             return await ExecuteAsync<T>(executionRequest, cancellationToken).ConfigureAwait(false);
         }
 
-        private static void ValidateCustomPapiRequest(PapiRestRequest request)
-        {
-            ArgumentNullException.ThrowIfNull(request);
-
-            if (string.IsNullOrWhiteSpace(request.Path))
-            {
-                throw new ArgumentException("PAPI request path must not be null, empty, or whitespace.", nameof(request));
-            }
-
-            if (request.Path.Contains("://", StringComparison.Ordinal))
-            {
-                throw new ArgumentException("PAPI request path must be a relative path, not an absolute URL.", nameof(request));
-            }
-
-            if (request.Path.StartsWith("//", StringComparison.Ordinal))
-            {
-                throw new ArgumentException("PAPI request path must not be a protocol-relative URL.", nameof(request));
-            }
-
-            if (!request.Path.StartsWith('/'))
-            {
-                throw new ArgumentException("PAPI request path must begin with '/'.", nameof(request));
-            }
-
-            if (request.AuthRequired &&
-                !request.Path.StartsWith("/public/", StringComparison.OrdinalIgnoreCase) &&
-                !request.Path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase))
-            {
-                throw new ArgumentException("Authenticated custom PAPI request paths must begin with '/public/' or '/protected/'.", nameof(request));
-            }
-        }
-
-        private bool RequiresProtectedToken(PapiRestRequest request, bool pathContainsProtectedTokenPlaceholder)
-        {
-            if (IsStaffAuthenticatorRequest(request))
-            {
-                return false;
-            }
-
-            if (pathContainsProtectedTokenPlaceholder)
-            {
-                return true;
-            }
-
-            if (request.IsProtectedMethod && string.IsNullOrWhiteSpace(request.Password))
-            {
-                return true;
-            }
-
-            return IsStaffOverridePatronRequest(request);
-        }
-
-        private bool IsStaffOverridePatronRequest(PapiRestRequest request)
-        {
-            return request.IsPublicMethod &&
-                request.AuthRequired &&
-                AllowStaffOverrideRequests &&
-                string.IsNullOrWhiteSpace(request.Password) &&
-                !request.BlockStaffOverride &&
-                StaffOverrideAccount != null &&
-                HasPatronBarcodeRouteSegment(request.Path);
-        }
-
-        private static bool HasPatronBarcodeRouteSegment(string path)
-        {
-            var pathWithoutQuery = path.Split('?', 2)[0];
-            var segments = pathWithoutQuery.Split('/', StringSplitOptions.RemoveEmptyEntries);
-
-            for (var i = 0; i < segments.Length - 1; i++)
-            {
-                if (segments[i].Equals("patron", StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static bool IsStaffAuthenticatorRequest(PapiRestRequest? request)
-        {
-            var path = request?.Path;
-
-            return request?.Method == HttpMethod.Post &&
-                !string.IsNullOrWhiteSpace(path) &&
-                path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase) &&
-                path.EndsWith("/authenticator/staff", StringComparison.OrdinalIgnoreCase) &&
-                path.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) < 0;
-        }
 
         private static InvalidOperationException CreateProtectedTokenRequiredException(string reason, bool pathContainsProtectedTokenPlaceholder)
         {
@@ -304,14 +206,9 @@ namespace Clc.Polaris.Api
             return new InvalidOperationException($"A valid protected access token is required for this request. {reason}{placeholderReason}");
         }
 
-        private static bool RequestPathContainsProtectedTokenPlaceholder(PapiRestRequest request)
-        {
-            return request.Path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal);
-        }
-
         private static void ReplaceProtectedTokenPlaceholderInPath(PapiRestRequest request, ProtectedToken token)
         {
-            if (!IsProtectedTokenUsable(token))
+            if (!ProtectedTokenCache.IsUsable(token))
             {
                 throw new InvalidOperationException("A valid protected access token is required to replace ProtectedToken.Placeholder in the request path.");
             }
@@ -322,7 +219,7 @@ namespace Clc.Polaris.Api
         private async Task<ProtectedToken> GetProtectedTokenOrThrowAsync(bool pathContainsProtectedTokenPlaceholder, CancellationToken cancellationToken = default)
         {
             var token = Token;
-            if (IsProtectedTokenUsable(token))
+            if (ProtectedTokenCache.IsUsable(token))
             {
                 return token!;
             }
@@ -337,7 +234,7 @@ namespace Clc.Polaris.Api
                 throw CreateProtectedTokenRequiredException("No staff override credentials are configured.", pathContainsProtectedTokenPlaceholder);
             }
 
-            var cacheKey = BuildProtectedTokenCacheKey();
+            var cacheKey = ProtectedTokenCache.BuildKey(Hostname, AccessID, AccessKey, StaffOverrideAccount);
 
             if (TryLoadProtectedTokenFromCache(cacheKey, out var cachedToken))
             {
@@ -349,10 +246,10 @@ namespace Clc.Polaris.Api
                 return await AuthenticateAndLoadProtectedTokenOrThrowAsync(null, pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false);
             }
 
-            using var cacheLockLease = await AcquireProtectedTokenCacheLockAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+            using var cacheLockLease = await ProtectedTokenCache.AcquireLockAsync(cacheKey, cancellationToken).ConfigureAwait(false);
 
             token = Token;
-            if (IsProtectedTokenUsable(token))
+            if (ProtectedTokenCache.IsUsable(token))
             {
                 return token!;
             }
@@ -369,321 +266,34 @@ namespace Clc.Polaris.Api
 
             if (UseProtectedTokenCache)
             {
-                PruneProtectedTokenCache();
-                PruneProtectedTokenCacheLocks();
+                ProtectedTokenCache.PruneExpired();
+                ProtectedTokenCache.PruneLocks();
             }
 
             return await AuthenticateAndLoadProtectedTokenOrThrowAsync(cacheKey, pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false);
         }
 
-        private static async Task<ProtectedTokenCacheLockLease> AcquireProtectedTokenCacheLockAsync(string cacheKey, CancellationToken cancellationToken)
-        {
-            while (true)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var entry = ProtectedTokenCacheLocks.GetOrAdd(
-                    cacheKey,
-                    _ => new ProtectedTokenCacheLockEntry());
-
-                if (!entry.TryAddLease())
-                {
-                    continue;
-                }
-
-                try
-                {
-                    await entry.Semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    return new ProtectedTokenCacheLockLease(entry);
-                }
-                catch
-                {
-                    entry.ReleaseLease();
-
-                    if (ProtectedTokenCacheLocks.Count > MaxProtectedTokenCacheLockEntries)
-                    {
-                        PruneProtectedTokenCacheLocks();
-                    }
-
-                    throw;
-                }
-            }
-        }
-
-        private static void PruneProtectedTokenCacheLocks()
-        {
-            if (ProtectedTokenCacheLocks.Count <= MaxProtectedTokenCacheLockEntries)
-            {
-                return;
-            }
-
-            lock (ProtectedTokenCacheLocksPruneLock)
-            {
-                if (ProtectedTokenCacheLocks.Count <= MaxProtectedTokenCacheLockEntries)
-                {
-                    return;
-                }
-
-                var cutoffUtc = DateTime.UtcNow.Subtract(ProtectedTokenCacheLockIdleLimit);
-
-                PruneProtectedTokenCacheLocks(cutoffUtc, requireIdle: true);
-
-                if (ProtectedTokenCacheLocks.Count > MaxProtectedTokenCacheLockEntries)
-                {
-                    PruneProtectedTokenCacheLocks(cutoffUtc, requireIdle: false);
-                }
-            }
-        }
-
-        private static void PruneProtectedTokenCacheLocks(DateTime cutoffUtc, bool requireIdle)
-        {
-            foreach (var pair in ProtectedTokenCacheLocks)
-            {
-                if (ProtectedTokenCacheLocks.Count <= TargetProtectedTokenCacheLockEntries)
-                {
-                    return;
-                }
-
-                var entry = pair.Value;
-
-                if (!entry.TryRetire(cutoffUtc, requireIdle))
-                {
-                    continue;
-                }
-
-                if (ProtectedTokenCacheLocks.TryRemove(pair.Key, out var removedEntry) &&
-                    ReferenceEquals(removedEntry, entry))
-                {
-                    removedEntry.Dispose();
-                }
-                else
-                {
-                    entry.UndoRetire();
-                }
-            }
-        }
-
-        private sealed class ProtectedTokenCacheLockLease : IDisposable
-        {
-            private ProtectedTokenCacheLockEntry? _entry;
-
-            public ProtectedTokenCacheLockLease(ProtectedTokenCacheLockEntry entry)
-            {
-                _entry = entry;
-            }
-
-            public void Dispose()
-            {
-                var entry = _entry;
-                if (entry == null)
-                {
-                    return;
-                }
-
-                _entry = null;
-
-                try
-                {
-                    entry.Semaphore.Release();
-                }
-                finally
-                {
-                    entry.ReleaseLease();
-
-                    if (ProtectedTokenCacheLocks.Count > MaxProtectedTokenCacheLockEntries)
-                    {
-                        PruneProtectedTokenCacheLocks();
-                    }
-                }
-            }
-        }
-
-        private sealed class ProtectedTokenCacheLockEntry : IDisposable
-        {
-            private readonly object _syncRoot = new object();
-            private int _leaseCount;
-            private bool _retired;
-            private DateTime _lastUsedUtc = DateTime.UtcNow;
-
-            public SemaphoreSlim Semaphore { get; } = new SemaphoreSlim(1, 1);
-
-            public bool TryAddLease()
-            {
-                lock (_syncRoot)
-                {
-                    if (_retired)
-                    {
-                        return false;
-                    }
-
-                    _leaseCount++;
-                    _lastUsedUtc = DateTime.UtcNow;
-                    return true;
-                }
-            }
-
-            public void ReleaseLease()
-            {
-                lock (_syncRoot)
-                {
-                    if (_leaseCount > 0)
-                    {
-                        _leaseCount--;
-                    }
-
-                    _lastUsedUtc = DateTime.UtcNow;
-                }
-            }
-
-            public bool TryRetire(DateTime cutoffUtc, bool requireIdle)
-            {
-                lock (_syncRoot)
-                {
-                    if (_retired || _leaseCount != 0)
-                    {
-                        return false;
-                    }
-
-                    if (requireIdle && _lastUsedUtc > cutoffUtc)
-                    {
-                        return false;
-                    }
-
-                    _retired = true;
-                    return true;
-                }
-            }
-
-            public void UndoRetire()
-            {
-                lock (_syncRoot)
-                {
-                    if (_retired && _leaseCount == 0)
-                    {
-                        _retired = false;
-                    }
-                }
-            }
-
-            public void Dispose()
-            {
-                Semaphore.Dispose();
-            }
-        }
-
-        private string? BuildProtectedTokenCacheKey()
-        {
-            if (StaffOverrideAccount == null ||
-                string.IsNullOrWhiteSpace(Hostname) ||
-                string.IsNullOrWhiteSpace(AccessID) ||
-                string.IsNullOrWhiteSpace(AccessKey) ||
-                string.IsNullOrWhiteSpace(StaffOverrideAccount.Domain) ||
-                string.IsNullOrWhiteSpace(StaffOverrideAccount.Username) ||
-                string.IsNullOrWhiteSpace(StaffOverrideAccount.Password))
-            {
-                return null;
-            }
-
-            return $"{Hostname.Trim()}|{AccessID.Trim()}|{StaffOverrideAccount.Domain.Trim()}|{StaffOverrideAccount.Username.Trim()}|{BuildProtectedTokenCredentialFingerprint(AccessKey, StaffOverrideAccount.Password)}";
-        }
-
-        private static string BuildProtectedTokenCredentialFingerprint(string accessKey, string staffPassword)
-        {
-            var credentialMaterial = $"access-key:{accessKey.Length}:{accessKey}|staff-password:{staffPassword.Length}:{staffPassword}";
-            var hash = SHA256.HashData(Encoding.UTF8.GetBytes(credentialMaterial));
-            return Convert.ToHexString(hash);
-        }
-
-        private static bool IsProtectedTokenMissingOrExpired(ProtectedToken? token)
-        {
-            if (token == null || !token.ExpirationDate.HasValue)
-            {
-                return true;
-            }
-
-            var expirationUtc = NormalizeProtectedTokenExpirationUtc(token.ExpirationDate.Value);
-
-            return expirationUtc <= DateTime.UtcNow.Add(ProtectedTokenExpirationSkew);
-        }
-
-        private static DateTime NormalizeProtectedTokenExpirationUtc(DateTime expirationDate)
-        {
-            return expirationDate.Kind switch
-            {
-                DateTimeKind.Utc => expirationDate,
-                DateTimeKind.Local => expirationDate.ToUniversalTime(),
-                _ => DateTime.SpecifyKind(expirationDate, DateTimeKind.Utc)
-            };
-        }
-
-        private static bool IsProtectedTokenUsable(ProtectedToken? token)
-        {
-            return !IsProtectedTokenMissingOrExpired(token) &&
-                !string.IsNullOrWhiteSpace(token?.AccessToken) &&
-                !string.IsNullOrWhiteSpace(token.AccessSecret);
-        }
 
         private bool TryLoadProtectedTokenFromCache(string? cacheKey, out ProtectedToken? protectedToken)
         {
-            protectedToken = null;
-
-            if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
+            if (!ProtectedTokenCache.TryGet(cacheKey, UseProtectedTokenCache, out protectedToken))
             {
-                return false;
-            }
-
-            if (!ProtectedTokenCache.TryGetValue(cacheKey, out var cachedToken))
-            {
-                return false;
-            }
-
-            if (!IsProtectedTokenUsable(cachedToken))
-            {
-                ProtectedTokenCache.TryRemove(cacheKey, out _);
                 _token = null;
                 return false;
             }
 
-            protectedToken = new ProtectedToken(cachedToken);
             _token = protectedToken;
             return true;
         }
 
-        internal static int PruneProtectedTokenCache()
-        {
-            var removedCount = 0;
+        internal static int PruneProtectedTokenCache() => ProtectedTokenCache.PruneExpired();
 
-            foreach (var cachedToken in ProtectedTokenCache)
-            {
-                if (!IsProtectedTokenUsable(cachedToken.Value) &&
-                    ProtectedTokenCache.TryRemove(cachedToken.Key, out _))
-                {
-                    removedCount++;
-                }
-            }
+        internal static void ClearProtectedTokenCache() => ProtectedTokenCache.ClearForTesting();
 
-            return removedCount;
-        }
+        internal static void AddProtectedTokenToCacheForTesting(string cacheKey, ProtectedToken token) =>
+            ProtectedTokenCache.AddForTesting(cacheKey, token);
 
-        internal static void ClearProtectedTokenCache()
-        {
-            ProtectedTokenCache.Clear();
-        }
-
-        internal static void AddProtectedTokenToCacheForTesting(string cacheKey, ProtectedToken token)
-        {
-            ArgumentException.ThrowIfNullOrWhiteSpace(cacheKey);
-            ArgumentNullException.ThrowIfNull(token);
-
-            ProtectedTokenCache[cacheKey] = new ProtectedToken(token);
-        }
-
-        internal static bool ProtectedTokenCacheContainsKey(string cacheKey)
-        {
-            ArgumentException.ThrowIfNullOrWhiteSpace(cacheKey);
-
-            return ProtectedTokenCache.ContainsKey(cacheKey);
-        }
+        internal static bool ProtectedTokenCacheContainsKey(string cacheKey) => ProtectedTokenCache.ContainsKey(cacheKey);
 
         private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenOrThrowAsync(string? cacheKey, bool pathContainsProtectedTokenPlaceholder, CancellationToken cancellationToken)
         {
@@ -697,7 +307,7 @@ namespace Clc.Polaris.Api
                 throw CreateProtectedTokenRequiredException("Staff authentication did not succeed.", pathContainsProtectedTokenPlaceholder);
             }
 
-            if (!IsProtectedTokenUsable(responseData))
+            if (!ProtectedTokenCache.IsUsable(responseData))
             {
                 ClearFailedProtectedToken(cacheKey);
                 throw CreateProtectedTokenRequiredException("Staff authentication did not return a usable protected access token.", pathContainsProtectedTokenPlaceholder);
@@ -706,20 +316,14 @@ namespace Clc.Polaris.Api
             var protectedToken = responseData!;
             _token = protectedToken;
 
-            if (UseProtectedTokenCache && !string.IsNullOrWhiteSpace(cacheKey))
-            {
-                ProtectedTokenCache[cacheKey] = new ProtectedToken(protectedToken);
-            }
+            ProtectedTokenCache.Set(cacheKey, UseProtectedTokenCache, protectedToken);
 
             return protectedToken;
         }
 
         private void ClearFailedProtectedToken(string? cacheKey)
         {
-            if (!string.IsNullOrWhiteSpace(cacheKey))
-            {
-                ProtectedTokenCache.TryRemove(cacheKey, out _);
-            }
+            ProtectedTokenCache.Remove(cacheKey);
 
             _token = null;
         }

--- a/src/polaris-api-csharp/PapiRequestClassifier.cs
+++ b/src/polaris-api-csharp/PapiRequestClassifier.cs
@@ -1,0 +1,81 @@
+﻿using Clc.Polaris.Api.Models;
+using Clc.Rest;
+using Clc.Rest.Models;
+using System;
+using System.Net.Http;
+
+namespace Clc.Polaris.Api
+{
+    internal static class PapiRequestClassifier
+    {
+        internal static bool RequiresProtectedToken(
+            PapiRestRequest request,
+            bool pathContainsProtectedTokenPlaceholder,
+            bool allowStaffOverrideRequests,
+            PolarisUser? staffOverrideAccount)
+        {
+            if (IsStaffAuthenticatorRequest(request))
+            {
+                return false;
+            }
+
+            if (pathContainsProtectedTokenPlaceholder)
+            {
+                return true;
+            }
+
+            if (request.IsProtectedMethod && string.IsNullOrWhiteSpace(request.Password))
+            {
+                return true;
+            }
+
+            return IsStaffOverridePatronRequest(request, allowStaffOverrideRequests, staffOverrideAccount);
+        }
+
+        internal static bool IsStaffOverridePatronRequest(
+            PapiRestRequest request,
+            bool allowStaffOverrideRequests,
+            PolarisUser? staffOverrideAccount)
+        {
+            return request.IsPublicMethod &&
+                request.AuthRequired &&
+                allowStaffOverrideRequests &&
+                string.IsNullOrWhiteSpace(request.Password) &&
+                !request.BlockStaffOverride &&
+                staffOverrideAccount != null &&
+                HasPatronBarcodeRouteSegment(request.Path);
+        }
+
+        internal static bool HasPatronBarcodeRouteSegment(string path)
+        {
+            var pathWithoutQuery = path.Split('?', 2)[0];
+            var segments = pathWithoutQuery.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+            for (var i = 0; i < segments.Length - 1; i++)
+            {
+                if (segments[i].Equals("patron", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        internal static bool IsStaffAuthenticatorRequest(PapiRestRequest? request)
+        {
+            var path = request?.Path;
+
+            return request?.Method == HttpMethod.Post &&
+                !string.IsNullOrWhiteSpace(path) &&
+                path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase) &&
+                path.EndsWith("/authenticator/staff", StringComparison.OrdinalIgnoreCase) &&
+                path.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) < 0;
+        }
+
+        internal static bool PathContainsProtectedTokenPlaceholder(PapiRestRequest request)
+        {
+            return request.Path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal);
+        }
+    }
+}

--- a/src/polaris-api-csharp/PapiRequestValidator.cs
+++ b/src/polaris-api-csharp/PapiRequestValidator.cs
@@ -1,0 +1,40 @@
+﻿using Clc.Polaris.Api.Models;
+using System;
+
+namespace Clc.Polaris.Api
+{
+    internal static class PapiRequestValidator
+    {
+        internal static void ValidateExecutableRequest(PapiRestRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+
+            if (string.IsNullOrWhiteSpace(request.Path))
+            {
+                throw new ArgumentException("PAPI request path must not be null, empty, or whitespace.", nameof(request));
+            }
+
+            if (request.Path.Contains("://", StringComparison.Ordinal))
+            {
+                throw new ArgumentException("PAPI request path must be a relative path, not an absolute URL.", nameof(request));
+            }
+
+            if (request.Path.StartsWith("//", StringComparison.Ordinal))
+            {
+                throw new ArgumentException("PAPI request path must not be a protocol-relative URL.", nameof(request));
+            }
+
+            if (!request.Path.StartsWith('/'))
+            {
+                throw new ArgumentException("PAPI request path must begin with '/'.", nameof(request));
+            }
+
+            if (request.AuthRequired &&
+                !request.Path.StartsWith("/public/", StringComparison.OrdinalIgnoreCase) &&
+                !request.Path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("Authenticated custom PAPI request paths must begin with '/public/' or '/protected/'.", nameof(request));
+            }
+        }
+    }
+}

--- a/src/polaris-api-csharp/ProtectedTokenCache.cs
+++ b/src/polaris-api-csharp/ProtectedTokenCache.cs
@@ -1,0 +1,358 @@
+﻿using Clc.Polaris.Api.Models;
+using System;
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Clc.Polaris.Api
+{
+    internal static class ProtectedTokenCache
+    {
+        private const int MaxLockEntries = 1024;
+        private const int TargetLockEntries = 512;
+
+        private static readonly TimeSpan LockIdleLimit = TimeSpan.FromMinutes(10);
+        private static readonly object LocksPruneLock = new object();
+        private static readonly TimeSpan ExpirationSkew = TimeSpan.FromMinutes(1);
+
+        private static ConcurrentDictionary<string, ProtectedToken> Tokens { get; } = new ConcurrentDictionary<string, ProtectedToken>();
+        private static ConcurrentDictionary<string, LockEntry> Locks { get; } = new ConcurrentDictionary<string, LockEntry>();
+
+        internal static string? BuildKey(string hostname, string accessId, string accessKey, PolarisUser? staffOverrideAccount)
+        {
+            if (staffOverrideAccount == null ||
+                string.IsNullOrWhiteSpace(hostname) ||
+                string.IsNullOrWhiteSpace(accessId) ||
+                string.IsNullOrWhiteSpace(accessKey) ||
+                string.IsNullOrWhiteSpace(staffOverrideAccount.Domain) ||
+                string.IsNullOrWhiteSpace(staffOverrideAccount.Username) ||
+                string.IsNullOrWhiteSpace(staffOverrideAccount.Password))
+            {
+                return null;
+            }
+
+            return $"{hostname.Trim()}|{accessId.Trim()}|{staffOverrideAccount.Domain.Trim()}|{staffOverrideAccount.Username.Trim()}|{BuildCredentialFingerprint(accessKey, staffOverrideAccount.Password)}";
+        }
+
+        internal static bool IsUsable(ProtectedToken? token)
+        {
+            return !IsMissingOrExpired(token) &&
+                !string.IsNullOrWhiteSpace(token?.AccessToken) &&
+                !string.IsNullOrWhiteSpace(token.AccessSecret);
+        }
+
+        internal static bool TryGet(string? cacheKey, bool useCache, out ProtectedToken? protectedToken)
+        {
+            protectedToken = null;
+
+            if (!useCache || string.IsNullOrWhiteSpace(cacheKey))
+            {
+                return false;
+            }
+
+            if (!Tokens.TryGetValue(cacheKey, out var cachedToken))
+            {
+                return false;
+            }
+
+            if (!IsUsable(cachedToken))
+            {
+                Tokens.TryRemove(cacheKey, out _);
+                return false;
+            }
+
+            protectedToken = new ProtectedToken(cachedToken);
+            return true;
+        }
+
+        internal static void Set(string? cacheKey, bool useCache, ProtectedToken token)
+        {
+            if (!useCache || string.IsNullOrWhiteSpace(cacheKey))
+            {
+                return;
+            }
+
+            Tokens[cacheKey] = new ProtectedToken(token);
+        }
+
+        internal static void Remove(string? cacheKey)
+        {
+            if (!string.IsNullOrWhiteSpace(cacheKey))
+            {
+                Tokens.TryRemove(cacheKey, out _);
+            }
+        }
+
+        internal static int PruneExpired()
+        {
+            var removedCount = 0;
+
+            foreach (var cachedToken in Tokens)
+            {
+                if (!IsUsable(cachedToken.Value) &&
+                    Tokens.TryRemove(cachedToken.Key, out _))
+                {
+                    removedCount++;
+                }
+            }
+
+            return removedCount;
+        }
+
+        internal static async Task<IDisposable> AcquireLockAsync(string cacheKey, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var entry = Locks.GetOrAdd(
+                    cacheKey,
+                    _ => new LockEntry());
+
+                if (!entry.TryAddLease())
+                {
+                    continue;
+                }
+
+                try
+                {
+                    await entry.Semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    return new LockLease(entry);
+                }
+                catch
+                {
+                    entry.ReleaseLease();
+
+                    if (Locks.Count > MaxLockEntries)
+                    {
+                        PruneLocks();
+                    }
+
+                    throw;
+                }
+            }
+        }
+
+        internal static void PruneLocks()
+        {
+            if (Locks.Count <= MaxLockEntries)
+            {
+                return;
+            }
+
+            lock (LocksPruneLock)
+            {
+                if (Locks.Count <= MaxLockEntries)
+                {
+                    return;
+                }
+
+                var cutoffUtc = DateTime.UtcNow.Subtract(LockIdleLimit);
+
+                PruneLocks(cutoffUtc, requireIdle: true);
+
+                if (Locks.Count > MaxLockEntries)
+                {
+                    PruneLocks(cutoffUtc, requireIdle: false);
+                }
+            }
+        }
+
+        internal static void ClearForTesting()
+        {
+            Tokens.Clear();
+
+            foreach (var lockEntry in Locks)
+            {
+                if (Locks.TryRemove(lockEntry.Key, out var removedEntry))
+                {
+                    removedEntry.Dispose();
+                }
+            }
+        }
+
+        internal static void AddForTesting(string cacheKey, ProtectedToken token)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(cacheKey);
+            ArgumentNullException.ThrowIfNull(token);
+
+            Tokens[cacheKey] = new ProtectedToken(token);
+        }
+
+        internal static bool ContainsKey(string cacheKey)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(cacheKey);
+
+            return Tokens.ContainsKey(cacheKey);
+        }
+
+        internal static int CountForTesting() => Tokens.Count;
+
+        private static string BuildCredentialFingerprint(string accessKey, string staffPassword)
+        {
+            var credentialMaterial = $"access-key:{accessKey.Length}:{accessKey}|staff-password:{staffPassword.Length}:{staffPassword}";
+            var hash = SHA256.HashData(Encoding.UTF8.GetBytes(credentialMaterial));
+            return Convert.ToHexString(hash);
+        }
+
+        private static bool IsMissingOrExpired(ProtectedToken? token)
+        {
+            if (token == null || !token.ExpirationDate.HasValue)
+            {
+                return true;
+            }
+
+            var expirationUtc = NormalizeExpirationUtc(token.ExpirationDate.Value);
+
+            return expirationUtc <= DateTime.UtcNow.Add(ExpirationSkew);
+        }
+
+        private static DateTime NormalizeExpirationUtc(DateTime expirationDate)
+        {
+            return expirationDate.Kind switch
+            {
+                DateTimeKind.Utc => expirationDate,
+                DateTimeKind.Local => expirationDate.ToUniversalTime(),
+                _ => DateTime.SpecifyKind(expirationDate, DateTimeKind.Utc)
+            };
+        }
+
+        private static void PruneLocks(DateTime cutoffUtc, bool requireIdle)
+        {
+            foreach (var pair in Locks)
+            {
+                if (Locks.Count <= TargetLockEntries)
+                {
+                    return;
+                }
+
+                var entry = pair.Value;
+
+                if (!entry.TryRetire(cutoffUtc, requireIdle))
+                {
+                    continue;
+                }
+
+                if (Locks.TryRemove(pair.Key, out var removedEntry) &&
+                    ReferenceEquals(removedEntry, entry))
+                {
+                    removedEntry.Dispose();
+                }
+                else
+                {
+                    entry.UndoRetire();
+                }
+            }
+        }
+
+        private sealed class LockLease : IDisposable
+        {
+            private LockEntry? _entry;
+
+            public LockLease(LockEntry entry)
+            {
+                _entry = entry;
+            }
+
+            public void Dispose()
+            {
+                var entry = _entry;
+                if (entry == null)
+                {
+                    return;
+                }
+
+                _entry = null;
+
+                try
+                {
+                    entry.Semaphore.Release();
+                }
+                finally
+                {
+                    entry.ReleaseLease();
+
+                    if (Locks.Count > MaxLockEntries)
+                    {
+                        PruneLocks();
+                    }
+                }
+            }
+        }
+
+        private sealed class LockEntry : IDisposable
+        {
+            private readonly object _syncRoot = new object();
+            private int _leaseCount;
+            private bool _retired;
+            private DateTime _lastUsedUtc = DateTime.UtcNow;
+
+            public SemaphoreSlim Semaphore { get; } = new SemaphoreSlim(1, 1);
+
+            public bool TryAddLease()
+            {
+                lock (_syncRoot)
+                {
+                    if (_retired)
+                    {
+                        return false;
+                    }
+
+                    _leaseCount++;
+                    _lastUsedUtc = DateTime.UtcNow;
+                    return true;
+                }
+            }
+
+            public void ReleaseLease()
+            {
+                lock (_syncRoot)
+                {
+                    if (_leaseCount > 0)
+                    {
+                        _leaseCount--;
+                    }
+
+                    _lastUsedUtc = DateTime.UtcNow;
+                }
+            }
+
+            public bool TryRetire(DateTime cutoffUtc, bool requireIdle)
+            {
+                lock (_syncRoot)
+                {
+                    if (_retired || _leaseCount != 0)
+                    {
+                        return false;
+                    }
+
+                    if (requireIdle && _lastUsedUtc > cutoffUtc)
+                    {
+                        return false;
+                    }
+
+                    _retired = true;
+                    return true;
+                }
+            }
+
+            public void UndoRetire()
+            {
+                lock (_syncRoot)
+                {
+                    if (_retired && _leaseCount == 0)
+                    {
+                        _retired = false;
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                Semaphore.Dispose();
+            }
+        }
+    }
+}

--- a/src/polaris-api-csharpTests/Methods/ProtectedTokens/PatronSearchTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ProtectedTokens/PatronSearchTests.cs
@@ -459,7 +459,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             Assert.AreEqual(1, handlerA.AuthenticationRequestCount);
             Assert.AreEqual(1, handlerB.AuthenticationRequestCount);
             Assert.AreEqual("token-b", clientB.Token?.AccessToken);
-            Assert.AreEqual(1, GetProtectedTokenCache().Count);
+            Assert.AreEqual(1, ProtectedTokenCache.CountForTesting());
             Assert.IsFalse(TryGetCachedToken(hostname, clientB.AccessID, clientB.AccessKey, clientB.StaffOverrideAccount, out _));
         }
 

--- a/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiContractTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiContractTests.cs
@@ -46,10 +46,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
 
         private static bool InvokeIsStaffAuthenticatorRequest(PapiRestRequest? request)
         {
-            var isStaffAuthenticatorRequest = typeof(PapiClient)
-                .GetMethod("IsStaffAuthenticatorRequest", BindingFlags.Static | BindingFlags.NonPublic)!;
-
-            return (bool)isStaffAuthenticatorRequest.Invoke(null, new object?[] { request })!;
+            return PapiRequestClassifier.IsStaffAuthenticatorRequest(request);
         }
 
         private static PapiRestRequest CreateStaffAuthenticatorRequestWithPath(string? path)

--- a/src/polaris-api-csharpTests/TestInfrastructure/PapiClientTestBase.cs
+++ b/src/polaris-api-csharpTests/TestInfrastructure/PapiClientTestBase.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -159,12 +158,7 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
 
         protected static void ClearProtectedTokenState()
         {
-            var cache = GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache");
-            cache?.Clear();
-
-            var locksProperty = typeof(PapiClient).GetProperty("ProtectedTokenCacheLocks", BindingFlags.NonPublic | BindingFlags.Static);
-            var locks = locksProperty?.GetValue(null);
-            locks?.GetType().GetMethod("Clear")?.Invoke(locks, null);
+            ProtectedTokenCache.ClearForTesting();
         }
 
         protected static void SetCachedToken(string hostname, string accessId, string accessKey, PolarisUser? staffUser, ProtectedToken token)
@@ -172,7 +166,7 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
             var cacheKey = BuildCacheKey(hostname, accessId, accessKey, staffUser);
             if (cacheKey != null)
             {
-                GetProtectedTokenCache().TryAdd(cacheKey, token);
+                ProtectedTokenCache.AddForTesting(cacheKey, token);
             }
         }
 
@@ -180,41 +174,17 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
         {
             token = null;
             var cacheKey = BuildCacheKey(hostname, accessId, accessKey, staffUser);
-            return cacheKey != null && GetProtectedTokenCache().TryGetValue(cacheKey, out token);
-        }
-
-        protected static ConcurrentDictionary<string, ProtectedToken> GetProtectedTokenCache()
-        {
-            return GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache")
-                ?? throw new InvalidOperationException("Protected token cache was not available.");
-        }
-
-        protected static T? GetPrivateStaticProperty<T>(string propertyName) where T : class
-        {
-            var cacheProperty = typeof(PapiClient).GetProperty(propertyName, BindingFlags.NonPublic | BindingFlags.Static);
-            return cacheProperty?.GetValue(null) as T;
+            return cacheKey != null && ProtectedTokenCache.TryGet(cacheKey, useCache: true, out token);
         }
 
         protected static string? BuildCacheKey(string hostname, string accessId, string accessKey, PolarisUser? staffUser)
         {
-            if (staffUser == null) { return null; }
-
-            var client = new PapiClient
-            {
-                Hostname = hostname,
-                AccessID = accessId,
-                AccessKey = accessKey,
-                StaffOverrideAccount = staffUser
-            };
-
-            return BuildCacheKey(client);
+            return ProtectedTokenCache.BuildKey(hostname, accessId, accessKey, staffUser);
         }
 
         protected static string? BuildCacheKey(PapiClient client)
         {
-            var buildCacheKeyMethod = typeof(PapiClient).GetMethod("BuildProtectedTokenCacheKey", BindingFlags.Instance | BindingFlags.NonPublic)
-                ?? throw new InvalidOperationException("Protected token cache-key builder was not available.");
-            return buildCacheKeyMethod.Invoke(client, Array.Empty<object>()) as string;
+            return ProtectedTokenCache.BuildKey(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount);
         }
 
         protected sealed class TestPapiSettings : IPapiSettings


### PR DESCRIPTION
### Motivation
- Reduce size and improve cohesion of `PapiClient` by moving self-contained helper responsibilities out of the central client while preserving runtime behavior. 
- Centralize protected-token cache management, request classification, and request validation into focused internal helpers to make the orchestration logic in `PapiClient` clearer. 

### Description
- Introduced an internal `ProtectedTokenCache` (`src/polaris-api-csharp/ProtectedTokenCache.cs`) that owns process-wide protected-token storage, cache-key building and credential fingerprinting, expiration/usability checks with preserved skew, defensive copying, cache pruning, per-key async lock leases and bounded lock pruning, and internal test hooks (`BuildKey`, `IsUsable`, `TryGet`, `Set`, `Remove`, `PruneExpired`, `AcquireLockAsync`, `PruneLocks`, `ClearForTesting`, `AddForTesting`, `ContainsKey`, `CountForTesting`).
- Introduced an internal `PapiRequestClassifier` (`src/polaris-api-csharp/PapiRequestClassifier.cs`) that centralizes request/path classification and decisions about protected-token requirements, staff-override patron requests, staff-authenticator routes, patron barcode segment detection, and placeholder detection (APIs: `RequiresProtectedToken`, `IsStaffOverridePatronRequest`, `HasPatronBarcodeRouteSegment`, `IsStaffAuthenticatorRequest`, `PathContainsProtectedTokenPlaceholder`).
- Introduced an internal `PapiRequestValidator` (`src/polaris-api-csharp/PapiRequestValidator.cs`) that encapsulates the pure validation logic for executable `PapiRestRequest` instances (preserves original rules and exception messages) via `ValidateExecutableRequest`.
- Updated `PapiClient` to delegate to these helpers for cache key building/lookup/locking/pruning, request classification, and request validation while leaving orchestration, configuration, signing, token acquisition orchestration, and public API surface unchanged; preserved defensive token copying and expiration-skew behavior.
- Updated tests and test infrastructure to use the new internal helper hooks instead of reflection into `PapiClient` internals (files changed: `src/polaris-api-csharpTests/TestInfrastructure/PapiClientTestBase.cs`, `src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiContractTests.cs`, `src/polaris-api-csharpTests/Methods/ProtectedTokens/PatronSearchTests.cs`).
- Files created: `ProtectedTokenCache.cs`, `PapiRequestClassifier.cs`, `PapiRequestValidator.cs`.
- Approximate `PapiClient.cs` reduction: from ~729 to ~333 lines (≈396 lines reduced).
- No public APIs were added and behavior is intended to be unchanged (cache copying, skew, route matching, and async/cancellation/`ConfigureAwait(false)` behavior preserved).

### Testing
- Built the library with `dotnet build src/polaris-api-csharp/Clc.Polaris.Api.csproj` (succeeded). 
- Built the tests with `dotnet build src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj` (succeeded).
- Ran unit tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Unit"` and all unit tests passed (`199` tests passed, `0` failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a0a99dd1c83239e73d409715fb480)