### PR TITLE
Refactor PapiClient internals and clean up test infrastructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,11 +99,11 @@ ExpiredProtectedTokenExpirationDate
 
 Do not replace explicit `DateTime.UtcNow`, `DateTime.SpecifyKind`, or expiration-skew values when the test is specifically about:
 
-- UTC expiration handling
-- unspecified `DateTimeKind`
-- expiration skew
-- missing/null expiration dates
-- exact timestamp behavior
+- UTC expiration handling.
+- Unspecified `DateTimeKind`.
+- Expiration skew.
+- Missing/null expiration dates.
+- Exact timestamp behavior.
 
 ### Test HTTP handlers
 
@@ -167,6 +167,32 @@ Do not call the overload without a cancellation token when a suitable overload e
 ```csharp
 await client.AuthenticateStaffUserAsync(user);
 ```
+
+### MSTEST0037: Use specific assertion methods
+
+Prefer specific MSTest assertions over generic boolean assertions when available.
+
+Use:
+
+```csharp
+Assert.IsNotEmpty(items);
+Assert.Contains("expected", actual);
+Assert.AreEqual(expected, actual);
+Assert.IsNull(value);
+Assert.IsNotNull(value);
+```
+
+instead of:
+
+```csharp
+Assert.IsTrue(items.Length > 0);
+Assert.IsTrue(actual.Contains("expected"));
+Assert.IsTrue(expected == actual);
+Assert.IsTrue(value == null);
+Assert.IsTrue(value != null);
+```
+
+Do not change assertion meaning just to satisfy the analyzer. If the specific assertion would obscure the intent or change comparison semantics, preserve the clearer assertion.
 
 ### MSTEST0046: Assert.Contains vs StringAssert.Contains
 
@@ -268,10 +294,11 @@ CreateProtectedTokenJson("t", "s", ValidProtectedTokenExpirationDate)
 
 Do not introduce new diagnostics for:
 
+- `MSTEST0037`
 - `MSTEST0046`
 - `MSTEST0049`
-- nullable initialization warnings such as `CS8618`
-- member hiding warnings such as `CS0108`
+- Nullable initialization warnings such as `CS8618`
+- Member hiding warnings such as `CS0108`
 
 If touching tests, fix analyzer diagnostics in the touched files unless the task explicitly says not to.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,304 @@
+# AGENTS.md
+
+## Scope
+
+These instructions apply to the entire repository.
+
+This repository is a C#/.NET library and test suite for the Polaris API client. Prefer small, behavior-preserving changes unless the task explicitly asks for a functional refactor.
+
+## General expectations
+
+- Preserve runtime behavior unless the task explicitly requests behavior changes.
+- Prefer readable code over minimizing line count.
+- Do not introduce new analyzer warnings, build warnings, or test failures.
+- Do not add package references unless explicitly asked.
+- Do not rename public APIs unless explicitly asked.
+- Keep changes scoped to the task. Avoid drive-by refactors outside touched code.
+- Before finishing, review the diff for accidental value changes, especially string literals used by assertions.
+
+## C# formatting style
+
+- Use ordinary C# formatting consistent with nearby files.
+- Avoid unnecessary vertical wrapping.
+- Keep simple constructor and method calls on one line when readable.
+- Prefer local variables when an inline expression becomes visually dense.
+- Keep one blank line between methods and test methods.
+- Avoid double/triple blank-line gaps.
+- Normalize using order in touched files:
+  - `System.*`
+  - `Clc.*`
+  - `Microsoft.*`
+
+## Test infrastructure
+
+Prefer shared test infrastructure from `PapiClientTestBase` instead of adding new local helper classes.
+
+Use the existing helpers where applicable:
+
+```csharp
+CreateJson(...)
+CreatePapiResponseJson()
+CreatePapiResponseJson(1)
+CreateEmptyJsonObject()
+CreateProtectedTokenJson(accessToken: "...", accessSecret: "...", expirationDate: ValidProtectedTokenExpirationDate)
+ValidProtectedTokenExpirationDate
+ExpiredProtectedTokenExpirationDate
+```
+
+### JSON response helpers
+
+Do not hand-build escaped JSON strings such as:
+
+```csharp
+"{\"PAPIErrorCode\":0}"
+"{\"PAPIErrorCode\":1}"
+"{\"PAPIErrorCode\":0,\"AccessToken\":\"t\",\"AccessSecret\":\"s\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}"
+```
+
+Use helpers instead:
+
+```csharp
+CreatePapiResponseJson()
+CreatePapiResponseJson(1)
+CreateProtectedTokenJson(accessToken: "t", accessSecret: "s", expirationDate: ValidProtectedTokenExpirationDate)
+```
+
+Use `CreateProtectedTokenJson(...)` only for protected-token/staff-authentication responses that contain:
+
+```json
+{
+  "PAPIErrorCode": 0,
+  "AccessToken": "...",
+  "AccessSecret": "...",
+  "AuthExpDate": "..."
+}
+```
+
+Do not use `CreateProtectedTokenJson(...)` for patron-authentication responses or other response shapes. For other JSON response shapes, use `CreateJson(new { ... })` or add a clearly named helper if the shape is repeated.
+
+Example patron authentication response:
+
+```csharp
+CreateJson(new { PAPIErrorCode = 0, AccessToken = "mock-token", AccessSecret = "mock-secret", PatronID = 123 })
+```
+
+Preserve intentional literal responses when the test specifically requires them, especially:
+
+```csharp
+"null"
+```
+
+### Protected-token dates
+
+Use the shared date properties when the test only cares whether a token is valid or expired:
+
+```csharp
+ValidProtectedTokenExpirationDate
+ExpiredProtectedTokenExpirationDate
+```
+
+Do not replace explicit `DateTime.UtcNow`, `DateTime.SpecifyKind`, or expiration-skew values when the test is specifically about:
+
+- UTC expiration handling
+- unspecified `DateTimeKind`
+- expiration skew
+- missing/null expiration dates
+- exact timestamp behavior
+
+### Test HTTP handlers
+
+Prefer `CapturingHttpMessageHandler` for tests that need to inspect the request or request body.
+
+`CapturingHttpMessageHandler` captures:
+
+```csharp
+LastRequest
+LastRequestContent
+LastCancellationToken
+RequestCount
+```
+
+and allows a custom JSON response:
+
+```csharp
+var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
+```
+
+or:
+
+```csharp
+var handler = new CapturingHttpMessageHandler(CreateJson(new { PAPIErrorCode = 0, AccessToken = "mock-token", AccessSecret = "mock-secret", PatronID = 123 }));
+```
+
+Do not introduce local nested handlers with names that collide with base test infrastructure, such as:
+
+```csharp
+CaptureHttpMessageHandler
+CapturingHttpMessageHandler
+ProtectedTokenHttpMessageHandler
+```
+
+If a new handler is genuinely needed, give it a specific name that describes its behavior.
+
+## MSTest expectations
+
+### TestContext
+
+If a shared test base class exposes `TestContext`, use this pattern:
+
+```csharp
+public TestContext TestContext { get; set; } = null!;
+```
+
+MSTest initializes this property at runtime. The `= null!;` initializer is intentional and avoids nullable initialization warnings.
+
+If a test class inherits from a base class that already provides `TestContext`, do not redeclare it in the child class.
+
+### Cancellation tokens
+
+When calling async methods that expose a `CancellationToken` overload, pass the MSTest cancellation token:
+
+```csharp
+await client.AuthenticateStaffUserAsync(user, cancellationToken: TestContext.CancellationToken);
+```
+
+Do not call the overload without a cancellation token when a suitable overload exists:
+
+```csharp
+await client.AuthenticateStaffUserAsync(user);
+```
+
+### MSTEST0046: Assert.Contains vs StringAssert.Contains
+
+Prefer `Assert.Contains(...)` over `StringAssert.Contains(...)`.
+
+Important: the argument order is different.
+
+`StringAssert.Contains` uses:
+
+```csharp
+StringAssert.Contains(actualString, substring);
+```
+
+`Assert.Contains` uses:
+
+```csharp
+Assert.Contains(substring, value);
+```
+
+Correct conversion:
+
+```csharp
+StringAssert.Contains(handler.LastRequestContent, "secret");
+Assert.Contains("secret", handler.LastRequestContent);
+```
+
+Incorrect conversion:
+
+```csharp
+Assert.Contains(handler.LastRequestContent, "secret");
+```
+
+Do not blindly trust IDE quick fixes for this rule. Verify the first argument is the expected substring and the second argument is the actual value being searched.
+
+For URI assertions:
+
+```csharp
+Assert.Contains("/protected/v1/1033/100/1/authenticator/staff", handler.LastRequest!.RequestUri!.AbsolutePath);
+```
+
+not:
+
+```csharp
+Assert.Contains(handler.LastRequest!.RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
+```
+
+### Request body assertions
+
+After asserting captured request content is not null:
+
+```csharp
+Assert.IsNotNull(handler.LastRequestContent);
+```
+
+use `Assert.Contains` with expected substring first:
+
+```csharp
+Assert.Contains("main", handler.LastRequestContent);
+Assert.Contains("staff", handler.LastRequestContent);
+Assert.Contains("secret", handler.LastRequestContent);
+```
+
+## Object construction and named arguments
+
+Use named arguments when positional values are easy to confuse.
+
+Preferred:
+
+```csharp
+new PolarisUser(domain: "main", username: "staff", password: "secret")
+```
+
+Acceptable when object initializer clarity is useful:
+
+```csharp
+new PolarisUser
+{
+    Domain = "main",
+    Username = "staff",
+    Password = "secret"
+}
+```
+
+Be careful not to change assertion-sensitive literals during refactors. For example, do not accidentally change `"secret"` to `"sercret"`.
+
+For protected token JSON helper calls, use named arguments:
+
+```csharp
+CreateProtectedTokenJson(accessToken: "t", accessSecret: "s", expirationDate: ValidProtectedTokenExpirationDate)
+```
+
+Do not use unclear positional calls:
+
+```csharp
+CreateProtectedTokenJson("t", "s", ValidProtectedTokenExpirationDate)
+```
+
+## Analyzer cleanup
+
+Do not introduce new diagnostics for:
+
+- `MSTEST0046`
+- `MSTEST0049`
+- nullable initialization warnings such as `CS8618`
+- member hiding warnings such as `CS0108`
+
+If touching tests, fix analyzer diagnostics in the touched files unless the task explicitly says not to.
+
+## Validation
+
+Before finishing a change that touches source or tests, run the relevant commands from the repository root.
+
+For library changes:
+
+```bash
+dotnet build src/polaris-api-csharp/Clc.Polaris.Api.csproj
+```
+
+For test changes:
+
+```bash
+dotnet build src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj
+dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Unit"
+```
+
+If a command cannot be run in the environment, say so explicitly in the summary.
+
+## Final response expectations
+
+When summarizing work:
+
+- List the files changed.
+- Note any behavior changes, or explicitly state that behavior was preserved.
+- Report build/test commands run and their results.
+- Mention any remaining diagnostics or skipped validation.

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,7 +1,19 @@
 ﻿[*.cs]
 
+# MSTEST0046: Use Assert.Contains instead of StringAssert.Contains
+dotnet_diagnostic.MSTEST0046.severity = warning
+
+# MSTEST0049: Pass TestContext.CancellationToken to async test calls when available
+dotnet_diagnostic.MSTEST0049.severity = warning
+
+# MSTEST0037: Use the most specific Assert method instead of generic Assert.IsTrue/Assert.IsFalse patterns
+dotnet_diagnostic.MSTEST0037.severity = warning
+
 # CA1707: Identifiers should not contain underscores
 dotnet_diagnostic.CA1707.severity = none
 
 # IDE0130: Namespace does not match folder structure
 dotnet_diagnostic.IDE0130.severity = none
+
+# IDE0290: Use primary constructor
+dotnet_diagnostic.IDE0290.severity = none

--- a/src/polaris-api-csharp/Extensions/CreatePatronBlocksExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/CreatePatronBlocksExtensions.cs
@@ -16,13 +16,7 @@ namespace Clc.Polaris.Api
             int? workstationId = null,
             CancellationToken cancellationToken = default)
         {
-            return client.CreatePatronBlocksAsync(
-                barcode,
-                BlockType.FreeText,
-                blockText,
-                userId,
-                workstationId,
-                cancellationToken);
+            return client.CreatePatronBlocksAsync(barcode, BlockType.FreeText, blockText, userId, workstationId, cancellationToken);
         }
 
         public static Task<IRestResponse<CreatePatronBlocksResult>> CreatePatronLibraryAssignedBlockAsync(
@@ -33,13 +27,7 @@ namespace Clc.Polaris.Api
             int? workstationId = null,
             CancellationToken cancellationToken = default)
         {
-            return client.CreatePatronBlocksAsync(
-                barcode,
-                BlockType.LibraryAssigned,
-                blockId.ToString(CultureInfo.InvariantCulture),
-                userId,
-                workstationId,
-                cancellationToken);
+            return client.CreatePatronBlocksAsync(barcode, BlockType.LibraryAssigned, blockId.ToString(CultureInfo.InvariantCulture), userId, workstationId, cancellationToken);
         }
 
         public static Task<IRestResponse<CreatePatronBlocksResult>> CreatePatronSystemBlockAsync(
@@ -50,13 +38,7 @@ namespace Clc.Polaris.Api
             int? workstationId = null,
             CancellationToken cancellationToken = default)
         {
-            return client.CreatePatronBlocksAsync(
-                barcode,
-                BlockType.System,
-                ((int)systemBlock).ToString(CultureInfo.InvariantCulture),
-                userId,
-                workstationId,
-                cancellationToken);
+            return client.CreatePatronBlocksAsync(barcode, BlockType.System, ((int)systemBlock).ToString(CultureInfo.InvariantCulture), userId, workstationId, cancellationToken);
         }
     }
 }

--- a/src/polaris-api-csharp/Extensions/ItemRenewExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/ItemRenewExtensions.cs
@@ -14,12 +14,7 @@ namespace Clc.Polaris.Api
             ItemRenewOptions? renewOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return client.ItemRenewAsync(
-                barcode,
-                0,
-                password,
-                renewOptions,
-                cancellationToken);
+            return client.ItemRenewAsync(barcode, 0, password, renewOptions, cancellationToken);
         }
     }
 }

--- a/src/polaris-api-csharp/Extensions/PatronReadingHistoryClearExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/PatronReadingHistoryClearExtensions.cs
@@ -14,11 +14,7 @@ namespace Clc.Polaris.Api
             IEnumerable<int> ids,
             CancellationToken cancellationToken = default)
         {
-            return client.PatronReadingHistoryClearAsync(
-                barcode,
-                null,
-                ids,
-                cancellationToken);
+            return client.PatronReadingHistoryClearAsync(barcode, null, ids, cancellationToken);
         }
     }
 }

--- a/src/polaris-api-csharp/Extensions/RecordSetContentPutExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/RecordSetContentPutExtensions.cs
@@ -16,13 +16,7 @@ namespace Clc.Polaris.Api
             int workstationId = 1,
             CancellationToken cancellationToken = default)
         {
-            return client.RecordSetContentPutAsync(
-                recordSetId,
-                new[] { recordId },
-                RecordSetContentPutActions.Add,
-                userId,
-                workstationId,
-                cancellationToken);
+            return client.RecordSetContentPutAsync(recordSetId, [recordId], RecordSetContentPutActions.Add, userId, workstationId, cancellationToken);
         }
 
         public static Task<IRestResponse<PapiResponseCommon>> RecordSetContentAddAsync(
@@ -33,13 +27,7 @@ namespace Clc.Polaris.Api
             int workstationId = 1,
             CancellationToken cancellationToken = default)
         {
-            return client.RecordSetContentPutAsync(
-                recordSetId,
-                records,
-                RecordSetContentPutActions.Add,
-                userId,
-                workstationId,
-                cancellationToken);
+            return client.RecordSetContentPutAsync(recordSetId, records, RecordSetContentPutActions.Add, userId, workstationId, cancellationToken);
         }
 
         public static Task<IRestResponse<PapiResponseCommon>> RecordSetContentRemoveAsync(
@@ -50,13 +38,7 @@ namespace Clc.Polaris.Api
             int workstationId = 1,
             CancellationToken cancellationToken = default)
         {
-            return client.RecordSetContentPutAsync(
-                recordSetId,
-                new[] { recordId },
-                RecordSetContentPutActions.Remove,
-                userId,
-                workstationId,
-                cancellationToken);
+            return client.RecordSetContentPutAsync(recordSetId, [recordId], RecordSetContentPutActions.Remove, userId, workstationId, cancellationToken);
         }
 
         public static Task<IRestResponse<PapiResponseCommon>> RecordSetContentRemoveAsync(
@@ -67,13 +49,7 @@ namespace Clc.Polaris.Api
             int workstationId = 1,
             CancellationToken cancellationToken = default)
         {
-            return client.RecordSetContentPutAsync(
-                recordSetId,
-                records,
-                RecordSetContentPutActions.Remove,
-                userId,
-                workstationId,
-                cancellationToken);
+            return client.RecordSetContentPutAsync(recordSetId, records, RecordSetContentPutActions.Remove, userId, workstationId, cancellationToken);
         }
     }
 }

--- a/src/polaris-api-csharp/Extensions/SynchBibsByIdGetExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/SynchBibsByIdGetExtensions.cs
@@ -1,7 +1,7 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
 using System.Threading;
 using System.Threading.Tasks;
+using Clc.Polaris.Api.Models;
+using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {
@@ -13,10 +13,7 @@ namespace Clc.Polaris.Api
             bool includeItems = false,
             CancellationToken cancellationToken = default)
         {
-            return client.Synch_BibsByIdGetAsync(
-                new[] { bibId },
-                includeItems,
-                cancellationToken);
+            return client.Synch_BibsByIdGetAsync([bibId], includeItems, cancellationToken);
         }
     }
 }

--- a/src/polaris-api-csharp/GlobalSuppressions.cs
+++ b/src/polaris-api-csharp/GlobalSuppressions.cs
@@ -1,4 +1,0 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
-// attributes that are applied to this project.
-// Project-level suppressions either have no target or are given
-// a specific target and scoped to a namespace, type, member, etc.

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -178,11 +178,7 @@ namespace Clc.Polaris.Api
             var executionRequest = new PapiRestRequest(request);
 
             var pathContainsProtectedTokenPlaceholder = PapiRequestClassifier.PathContainsProtectedTokenPlaceholder(executionRequest);
-            var requiresProtectedToken = PapiRequestClassifier.RequiresProtectedToken(
-                executionRequest,
-                pathContainsProtectedTokenPlaceholder,
-                AllowStaffOverrideRequests,
-                StaffOverrideAccount);
+            var requiresProtectedToken = PapiRequestClassifier.RequiresProtectedToken(executionRequest, pathContainsProtectedTokenPlaceholder, AllowStaffOverrideRequests, StaffOverrideAccount);
 
             var protectedToken = requiresProtectedToken
                 ? await GetProtectedTokenOrThrowAsync(pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false)
@@ -195,7 +191,6 @@ namespace Clc.Polaris.Api
 
             return await ExecuteAsync<T>(executionRequest, cancellationToken).ConfigureAwait(false);
         }
-
 
         private static InvalidOperationException CreateProtectedTokenRequiredException(string reason, bool pathContainsProtectedTokenPlaceholder)
         {
@@ -219,9 +214,9 @@ namespace Clc.Polaris.Api
         private async Task<ProtectedToken> GetProtectedTokenOrThrowAsync(bool pathContainsProtectedTokenPlaceholder, CancellationToken cancellationToken = default)
         {
             var token = Token;
-            if (ProtectedTokenCache.IsUsable(token))
+            if (token != null)
             {
-                return token!;
+                return token;
             }
 
             if (StaffOverrideAccount == null)

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -3,11 +3,8 @@ using Clc.Polaris.Api.Models;
 using Clc.Rest;
 using Clc.Rest.Models;
 using System;
-using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -43,17 +40,7 @@ namespace Clc.Polaris.Api
 
         public bool UseProtectedTokenCache { get; set; } = true;
 
-        private const int MaxProtectedTokenCacheLockEntries = 1024;
-        private const int TargetProtectedTokenCacheLockEntries = 512;
-
-        private static readonly TimeSpan ProtectedTokenCacheLockIdleLimit = TimeSpan.FromMinutes(10);
-        private static readonly object ProtectedTokenCacheLocksPruneLock = new object();
-
-        private static ConcurrentDictionary<string, ProtectedToken> ProtectedTokenCache { get; } = new ConcurrentDictionary<string, ProtectedToken>();
-        private static ConcurrentDictionary<string, ProtectedTokenCacheLockEntry> ProtectedTokenCacheLocks { get; } = new ConcurrentDictionary<string, ProtectedTokenCacheLockEntry>();
-
         private ProtectedToken? _token;
-        private static readonly TimeSpan ProtectedTokenExpirationSkew = TimeSpan.FromMinutes(1);
 
         /// <summary>
         /// Used for protected methods and public method overrides
@@ -62,7 +49,7 @@ namespace Clc.Polaris.Api
         {
             get
             {
-                if (IsProtectedTokenMissingOrExpired(_token))
+                if (!ProtectedTokenCache.IsUsable(_token))
                 {
                     _token = null;
                     return null;
@@ -114,7 +101,7 @@ namespace Clc.Polaris.Api
                 var accessSecret = token?.AccessSecret;
                 var accessToken = token?.AccessToken;
 
-                if (IsStaffOverridePatronRequest(papiRequest))
+                if (PapiRequestClassifier.IsStaffOverridePatronRequest(papiRequest, AllowStaffOverrideRequests, StaffOverrideAccount))
                 {
                     if (!string.IsNullOrWhiteSpace(accessSecret) && !string.IsNullOrWhiteSpace(accessToken))
                     {
@@ -186,12 +173,16 @@ namespace Clc.Polaris.Api
         /// <exception cref="ArgumentException"><paramref name="request"/> has an invalid custom PAPI path.</exception>
         public async Task<IRestResponse<T>> ExecutePapiAsync<T>(PapiRestRequest request, CancellationToken cancellationToken = default)
         {
-            ValidateCustomPapiRequest(request);
+            PapiRequestValidator.ValidateExecutableRequest(request);
 
             var executionRequest = new PapiRestRequest(request);
 
-            var pathContainsProtectedTokenPlaceholder = RequestPathContainsProtectedTokenPlaceholder(executionRequest);
-            var requiresProtectedToken = RequiresProtectedToken(executionRequest, pathContainsProtectedTokenPlaceholder);
+            var pathContainsProtectedTokenPlaceholder = PapiRequestClassifier.PathContainsProtectedTokenPlaceholder(executionRequest);
+            var requiresProtectedToken = PapiRequestClassifier.RequiresProtectedToken(
+                executionRequest,
+                pathContainsProtectedTokenPlaceholder,
+                AllowStaffOverrideRequests,
+                StaffOverrideAccount);
 
             var protectedToken = requiresProtectedToken
                 ? await GetProtectedTokenOrThrowAsync(pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false)
@@ -205,95 +196,6 @@ namespace Clc.Polaris.Api
             return await ExecuteAsync<T>(executionRequest, cancellationToken).ConfigureAwait(false);
         }
 
-        private static void ValidateCustomPapiRequest(PapiRestRequest request)
-        {
-            ArgumentNullException.ThrowIfNull(request);
-
-            if (string.IsNullOrWhiteSpace(request.Path))
-            {
-                throw new ArgumentException("PAPI request path must not be null, empty, or whitespace.", nameof(request));
-            }
-
-            if (request.Path.Contains("://", StringComparison.Ordinal))
-            {
-                throw new ArgumentException("PAPI request path must be a relative path, not an absolute URL.", nameof(request));
-            }
-
-            if (request.Path.StartsWith("//", StringComparison.Ordinal))
-            {
-                throw new ArgumentException("PAPI request path must not be a protocol-relative URL.", nameof(request));
-            }
-
-            if (!request.Path.StartsWith('/'))
-            {
-                throw new ArgumentException("PAPI request path must begin with '/'.", nameof(request));
-            }
-
-            if (request.AuthRequired &&
-                !request.Path.StartsWith("/public/", StringComparison.OrdinalIgnoreCase) &&
-                !request.Path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase))
-            {
-                throw new ArgumentException("Authenticated custom PAPI request paths must begin with '/public/' or '/protected/'.", nameof(request));
-            }
-        }
-
-        private bool RequiresProtectedToken(PapiRestRequest request, bool pathContainsProtectedTokenPlaceholder)
-        {
-            if (IsStaffAuthenticatorRequest(request))
-            {
-                return false;
-            }
-
-            if (pathContainsProtectedTokenPlaceholder)
-            {
-                return true;
-            }
-
-            if (request.IsProtectedMethod && string.IsNullOrWhiteSpace(request.Password))
-            {
-                return true;
-            }
-
-            return IsStaffOverridePatronRequest(request);
-        }
-
-        private bool IsStaffOverridePatronRequest(PapiRestRequest request)
-        {
-            return request.IsPublicMethod &&
-                request.AuthRequired &&
-                AllowStaffOverrideRequests &&
-                string.IsNullOrWhiteSpace(request.Password) &&
-                !request.BlockStaffOverride &&
-                StaffOverrideAccount != null &&
-                HasPatronBarcodeRouteSegment(request.Path);
-        }
-
-        private static bool HasPatronBarcodeRouteSegment(string path)
-        {
-            var pathWithoutQuery = path.Split('?', 2)[0];
-            var segments = pathWithoutQuery.Split('/', StringSplitOptions.RemoveEmptyEntries);
-
-            for (var i = 0; i < segments.Length - 1; i++)
-            {
-                if (segments[i].Equals("patron", StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static bool IsStaffAuthenticatorRequest(PapiRestRequest? request)
-        {
-            var path = request?.Path;
-
-            return request?.Method == HttpMethod.Post &&
-                !string.IsNullOrWhiteSpace(path) &&
-                path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase) &&
-                path.EndsWith("/authenticator/staff", StringComparison.OrdinalIgnoreCase) &&
-                path.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) < 0;
-        }
 
         private static InvalidOperationException CreateProtectedTokenRequiredException(string reason, bool pathContainsProtectedTokenPlaceholder)
         {
@@ -304,14 +206,9 @@ namespace Clc.Polaris.Api
             return new InvalidOperationException($"A valid protected access token is required for this request. {reason}{placeholderReason}");
         }
 
-        private static bool RequestPathContainsProtectedTokenPlaceholder(PapiRestRequest request)
-        {
-            return request.Path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal);
-        }
-
         private static void ReplaceProtectedTokenPlaceholderInPath(PapiRestRequest request, ProtectedToken token)
         {
-            if (!IsProtectedTokenUsable(token))
+            if (!ProtectedTokenCache.IsUsable(token))
             {
                 throw new InvalidOperationException("A valid protected access token is required to replace ProtectedToken.Placeholder in the request path.");
             }
@@ -322,7 +219,7 @@ namespace Clc.Polaris.Api
         private async Task<ProtectedToken> GetProtectedTokenOrThrowAsync(bool pathContainsProtectedTokenPlaceholder, CancellationToken cancellationToken = default)
         {
             var token = Token;
-            if (IsProtectedTokenUsable(token))
+            if (ProtectedTokenCache.IsUsable(token))
             {
                 return token!;
             }
@@ -337,10 +234,11 @@ namespace Clc.Polaris.Api
                 throw CreateProtectedTokenRequiredException("No staff override credentials are configured.", pathContainsProtectedTokenPlaceholder);
             }
 
-            var cacheKey = BuildProtectedTokenCacheKey();
+            var cacheKey = ProtectedTokenCache.BuildKey(Hostname, AccessID, AccessKey, StaffOverrideAccount);
 
-            if (TryLoadProtectedTokenFromCache(cacheKey, out var cachedToken))
+            if (ProtectedTokenCache.TryGet(cacheKey, UseProtectedTokenCache, out var cachedToken))
             {
+                _token = cachedToken;
                 return cachedToken!;
             }
 
@@ -349,10 +247,10 @@ namespace Clc.Polaris.Api
                 return await AuthenticateAndLoadProtectedTokenOrThrowAsync(null, pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false);
             }
 
-            using var cacheLockLease = await AcquireProtectedTokenCacheLockAsync(cacheKey, cancellationToken).ConfigureAwait(false);
+            using var cacheLockLease = await ProtectedTokenCache.AcquireLockAsync(cacheKey, cancellationToken).ConfigureAwait(false);
 
             token = Token;
-            if (IsProtectedTokenUsable(token))
+            if (ProtectedTokenCache.IsUsable(token))
             {
                 return token!;
             }
@@ -362,326 +260,37 @@ namespace Clc.Polaris.Api
                 _token = null;
             }
 
-            if (TryLoadProtectedTokenFromCache(cacheKey, out cachedToken))
+            if (ProtectedTokenCache.TryGet(cacheKey, UseProtectedTokenCache, out cachedToken))
             {
+                _token = cachedToken;
                 return cachedToken!;
             }
 
             if (UseProtectedTokenCache)
             {
-                PruneProtectedTokenCache();
-                PruneProtectedTokenCacheLocks();
+                ProtectedTokenCache.PruneExpired();
             }
 
             return await AuthenticateAndLoadProtectedTokenOrThrowAsync(cacheKey, pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false);
         }
 
-        private static async Task<ProtectedTokenCacheLockLease> AcquireProtectedTokenCacheLockAsync(string cacheKey, CancellationToken cancellationToken)
-        {
-            while (true)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var entry = ProtectedTokenCacheLocks.GetOrAdd(
-                    cacheKey,
-                    _ => new ProtectedTokenCacheLockEntry());
-
-                if (!entry.TryAddLease())
-                {
-                    continue;
-                }
-
-                try
-                {
-                    await entry.Semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    return new ProtectedTokenCacheLockLease(entry);
-                }
-                catch
-                {
-                    entry.ReleaseLease();
-
-                    if (ProtectedTokenCacheLocks.Count > MaxProtectedTokenCacheLockEntries)
-                    {
-                        PruneProtectedTokenCacheLocks();
-                    }
-
-                    throw;
-                }
-            }
-        }
-
-        private static void PruneProtectedTokenCacheLocks()
-        {
-            if (ProtectedTokenCacheLocks.Count <= MaxProtectedTokenCacheLockEntries)
-            {
-                return;
-            }
-
-            lock (ProtectedTokenCacheLocksPruneLock)
-            {
-                if (ProtectedTokenCacheLocks.Count <= MaxProtectedTokenCacheLockEntries)
-                {
-                    return;
-                }
-
-                var cutoffUtc = DateTime.UtcNow.Subtract(ProtectedTokenCacheLockIdleLimit);
-
-                PruneProtectedTokenCacheLocks(cutoffUtc, requireIdle: true);
-
-                if (ProtectedTokenCacheLocks.Count > MaxProtectedTokenCacheLockEntries)
-                {
-                    PruneProtectedTokenCacheLocks(cutoffUtc, requireIdle: false);
-                }
-            }
-        }
-
-        private static void PruneProtectedTokenCacheLocks(DateTime cutoffUtc, bool requireIdle)
-        {
-            foreach (var pair in ProtectedTokenCacheLocks)
-            {
-                if (ProtectedTokenCacheLocks.Count <= TargetProtectedTokenCacheLockEntries)
-                {
-                    return;
-                }
-
-                var entry = pair.Value;
-
-                if (!entry.TryRetire(cutoffUtc, requireIdle))
-                {
-                    continue;
-                }
-
-                if (ProtectedTokenCacheLocks.TryRemove(pair.Key, out var removedEntry) &&
-                    ReferenceEquals(removedEntry, entry))
-                {
-                    removedEntry.Dispose();
-                }
-                else
-                {
-                    entry.UndoRetire();
-                }
-            }
-        }
-
-        private sealed class ProtectedTokenCacheLockLease : IDisposable
-        {
-            private ProtectedTokenCacheLockEntry? _entry;
-
-            public ProtectedTokenCacheLockLease(ProtectedTokenCacheLockEntry entry)
-            {
-                _entry = entry;
-            }
-
-            public void Dispose()
-            {
-                var entry = _entry;
-                if (entry == null)
-                {
-                    return;
-                }
-
-                _entry = null;
-
-                try
-                {
-                    entry.Semaphore.Release();
-                }
-                finally
-                {
-                    entry.ReleaseLease();
-
-                    if (ProtectedTokenCacheLocks.Count > MaxProtectedTokenCacheLockEntries)
-                    {
-                        PruneProtectedTokenCacheLocks();
-                    }
-                }
-            }
-        }
-
-        private sealed class ProtectedTokenCacheLockEntry : IDisposable
-        {
-            private readonly object _syncRoot = new object();
-            private int _leaseCount;
-            private bool _retired;
-            private DateTime _lastUsedUtc = DateTime.UtcNow;
-
-            public SemaphoreSlim Semaphore { get; } = new SemaphoreSlim(1, 1);
-
-            public bool TryAddLease()
-            {
-                lock (_syncRoot)
-                {
-                    if (_retired)
-                    {
-                        return false;
-                    }
-
-                    _leaseCount++;
-                    _lastUsedUtc = DateTime.UtcNow;
-                    return true;
-                }
-            }
-
-            public void ReleaseLease()
-            {
-                lock (_syncRoot)
-                {
-                    if (_leaseCount > 0)
-                    {
-                        _leaseCount--;
-                    }
-
-                    _lastUsedUtc = DateTime.UtcNow;
-                }
-            }
-
-            public bool TryRetire(DateTime cutoffUtc, bool requireIdle)
-            {
-                lock (_syncRoot)
-                {
-                    if (_retired || _leaseCount != 0)
-                    {
-                        return false;
-                    }
-
-                    if (requireIdle && _lastUsedUtc > cutoffUtc)
-                    {
-                        return false;
-                    }
-
-                    _retired = true;
-                    return true;
-                }
-            }
-
-            public void UndoRetire()
-            {
-                lock (_syncRoot)
-                {
-                    if (_retired && _leaseCount == 0)
-                    {
-                        _retired = false;
-                    }
-                }
-            }
-
-            public void Dispose()
-            {
-                Semaphore.Dispose();
-            }
-        }
-
-        private string? BuildProtectedTokenCacheKey()
-        {
-            if (StaffOverrideAccount == null ||
-                string.IsNullOrWhiteSpace(Hostname) ||
-                string.IsNullOrWhiteSpace(AccessID) ||
-                string.IsNullOrWhiteSpace(AccessKey) ||
-                string.IsNullOrWhiteSpace(StaffOverrideAccount.Domain) ||
-                string.IsNullOrWhiteSpace(StaffOverrideAccount.Username) ||
-                string.IsNullOrWhiteSpace(StaffOverrideAccount.Password))
-            {
-                return null;
-            }
-
-            return $"{Hostname.Trim()}|{AccessID.Trim()}|{StaffOverrideAccount.Domain.Trim()}|{StaffOverrideAccount.Username.Trim()}|{BuildProtectedTokenCredentialFingerprint(AccessKey, StaffOverrideAccount.Password)}";
-        }
-
-        private static string BuildProtectedTokenCredentialFingerprint(string accessKey, string staffPassword)
-        {
-            var credentialMaterial = $"access-key:{accessKey.Length}:{accessKey}|staff-password:{staffPassword.Length}:{staffPassword}";
-            var hash = SHA256.HashData(Encoding.UTF8.GetBytes(credentialMaterial));
-            return Convert.ToHexString(hash);
-        }
-
-        private static bool IsProtectedTokenMissingOrExpired(ProtectedToken? token)
-        {
-            if (token == null || !token.ExpirationDate.HasValue)
-            {
-                return true;
-            }
-
-            var expirationUtc = NormalizeProtectedTokenExpirationUtc(token.ExpirationDate.Value);
-
-            return expirationUtc <= DateTime.UtcNow.Add(ProtectedTokenExpirationSkew);
-        }
-
-        private static DateTime NormalizeProtectedTokenExpirationUtc(DateTime expirationDate)
-        {
-            return expirationDate.Kind switch
-            {
-                DateTimeKind.Utc => expirationDate,
-                DateTimeKind.Local => expirationDate.ToUniversalTime(),
-                _ => DateTime.SpecifyKind(expirationDate, DateTimeKind.Utc)
-            };
-        }
-
-        private static bool IsProtectedTokenUsable(ProtectedToken? token)
-        {
-            return !IsProtectedTokenMissingOrExpired(token) &&
-                !string.IsNullOrWhiteSpace(token?.AccessToken) &&
-                !string.IsNullOrWhiteSpace(token.AccessSecret);
-        }
-
-        private bool TryLoadProtectedTokenFromCache(string? cacheKey, out ProtectedToken? protectedToken)
-        {
-            protectedToken = null;
-
-            if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
-            {
-                return false;
-            }
-
-            if (!ProtectedTokenCache.TryGetValue(cacheKey, out var cachedToken))
-            {
-                return false;
-            }
-
-            if (!IsProtectedTokenUsable(cachedToken))
-            {
-                ProtectedTokenCache.TryRemove(cacheKey, out _);
-                _token = null;
-                return false;
-            }
-
-            protectedToken = new ProtectedToken(cachedToken);
-            _token = protectedToken;
-            return true;
-        }
-
         internal static int PruneProtectedTokenCache()
         {
-            var removedCount = 0;
-
-            foreach (var cachedToken in ProtectedTokenCache)
-            {
-                if (!IsProtectedTokenUsable(cachedToken.Value) &&
-                    ProtectedTokenCache.TryRemove(cachedToken.Key, out _))
-                {
-                    removedCount++;
-                }
-            }
-
-            return removedCount;
+            return ProtectedTokenCache.PruneExpired();
         }
 
         internal static void ClearProtectedTokenCache()
         {
-            ProtectedTokenCache.Clear();
+            ProtectedTokenCache.ClearForTesting();
         }
 
         internal static void AddProtectedTokenToCacheForTesting(string cacheKey, ProtectedToken token)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(cacheKey);
-            ArgumentNullException.ThrowIfNull(token);
-
-            ProtectedTokenCache[cacheKey] = new ProtectedToken(token);
+            ProtectedTokenCache.AddForTesting(cacheKey, token);
         }
 
         internal static bool ProtectedTokenCacheContainsKey(string cacheKey)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(cacheKey);
-
             return ProtectedTokenCache.ContainsKey(cacheKey);
         }
 
@@ -697,7 +306,7 @@ namespace Clc.Polaris.Api
                 throw CreateProtectedTokenRequiredException("Staff authentication did not succeed.", pathContainsProtectedTokenPlaceholder);
             }
 
-            if (!IsProtectedTokenUsable(responseData))
+            if (!ProtectedTokenCache.IsUsable(responseData))
             {
                 ClearFailedProtectedToken(cacheKey);
                 throw CreateProtectedTokenRequiredException("Staff authentication did not return a usable protected access token.", pathContainsProtectedTokenPlaceholder);
@@ -708,7 +317,7 @@ namespace Clc.Polaris.Api
 
             if (UseProtectedTokenCache && !string.IsNullOrWhiteSpace(cacheKey))
             {
-                ProtectedTokenCache[cacheKey] = new ProtectedToken(protectedToken);
+                ProtectedTokenCache.Set(cacheKey, UseProtectedTokenCache, protectedToken);
             }
 
             return protectedToken;
@@ -718,7 +327,7 @@ namespace Clc.Polaris.Api
         {
             if (!string.IsNullOrWhiteSpace(cacheKey))
             {
-                ProtectedTokenCache.TryRemove(cacheKey, out _);
+                ProtectedTokenCache.Remove(cacheKey);
             }
 
             _token = null;

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -224,11 +224,6 @@ namespace Clc.Polaris.Api
                 return token!;
             }
 
-            if (token != null)
-            {
-                _token = null;
-            }
-
             if (StaffOverrideAccount == null)
             {
                 throw CreateProtectedTokenRequiredException("No staff override credentials are configured.", pathContainsProtectedTokenPlaceholder);
@@ -236,101 +231,31 @@ namespace Clc.Polaris.Api
 
             var cacheKey = ProtectedTokenCache.BuildKey(Hostname, AccessID, AccessKey, StaffOverrideAccount);
 
-            if (ProtectedTokenCache.TryGet(cacheKey, UseProtectedTokenCache, out var cachedToken))
-            {
-                _token = cachedToken;
-                return cachedToken!;
-            }
+            var protectedToken = await ProtectedTokenCache.GetOrCreateAsync(cacheKey, UseProtectedTokenCache, ct => AuthenticateProtectedTokenOrThrowAsync(pathContainsProtectedTokenPlaceholder, ct), cancellationToken).ConfigureAwait(false);
 
-            if (!UseProtectedTokenCache || string.IsNullOrWhiteSpace(cacheKey))
-            {
-                return await AuthenticateAndLoadProtectedTokenOrThrowAsync(null, pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false);
-            }
-
-            using var cacheLockLease = await ProtectedTokenCache.AcquireLockAsync(cacheKey, cancellationToken).ConfigureAwait(false);
-
-            token = Token;
-            if (ProtectedTokenCache.IsUsable(token))
-            {
-                return token!;
-            }
-
-            if (token != null)
-            {
-                _token = null;
-            }
-
-            if (ProtectedTokenCache.TryGet(cacheKey, UseProtectedTokenCache, out cachedToken))
-            {
-                _token = cachedToken;
-                return cachedToken!;
-            }
-
-            if (UseProtectedTokenCache)
-            {
-                ProtectedTokenCache.PruneExpired();
-            }
-
-            return await AuthenticateAndLoadProtectedTokenOrThrowAsync(cacheKey, pathContainsProtectedTokenPlaceholder, cancellationToken).ConfigureAwait(false);
+            _token = protectedToken;
+            return protectedToken;
         }
 
-        internal static int PruneProtectedTokenCache()
-        {
-            return ProtectedTokenCache.PruneExpired();
-        }
-
-        internal static void ClearProtectedTokenCache()
-        {
-            ProtectedTokenCache.ClearForTesting();
-        }
-
-        internal static void AddProtectedTokenToCacheForTesting(string cacheKey, ProtectedToken token)
-        {
-            ProtectedTokenCache.AddForTesting(cacheKey, token);
-        }
-
-        internal static bool ProtectedTokenCacheContainsKey(string cacheKey)
-        {
-            return ProtectedTokenCache.ContainsKey(cacheKey);
-        }
-
-        private async Task<ProtectedToken> AuthenticateAndLoadProtectedTokenOrThrowAsync(string? cacheKey, bool pathContainsProtectedTokenPlaceholder, CancellationToken cancellationToken)
+        private async Task<ProtectedToken> AuthenticateProtectedTokenOrThrowAsync(bool pathContainsProtectedTokenPlaceholder, CancellationToken cancellationToken)
         {
             var staffOverrideAccount = StaffOverrideAccount ?? throw CreateProtectedTokenRequiredException("No staff override credentials are configured.", pathContainsProtectedTokenPlaceholder);
+
             var response = await AuthenticateStaffUserAsync(staffOverrideAccount, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
+
             var responseData = response?.Data;
             if (response?.Response == null || !response.Response.IsSuccessStatusCode)
             {
-                ClearFailedProtectedToken(cacheKey);
                 throw CreateProtectedTokenRequiredException("Staff authentication did not succeed.", pathContainsProtectedTokenPlaceholder);
             }
 
             if (!ProtectedTokenCache.IsUsable(responseData))
             {
-                ClearFailedProtectedToken(cacheKey);
                 throw CreateProtectedTokenRequiredException("Staff authentication did not return a usable protected access token.", pathContainsProtectedTokenPlaceholder);
             }
 
-            var protectedToken = responseData!;
-            _token = protectedToken;
-
-            if (UseProtectedTokenCache && !string.IsNullOrWhiteSpace(cacheKey))
-            {
-                ProtectedTokenCache.Set(cacheKey, UseProtectedTokenCache, protectedToken);
-            }
-
-            return protectedToken;
-        }
-
-        private void ClearFailedProtectedToken(string? cacheKey)
-        {
-            if (!string.IsNullOrWhiteSpace(cacheKey))
-            {
-                ProtectedTokenCache.Remove(cacheKey);
-            }
-
-            _token = null;
+            return responseData!;
         }
 
         private static string EncodeBarcodePathSegment(string barcode) => WebUtility.UrlEncode(barcode);

--- a/src/polaris-api-csharp/PapiRequestClassifier.cs
+++ b/src/polaris-api-csharp/PapiRequestClassifier.cs
@@ -1,0 +1,80 @@
+using Clc.Polaris.Api.Models;
+using Clc.Rest.Models;
+using System;
+using System.Net.Http;
+
+namespace Clc.Polaris.Api
+{
+    internal static class PapiRequestClassifier
+    {
+        internal static bool RequiresProtectedToken(
+            PapiRestRequest request,
+            bool pathContainsProtectedTokenPlaceholder,
+            bool allowStaffOverrideRequests,
+            PolarisUser? staffOverrideAccount)
+        {
+            if (IsStaffAuthenticatorRequest(request))
+            {
+                return false;
+            }
+
+            if (pathContainsProtectedTokenPlaceholder)
+            {
+                return true;
+            }
+
+            if (request.IsProtectedMethod && string.IsNullOrWhiteSpace(request.Password))
+            {
+                return true;
+            }
+
+            return IsStaffOverridePatronRequest(request, allowStaffOverrideRequests, staffOverrideAccount);
+        }
+
+        internal static bool IsStaffOverridePatronRequest(
+            PapiRestRequest request,
+            bool allowStaffOverrideRequests,
+            PolarisUser? staffOverrideAccount)
+        {
+            return request.IsPublicMethod &&
+                request.AuthRequired &&
+                allowStaffOverrideRequests &&
+                string.IsNullOrWhiteSpace(request.Password) &&
+                !request.BlockStaffOverride &&
+                staffOverrideAccount != null &&
+                HasPatronBarcodeRouteSegment(request.Path);
+        }
+
+        internal static bool HasPatronBarcodeRouteSegment(string path)
+        {
+            var pathWithoutQuery = path.Split('?', 2)[0];
+            var segments = pathWithoutQuery.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+            for (var i = 0; i < segments.Length - 1; i++)
+            {
+                if (segments[i].Equals("patron", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        internal static bool IsStaffAuthenticatorRequest(PapiRestRequest? request)
+        {
+            var path = request?.Path;
+
+            return request?.Method == HttpMethod.Post &&
+                !string.IsNullOrWhiteSpace(path) &&
+                path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase) &&
+                path.EndsWith("/authenticator/staff", StringComparison.OrdinalIgnoreCase) &&
+                path.IndexOf(ProtectedToken.Placeholder, StringComparison.Ordinal) < 0;
+        }
+
+        internal static bool PathContainsProtectedTokenPlaceholder(PapiRestRequest request)
+        {
+            return request.Path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal);
+        }
+    }
+}

--- a/src/polaris-api-csharp/PapiRequestClassifier.cs
+++ b/src/polaris-api-csharp/PapiRequestClassifier.cs
@@ -7,11 +7,7 @@ namespace Clc.Polaris.Api
 {
     internal static class PapiRequestClassifier
     {
-        internal static bool RequiresProtectedToken(
-            PapiRestRequest request,
-            bool pathContainsProtectedTokenPlaceholder,
-            bool allowStaffOverrideRequests,
-            PolarisUser? staffOverrideAccount)
+        internal static bool RequiresProtectedToken(PapiRestRequest request, bool pathContainsProtectedTokenPlaceholder, bool allowStaffOverrideRequests, PolarisUser? staffOverrideAccount)
         {
             if (IsStaffAuthenticatorRequest(request))
             {
@@ -31,10 +27,7 @@ namespace Clc.Polaris.Api
             return IsStaffOverridePatronRequest(request, allowStaffOverrideRequests, staffOverrideAccount);
         }
 
-        internal static bool IsStaffOverridePatronRequest(
-            PapiRestRequest request,
-            bool allowStaffOverrideRequests,
-            PolarisUser? staffOverrideAccount)
+        internal static bool IsStaffOverridePatronRequest(PapiRestRequest request, bool allowStaffOverrideRequests, PolarisUser? staffOverrideAccount)
         {
             return request.IsPublicMethod &&
                 request.AuthRequired &&

--- a/src/polaris-api-csharp/PapiRequestValidator.cs
+++ b/src/polaris-api-csharp/PapiRequestValidator.cs
@@ -1,0 +1,40 @@
+using Clc.Polaris.Api.Models;
+using System;
+
+namespace Clc.Polaris.Api
+{
+    internal static class PapiRequestValidator
+    {
+        internal static void ValidateExecutableRequest(PapiRestRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+
+            if (string.IsNullOrWhiteSpace(request.Path))
+            {
+                throw new ArgumentException("PAPI request path must not be null, empty, or whitespace.", nameof(request));
+            }
+
+            if (request.Path.Contains("://", StringComparison.Ordinal))
+            {
+                throw new ArgumentException("PAPI request path must be a relative path, not an absolute URL.", nameof(request));
+            }
+
+            if (request.Path.StartsWith("//", StringComparison.Ordinal))
+            {
+                throw new ArgumentException("PAPI request path must not be a protocol-relative URL.", nameof(request));
+            }
+
+            if (!request.Path.StartsWith('/'))
+            {
+                throw new ArgumentException("PAPI request path must begin with '/'.", nameof(request));
+            }
+
+            if (request.AuthRequired &&
+                !request.Path.StartsWith("/public/", StringComparison.OrdinalIgnoreCase) &&
+                !request.Path.StartsWith("/protected/", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("Authenticated custom PAPI request paths must begin with '/public/' or '/protected/'.", nameof(request));
+            }
+        }
+    }
+}

--- a/src/polaris-api-csharp/PapiSignature.cs
+++ b/src/polaris-api-csharp/PapiSignature.cs
@@ -6,18 +6,11 @@ namespace Clc.Polaris.Api
 {
     internal static class PapiSignature
     {
-        internal static string ComputeHash(
-            string accessKey,
-            string httpMethod,
-            string uri,
-            string date,
-            string password)
+        internal static string ComputeHash(string accessKey, string httpMethod, string uri, string date, string password)
         {
             var hashString = httpMethod + uri + date + password;
 
-            var computedHash = HMACSHA1.HashData(
-                Encoding.UTF8.GetBytes(accessKey),
-                Encoding.UTF8.GetBytes(hashString));
+            var computedHash = HMACSHA1.HashData(Encoding.UTF8.GetBytes(accessKey), Encoding.UTF8.GetBytes(hashString));
 
             return Convert.ToBase64String(computedHash);
         }

--- a/src/polaris-api-csharp/ProtectedTokenCache.cs
+++ b/src/polaris-api-csharp/ProtectedTokenCache.cs
@@ -1,7 +1,6 @@
 using Clc.Polaris.Api.Models;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -241,9 +240,10 @@ namespace Clc.Polaris.Api
                     continue;
                 }
 
-                if (((ICollection<KeyValuePair<string, LockEntry>>)Locks).Remove(pair))
+                if (Locks.TryRemove(pair.Key, out var removedEntry) &&
+                    ReferenceEquals(removedEntry, entry))
                 {
-                    entry.Dispose();
+                    removedEntry.Dispose();
                 }
                 else
                 {

--- a/src/polaris-api-csharp/ProtectedTokenCache.cs
+++ b/src/polaris-api-csharp/ProtectedTokenCache.cs
@@ -1,0 +1,363 @@
+using Clc.Polaris.Api.Models;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Clc.Polaris.Api
+{
+    internal static class ProtectedTokenCache
+    {
+        private const int MaxProtectedTokenCacheLockEntries = 1024;
+        private const int TargetProtectedTokenCacheLockEntries = 512;
+
+        private static readonly TimeSpan LockIdleLimit = TimeSpan.FromMinutes(10);
+        private static readonly TimeSpan ExpirationSkew = TimeSpan.FromMinutes(1);
+        private static readonly object LocksPruneLock = new object();
+
+        private static ConcurrentDictionary<string, ProtectedToken> Tokens { get; } = new ConcurrentDictionary<string, ProtectedToken>();
+        private static ConcurrentDictionary<string, LockEntry> Locks { get; } = new ConcurrentDictionary<string, LockEntry>();
+
+        internal static string? BuildKey(string hostname, string accessId, string accessKey, PolarisUser? staffOverrideAccount)
+        {
+            if (staffOverrideAccount == null ||
+                string.IsNullOrWhiteSpace(hostname) ||
+                string.IsNullOrWhiteSpace(accessId) ||
+                string.IsNullOrWhiteSpace(accessKey) ||
+                string.IsNullOrWhiteSpace(staffOverrideAccount.Domain) ||
+                string.IsNullOrWhiteSpace(staffOverrideAccount.Username) ||
+                string.IsNullOrWhiteSpace(staffOverrideAccount.Password))
+            {
+                return null;
+            }
+
+            return $"{hostname.Trim()}|{accessId.Trim()}|{staffOverrideAccount.Domain.Trim()}|{staffOverrideAccount.Username.Trim()}|{BuildCredentialFingerprint(accessKey, staffOverrideAccount.Password)}";
+        }
+
+        internal static bool IsUsable(ProtectedToken? token)
+        {
+            return !IsMissingOrExpired(token) &&
+                !string.IsNullOrWhiteSpace(token?.AccessToken) &&
+                !string.IsNullOrWhiteSpace(token.AccessSecret);
+        }
+
+        internal static bool TryGet(string? cacheKey, bool useCache, out ProtectedToken? protectedToken)
+        {
+            protectedToken = null;
+
+            if (!useCache || string.IsNullOrWhiteSpace(cacheKey))
+            {
+                return false;
+            }
+
+            if (!Tokens.TryGetValue(cacheKey, out var cachedToken))
+            {
+                return false;
+            }
+
+            if (!IsUsable(cachedToken))
+            {
+                Tokens.TryRemove(cacheKey, out _);
+                return false;
+            }
+
+            protectedToken = new ProtectedToken(cachedToken);
+            return true;
+        }
+
+        internal static void Set(string? cacheKey, bool useCache, ProtectedToken token)
+        {
+            ArgumentNullException.ThrowIfNull(token);
+
+            if (!useCache || string.IsNullOrWhiteSpace(cacheKey))
+            {
+                return;
+            }
+
+            Tokens[cacheKey] = new ProtectedToken(token);
+        }
+
+        internal static void Remove(string? cacheKey)
+        {
+            if (!string.IsNullOrWhiteSpace(cacheKey))
+            {
+                Tokens.TryRemove(cacheKey, out _);
+            }
+        }
+
+        internal static int PruneExpired()
+        {
+            var removedCount = 0;
+
+            foreach (var cachedToken in Tokens)
+            {
+                if (!IsUsable(cachedToken.Value) &&
+                    Tokens.TryRemove(cachedToken.Key, out _))
+                {
+                    removedCount++;
+                }
+            }
+
+            return removedCount;
+        }
+
+        internal static async Task<IDisposable> AcquireLockAsync(string cacheKey, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var entry = Locks.GetOrAdd(
+                    cacheKey,
+                    _ => new LockEntry());
+
+                if (!entry.TryAddLease())
+                {
+                    continue;
+                }
+
+                try
+                {
+                    await entry.Semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    return new LockLease(entry);
+                }
+                catch
+                {
+                    entry.ReleaseLease();
+
+                    if (Locks.Count > MaxProtectedTokenCacheLockEntries)
+                    {
+                        PruneLocks();
+                    }
+
+                    throw;
+                }
+            }
+        }
+
+        internal static void ClearForTesting()
+        {
+            Tokens.Clear();
+
+            foreach (var cacheLock in Locks)
+            {
+                if (Locks.TryRemove(cacheLock.Key, out var removedEntry))
+                {
+                    removedEntry.Dispose();
+                }
+            }
+        }
+
+        internal static void AddForTesting(string cacheKey, ProtectedToken token)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(cacheKey);
+            ArgumentNullException.ThrowIfNull(token);
+
+            Tokens[cacheKey] = new ProtectedToken(token);
+        }
+
+        internal static bool ContainsKey(string cacheKey)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(cacheKey);
+
+            return Tokens.ContainsKey(cacheKey);
+        }
+
+        internal static int CountForTesting()
+        {
+            return Tokens.Count;
+        }
+
+        private static string BuildCredentialFingerprint(string accessKey, string staffPassword)
+        {
+            var credentialMaterial = $"access-key:{accessKey.Length}:{accessKey}|staff-password:{staffPassword.Length}:{staffPassword}";
+            var hash = SHA256.HashData(Encoding.UTF8.GetBytes(credentialMaterial));
+            return Convert.ToHexString(hash);
+        }
+
+        private static bool IsMissingOrExpired(ProtectedToken? token)
+        {
+            if (token == null || !token.ExpirationDate.HasValue)
+            {
+                return true;
+            }
+
+            var expirationUtc = NormalizeExpirationUtc(token.ExpirationDate.Value);
+
+            return expirationUtc <= DateTime.UtcNow.Add(ExpirationSkew);
+        }
+
+        private static DateTime NormalizeExpirationUtc(DateTime expirationDate)
+        {
+            return expirationDate.Kind switch
+            {
+                DateTimeKind.Utc => expirationDate,
+                DateTimeKind.Local => expirationDate.ToUniversalTime(),
+                _ => DateTime.SpecifyKind(expirationDate, DateTimeKind.Utc)
+            };
+        }
+
+        private static void PruneLocks()
+        {
+            if (Locks.Count <= MaxProtectedTokenCacheLockEntries)
+            {
+                return;
+            }
+
+            lock (LocksPruneLock)
+            {
+                if (Locks.Count <= MaxProtectedTokenCacheLockEntries)
+                {
+                    return;
+                }
+
+                var cutoffUtc = DateTime.UtcNow.Subtract(LockIdleLimit);
+
+                PruneLocks(cutoffUtc, requireIdle: true);
+
+                if (Locks.Count > MaxProtectedTokenCacheLockEntries)
+                {
+                    PruneLocks(cutoffUtc, requireIdle: false);
+                }
+            }
+        }
+
+        private static void PruneLocks(DateTime cutoffUtc, bool requireIdle)
+        {
+            foreach (var pair in Locks)
+            {
+                if (Locks.Count <= TargetProtectedTokenCacheLockEntries)
+                {
+                    return;
+                }
+
+                var entry = pair.Value;
+
+                if (!entry.TryRetire(cutoffUtc, requireIdle))
+                {
+                    continue;
+                }
+
+                if (((ICollection<KeyValuePair<string, LockEntry>>)Locks).Remove(pair))
+                {
+                    entry.Dispose();
+                }
+                else
+                {
+                    entry.UndoRetire();
+                }
+            }
+        }
+
+        private sealed class LockLease : IDisposable
+        {
+            private LockEntry? _entry;
+
+            public LockLease(LockEntry entry)
+            {
+                _entry = entry;
+            }
+
+            public void Dispose()
+            {
+                var entry = _entry;
+                if (entry == null)
+                {
+                    return;
+                }
+
+                _entry = null;
+
+                try
+                {
+                    entry.Semaphore.Release();
+                }
+                finally
+                {
+                    entry.ReleaseLease();
+
+                    if (Locks.Count > MaxProtectedTokenCacheLockEntries)
+                    {
+                        PruneLocks();
+                    }
+                }
+            }
+        }
+
+        private sealed class LockEntry : IDisposable
+        {
+            private readonly object _syncRoot = new object();
+            private int _leaseCount;
+            private bool _retired;
+            private DateTime _lastUsedUtc = DateTime.UtcNow;
+
+            internal SemaphoreSlim Semaphore { get; } = new SemaphoreSlim(1, 1);
+
+            public bool TryAddLease()
+            {
+                lock (_syncRoot)
+                {
+                    if (_retired)
+                    {
+                        return false;
+                    }
+
+                    _leaseCount++;
+                    _lastUsedUtc = DateTime.UtcNow;
+                    return true;
+                }
+            }
+
+            public void ReleaseLease()
+            {
+                lock (_syncRoot)
+                {
+                    if (_leaseCount > 0)
+                    {
+                        _leaseCount--;
+                    }
+
+                    _lastUsedUtc = DateTime.UtcNow;
+                }
+            }
+
+            public bool TryRetire(DateTime cutoffUtc, bool requireIdle)
+            {
+                lock (_syncRoot)
+                {
+                    if (_retired || _leaseCount != 0)
+                    {
+                        return false;
+                    }
+
+                    if (requireIdle && _lastUsedUtc > cutoffUtc)
+                    {
+                        return false;
+                    }
+
+                    _retired = true;
+                    return true;
+                }
+            }
+
+            public void UndoRetire()
+            {
+                lock (_syncRoot)
+                {
+                    if (_retired && _leaseCount == 0)
+                    {
+                        _retired = false;
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                Semaphore.Dispose();
+            }
+        }
+    }
+}

--- a/src/polaris-api-csharp/ProtectedTokenCache.cs
+++ b/src/polaris-api-csharp/ProtectedTokenCache.cs
@@ -252,6 +252,39 @@ namespace Clc.Polaris.Api
             }
         }
 
+        internal static async Task<ProtectedToken> GetOrCreateAsync(string? cacheKey, bool useCache, Func<CancellationToken, Task<ProtectedToken>> createTokenAsync, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(createTokenAsync);
+
+            if (!CanUseCache(cacheKey, useCache))
+            {
+                return await createTokenAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (TryGet(cacheKey, useCache: true, out var cachedToken))
+            {
+                return cachedToken!;
+            }
+
+            using var cacheLockLease = await AcquireLockAsync(cacheKey!, cancellationToken).ConfigureAwait(false);
+
+            if (TryGet(cacheKey, useCache: true, out cachedToken))
+            {
+                return cachedToken!;
+            }
+
+            var createdToken = await createTokenAsync(cancellationToken).ConfigureAwait(false);
+            Set(cacheKey, useCache: true, createdToken);
+            PruneExpired();
+
+            return createdToken;
+        }
+
+        private static bool CanUseCache(string? cacheKey, bool useCache)
+        {
+            return useCache && !string.IsNullOrWhiteSpace(cacheKey);
+        }
+
         private sealed class LockLease : IDisposable
         {
             private LockEntry? _entry;

--- a/src/polaris-api-csharp/ProtectedTokenCache.cs
+++ b/src/polaris-api-csharp/ProtectedTokenCache.cs
@@ -38,9 +38,7 @@ namespace Clc.Polaris.Api
 
         internal static bool IsUsable(ProtectedToken? token)
         {
-            return !IsMissingOrExpired(token) &&
-                !string.IsNullOrWhiteSpace(token?.AccessToken) &&
-                !string.IsNullOrWhiteSpace(token.AccessSecret);
+            return !IsMissingOrExpired(token) && !string.IsNullOrWhiteSpace(token?.AccessToken) && !string.IsNullOrWhiteSpace(token.AccessSecret);
         }
 
         internal static bool TryGet(string? cacheKey, bool useCache, out ProtectedToken? protectedToken)
@@ -87,14 +85,41 @@ namespace Clc.Polaris.Api
             }
         }
 
+        internal static async Task<ProtectedToken> GetOrCreateAsync(string? cacheKey, bool useCache, Func<CancellationToken, Task<ProtectedToken>> createTokenAsync, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(createTokenAsync);
+
+            if (!CanUseCache(cacheKey, useCache))
+            {
+                return await createTokenAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (TryGet(cacheKey, useCache: true, out var cachedToken))
+            {
+                return cachedToken!;
+            }
+
+            using var cacheLockLease = await AcquireLockAsync(cacheKey!, cancellationToken).ConfigureAwait(false);
+
+            if (TryGet(cacheKey, useCache: true, out cachedToken))
+            {
+                return cachedToken!;
+            }
+
+            var createdToken = await createTokenAsync(cancellationToken).ConfigureAwait(false);
+            Set(cacheKey, useCache: true, createdToken);
+            PruneExpired();
+
+            return createdToken;
+        }
+
         internal static int PruneExpired()
         {
             var removedCount = 0;
 
             foreach (var cachedToken in Tokens)
             {
-                if (!IsUsable(cachedToken.Value) &&
-                    Tokens.TryRemove(cachedToken.Key, out _))
+                if (!IsUsable(cachedToken.Value) && Tokens.TryRemove(cachedToken.Key, out _))
                 {
                     removedCount++;
                 }
@@ -103,15 +128,13 @@ namespace Clc.Polaris.Api
             return removedCount;
         }
 
-        internal static async Task<IDisposable> AcquireLockAsync(string cacheKey, CancellationToken cancellationToken)
+        private static async Task<IDisposable> AcquireLockAsync(string cacheKey, CancellationToken cancellationToken)
         {
             while (true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var entry = Locks.GetOrAdd(
-                    cacheKey,
-                    _ => new LockEntry());
+                var entry = Locks.GetOrAdd(cacheKey, _ => new LockEntry());
 
                 if (!entry.TryAddLease())
                 {
@@ -240,8 +263,7 @@ namespace Clc.Polaris.Api
                     continue;
                 }
 
-                if (Locks.TryRemove(pair.Key, out var removedEntry) &&
-                    ReferenceEquals(removedEntry, entry))
+                if (Locks.TryRemove(pair.Key, out var removedEntry) && ReferenceEquals(removedEntry, entry))
                 {
                     removedEntry.Dispose();
                 }
@@ -250,34 +272,6 @@ namespace Clc.Polaris.Api
                     entry.UndoRetire();
                 }
             }
-        }
-
-        internal static async Task<ProtectedToken> GetOrCreateAsync(string? cacheKey, bool useCache, Func<CancellationToken, Task<ProtectedToken>> createTokenAsync, CancellationToken cancellationToken)
-        {
-            ArgumentNullException.ThrowIfNull(createTokenAsync);
-
-            if (!CanUseCache(cacheKey, useCache))
-            {
-                return await createTokenAsync(cancellationToken).ConfigureAwait(false);
-            }
-
-            if (TryGet(cacheKey, useCache: true, out var cachedToken))
-            {
-                return cachedToken!;
-            }
-
-            using var cacheLockLease = await AcquireLockAsync(cacheKey!, cancellationToken).ConfigureAwait(false);
-
-            if (TryGet(cacheKey, useCache: true, out cachedToken))
-            {
-                return cachedToken!;
-            }
-
-            var createdToken = await createTokenAsync(cancellationToken).ConfigureAwait(false);
-            Set(cacheKey, useCache: true, createdToken);
-            PruneExpired();
-
-            return createdToken;
         }
 
         private static bool CanUseCache(string? cacheKey, bool useCache)

--- a/src/polaris-api-csharp/ProtectedTokenCache.cs
+++ b/src/polaris-api-csharp/ProtectedTokenCache.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api
 
         private static readonly TimeSpan LockIdleLimit = TimeSpan.FromMinutes(10);
         private static readonly TimeSpan ExpirationSkew = TimeSpan.FromMinutes(1);
-        private static readonly object LocksPruneLock = new object();
+        private static readonly object LocksPruneLock = new();
 
         private static ConcurrentDictionary<string, ProtectedToken> Tokens { get; } = new ConcurrentDictionary<string, ProtectedToken>();
         private static ConcurrentDictionary<string, LockEntry> Locks { get; } = new ConcurrentDictionary<string, LockEntry>();
@@ -316,7 +316,7 @@ namespace Clc.Polaris.Api
 
         private sealed class LockEntry : IDisposable
         {
-            private readonly object _syncRoot = new object();
+            private readonly object _syncRoot = new();
             private int _leaseCount;
             private bool _retired;
             private DateTime _lastUsedUtc = DateTime.UtcNow;

--- a/src/polaris-api-csharp/ProtectedTokenCache.cs
+++ b/src/polaris-api-csharp/ProtectedTokenCache.cs
@@ -1,6 +1,7 @@
 using Clc.Polaris.Api.Models;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -263,15 +264,21 @@ namespace Clc.Polaris.Api
                     continue;
                 }
 
-                if (Locks.TryRemove(pair.Key, out var removedEntry) && ReferenceEquals(removedEntry, entry))
+                if (TryRemoveLockEntry(pair.Key, entry))
                 {
-                    removedEntry.Dispose();
+                    entry.Dispose();
                 }
                 else
                 {
                     entry.UndoRetire();
                 }
             }
+        }
+
+        private static bool TryRemoveLockEntry(string cacheKey, LockEntry entry)
+        {
+            return ((ICollection<KeyValuePair<string, LockEntry>>)Locks)
+                .Remove(new KeyValuePair<string, LockEntry>(cacheKey, entry));
         }
 
         private static bool CanUseCache(string? cacheKey, bool useCache)

--- a/src/polaris-api-csharp/Validation/Require.cs
+++ b/src/polaris-api-csharp/Validation/Require.cs
@@ -14,9 +14,7 @@ namespace Clc.Polaris.Api.Validation
         /// </summary>
         /// <param name="value"></param>
         /// <param name="name"></param>
-        public static void Argument(
-            [NotNull] object? value,
-            [CallerArgumentExpression(nameof(value))] string? name = null)
+        public static void Argument([NotNull] object? value, [CallerArgumentExpression(nameof(value))] string? name = null)
         {
             if (value == null)
             {

--- a/src/polaris-api-csharpTests/Methods/ApiKeyValidateTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ApiKeyValidateTests.cs
@@ -12,7 +12,5 @@ namespace Clc.Polaris.Api.Tests
             var response = await Papi.ApiKeyValidateAsync(TestContext.CancellationToken);
             Assert.AreEqual(0, response.Data.PAPIErrorCode);
         }
-
-        public TestContext TestContext { get; set; }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/ApiVersionGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ApiVersionGetTests.cs
@@ -13,7 +13,5 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual(0, response.Data.PAPIErrorCode);
             Assert.IsFalse(string.IsNullOrWhiteSpace(response.Data.ToString()));
         }
-
-        public TestContext TestContext { get; set; }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/AuthenticatePatronTests.cs
+++ b/src/polaris-api-csharpTests/Methods/AuthenticatePatronTests.cs
@@ -1,73 +1,39 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Clc.Polaris.Api;
 using Clc.Polaris.Api.Configuration;
+using Clc.Polaris.Api.Tests.TestInfrastructure;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Clc.Polaris.Api.Tests
 {
     [TestClass]
     [UnitTest]
-    public class AuthenticatePatronTests
+    public class AuthenticatePatronTests : PapiClientTestBase
     {
-        private sealed class CaptureHttpMessageHandler : HttpMessageHandler
-        {
-            public HttpRequestMessage? LastRequest { get; private set; }
-            public string? RequestContent { get; private set; }
-
-            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                LastRequest = request;
-                if (request.Content != null)
-                {
-                    RequestContent = await request.Content.ReadAsStringAsync(cancellationToken);
-                }
-                var response = new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent("{\"PAPIErrorCode\":0, \"AccessToken\":\"mock-token\", \"AccessSecret\":\"mock-secret\", \"PatronID\":123}")
-                };
-                response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-                return response;
-            }
-        }
-
-        private static PapiClient CreateClient(CaptureHttpMessageHandler handler)
-        {
-            var settings = new PapiSettings
-            {
-                AccessId = "test-access-id",
-                AccessKey = "test-access-key",
-                Hostname = "https://example.test",
-                OrganizationId = 1,
-                UserId = 123,
-                WorkstationId = 456
-            };
-
-            var httpClient = new HttpClient(handler);
-            return new PapiClient(httpClient, settings);
-        }
-
         [TestMethod]
         public async Task AuthenticatePatron_SendsPostRequestWithJsonBody()
         {
-            var handler = new CaptureHttpMessageHandler();
+            var handler = new CapturingHttpMessageHandler(CreateJson(new { PAPIErrorCode = 0, AccessToken = "mock-token", AccessSecret = "mock-secret", PatronID = 123 }));
+
             var client = CreateClient(handler);
             var barcode = "21945001234567";
             var password = "mypassword";
 
-            var response = await client.AuthenticatePatronAsync(barcode, password);
+            var response = await client.AuthenticatePatronAsync(barcode, password, TestContext.CancellationToken);
 
             Assert.IsNotNull(handler.LastRequest);
             Assert.AreEqual(HttpMethod.Post, handler.LastRequest.Method);
             var expectedPath = "/PAPIService/REST/public/v1/1033/100/1/authenticator/patron";
             Assert.AreEqual(expectedPath, handler.LastRequest.RequestUri!.AbsolutePath);
 
-            Assert.IsNotNull(handler.RequestContent);
-            Assert.IsTrue(handler.RequestContent.Contains($"\"Barcode\":\"{barcode}\"") || handler.RequestContent.Contains($"\"barcode\":\"{barcode}\""), "Body should contain barcode");
-            Assert.IsTrue(handler.RequestContent.Contains($"\"Password\":\"{password}\"") || handler.RequestContent.Contains($"\"password\":\"{password}\""), "Body should contain password");
+            Assert.IsNotNull(handler.LastRequestContent);
+            Assert.IsTrue(handler.LastRequestContent.Contains($"\"Barcode\":\"{barcode}\"") || handler.LastRequestContent.Contains($"\"barcode\":\"{barcode}\""), "Body should contain barcode");
+            Assert.IsTrue(handler.LastRequestContent.Contains($"\"Password\":\"{password}\"") || handler.LastRequestContent.Contains($"\"password\":\"{password}\""), "Body should contain password");
 
             Assert.IsNotNull(response.Data);
             Assert.AreEqual(0, response.Data.PAPIErrorCode);

--- a/src/polaris-api-csharpTests/Methods/AuthenticateStaffUserTests.cs
+++ b/src/polaris-api-csharpTests/Methods/AuthenticateStaffUserTests.cs
@@ -18,7 +18,5 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsFalse(string.IsNullOrWhiteSpace(response.Data.AccessSecret));
             Assert.IsFalse(string.IsNullOrWhiteSpace(response.Data.AccessToken));
         }
-
-        public TestContext TestContext { get; set; }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/BibGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/BibGetTests.cs
@@ -24,7 +24,5 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsFalse(string.IsNullOrWhiteSpace(response.Data.Title));
             Assert.Contains("100/7/bib", response.Response.RequestMessage.RequestUri.ToString());
         }
-
-        public TestContext TestContext { get; set; }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/BibSearchTests.cs
+++ b/src/polaris-api-csharpTests/Methods/BibSearchTests.cs
@@ -10,10 +10,10 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task BibSearchTest()
         {
-            var response = await Papi.BibSearchAsync(new BibSearchOptions { Term = "dogs", PageSize = 10 });
-            Assert.IsTrue(response.Data.PAPIErrorCode == 10);
-            Assert.IsTrue(response.Data.WordList == "dogs ");
-            Assert.IsTrue(response.Data.TotalRecordsFound > 10000);
+            var response = await Papi.BibSearchAsync(new BibSearchOptions { Term = "dogs", PageSize = 10 }, TestContext.CancellationToken);
+            Assert.AreEqual(10, response.Data.PAPIErrorCode);
+            Assert.AreEqual("dogs ", response.Data.WordList);
+            Assert.IsGreaterThan(10000, response.Data.TotalRecordsFound);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/Cancellation/ApiKeyValidateTests.cs
+++ b/src/polaris-api-csharpTests/Methods/Cancellation/ApiKeyValidateTests.cs
@@ -14,7 +14,7 @@ namespace Clc.Polaris.Api.Tests.Methods.Cancellation
         [TestMethod]
         public async Task ApiKeyValidateAsync_PassesCancellationToken()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             using var cts = new CancellationTokenSource();
 

--- a/src/polaris-api-csharpTests/Methods/Cancellation/PatronSearchProtectedTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/Cancellation/PatronSearchProtectedTokenTests.cs
@@ -92,9 +92,10 @@ namespace Clc.Polaris.Api.Tests.Methods.Cancellation
                     Interlocked.Increment(ref _authenticationRequestCount);
                     AuthenticationStarted.TrySetResult();
                     await CompleteAuthentication.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    var responseJson = CreateProtectedTokenJson(accessToken: "blocked-token", accessSecret: "blocked-secret", expirationDate: ValidProtectedTokenExpirationDate);
                     return new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent("{\"PAPIErrorCode\":0,\"AccessToken\":\"blocked-token\",\"AccessSecret\":\"blocked-secret\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}", Encoding.UTF8, "application/json")
+                        Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
                     };
                 }
 
@@ -105,7 +106,7 @@ namespace Clc.Polaris.Api.Tests.Methods.Cancellation
 
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                    Content = new StringContent(CreatePapiResponseJson(), Encoding.UTF8, "application/json")
                 };
             }
         }
@@ -138,11 +139,8 @@ namespace Clc.Polaris.Api.Tests.Methods.Cancellation
 
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                    Content = new StringContent(CreatePapiResponseJson(), Encoding.UTF8, "application/json")
                 };
             }
-        }
-
-        public TestContext TestContext { get; set; }
-    }
+        }}
 }

--- a/src/polaris-api-csharpTests/Methods/CollectionsGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/CollectionsGetTests.cs
@@ -9,10 +9,10 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task CollectionsGetTest()
         {
-            var response = await Papi.CollectionsGetAsync();
-            Assert.IsTrue(response.Data.PAPIErrorCode > 300);
-            Assert.IsTrue(response.Data.CollectionsRows.Count > 300);
-            Assert.AreEqual(response.Data.PAPIErrorCode, response.Data.CollectionsRows.Count);
+            var response = await Papi.CollectionsGetAsync(cancellationToken: TestContext.CancellationToken);
+            Assert.IsGreaterThan(300, response.Data.PAPIErrorCode);
+            Assert.IsGreaterThan(300, response.Data.CollectionsRows.Count);
+            Assert.HasCount(response.Data.PAPIErrorCode, response.Data.CollectionsRows);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/CreatePatronBlocksTests.cs
+++ b/src/polaris-api-csharpTests/Methods/CreatePatronBlocksTests.cs
@@ -15,8 +15,8 @@ namespace Clc.Polaris.Api.Tests
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
             var blockText = CreateUniqueTestArtifactText(Settings.FreeTextBlock, maxLength: 80);
-            var response = await Papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.FreeText, blockText);
-            Assert.IsTrue(new[] { 0, -3507 }.Contains(response.Data.PAPIErrorCode));
+            var response = await Papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.FreeText, blockText, cancellationToken: TestContext.CancellationToken);
+            Assert.Contains(response.Data.PAPIErrorCode, [0, -3507]);
         }
 
         [TestMethod]
@@ -26,8 +26,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.System, "128");
-            Assert.IsTrue(new[] { 0, -3507 }.Contains(response.Data.PAPIErrorCode));
+            var response = await Papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.System, "128", cancellationToken: TestContext.CancellationToken);
+            Assert.Contains(response.Data.PAPIErrorCode, [0, -3507]);
         }
 
         [TestMethod]
@@ -37,8 +37,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.LibraryAssigned, "1");
-            Assert.IsTrue(new[] { 0, -3507 }.Contains(response.Data.PAPIErrorCode));
+            var response = await Papi.CreatePatronBlocksAsync(Settings.PatronBarcode, BlockType.LibraryAssigned, "1", cancellationToken: TestContext.CancellationToken);
+            Assert.Contains(response.Data.PAPIErrorCode, [0, -3507]);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/DatesClosedGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/DatesClosedGetTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task DatesClosedGetTest()
         {
-            var response = await Papi.DatesClosedGetAsync(7);
-            Assert.IsTrue(response.Data.DatesClosedRows.Any());
+            var response = await Papi.DatesClosedGetAsync(7, TestContext.CancellationToken);
+            Assert.IsNotEmpty(response.Data.DatesClosedRows);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/HoldRequestCancelTests.cs
+++ b/src/polaris-api-csharpTests/Methods/HoldRequestCancelTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task HoldRequestCancelTest()
         {
-            var response = await Papi.HoldRequestCancelAsync(Settings.PatronBarcode, 1234, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -4201);
+            var response = await Papi.HoldRequestCancelAsync(Settings.PatronBarcode, 1234, Settings.PatronPin, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(-4201, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/HoldRequestCreateTests.cs
+++ b/src/polaris-api-csharpTests/Methods/HoldRequestCreateTests.cs
@@ -12,8 +12,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task HoldRequestCreateTest()
         {
-            var response = await Papi.HoldRequestCreateAsync(new HoldRequestCreateParams(Settings.PatronId, 1234, 7, 7));
-            Assert.IsTrue(response.Data.PAPIErrorCode == -4006);
+            var response = await Papi.HoldRequestCreateAsync(new HoldRequestCreateParams(Settings.PatronId, 1234, 7, 7), TestContext.CancellationToken);
+            Assert.AreEqual(-4006, response.Data.PAPIErrorCode);
         }
 
         [TestMethod]
@@ -21,8 +21,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task HoldRequestCreateTest2()
         {
-            var response = await ((PapiClient)Papi).HoldRequestCreateAsync(Settings.PatronId, 1234, 7);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -4006);
+            var response = await ((PapiClient)Papi).HoldRequestCreateAsync(Settings.PatronId, 1234, 7, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(-4006, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/HoldRequestGetListTests.cs
+++ b/src/polaris-api-csharpTests/Methods/HoldRequestGetListTests.cs
@@ -11,8 +11,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.HoldRequestGetListAsync(7);
-            Assert.IsTrue(response.Data.PAPIErrorCode == 0);
+            var response = await Papi.HoldRequestGetListAsync(7, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(0, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/HoldRequestReactivateTests.cs
+++ b/src/polaris-api-csharpTests/Methods/HoldRequestReactivateTests.cs
@@ -11,8 +11,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task HoldRequestReactivateTest()
         {
-            var response = await Papi.HoldRequestReactivateAsync(Settings.PatronBarcode, Settings.PatronPin, 1234, DateTime.Now);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -4201);
+            var response = await Papi.HoldRequestReactivateAsync(Settings.PatronBarcode, Settings.PatronPin, 1234, DateTime.Now, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(-4201, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/HoldRequestReplyTests.cs
+++ b/src/polaris-api-csharpTests/Methods/HoldRequestReplyTests.cs
@@ -18,8 +18,8 @@ namespace Clc.Polaris.Api.Tests
                 TxnGroupQualifier = "test",
                 TxnQualifier = "test"
             };
-            var response = await Papi.HoldRequestReplyAsync(hold, 7, HoldRequestReplyAnswer.Yes, HoldRequestReplyState.AcceptEvenWithExistingHolds);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -4101);
+            var response = await Papi.HoldRequestReplyAsync(hold, 7, HoldRequestReplyAnswer.Yes, HoldRequestReplyState.AcceptEvenWithExistingHolds, TestContext.CancellationToken);
+            Assert.AreEqual(-4101, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/HoldRequestSuspendTests.cs
+++ b/src/polaris-api-csharpTests/Methods/HoldRequestSuspendTests.cs
@@ -11,8 +11,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task HoldRequestSuspendTest()
         {
-            var response = await Papi.HoldRequestSuspendAsync(Settings.PatronBarcode, 1234, DateTime.Now, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -4201);
+            var response = await Papi.HoldRequestSuspendAsync(Settings.PatronBarcode, 1234, DateTime.Now, Settings.PatronPin, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(-4201, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/HoldingsGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/HoldingsGetTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task HoldingsGetTest()
         {
-            var response = await Papi.HoldingsGetAsync(478907);
-            Assert.IsTrue(response.Data.BibHoldingsGetRows.Any());
+            var response = await Papi.HoldingsGetAsync(478907, TestContext.CancellationToken);
+            Assert.IsNotEmpty(response.Data.BibHoldingsGetRows);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/IntegrationTestBase.cs
+++ b/src/polaris-api-csharpTests/Methods/IntegrationTestBase.cs
@@ -15,6 +15,8 @@ namespace Clc.Polaris.Api.Tests
         protected PapiSettings PapiSettings = null!;
         protected IPapiClient Papi = null!;
 
+        public TestContext TestContext { get; set; } = null!;
+
         protected static IConfiguration InitConfiguration()
         {
             var config = new ConfigurationBuilder()

--- a/src/polaris-api-csharpTests/Methods/ItemRenewTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ItemRenewTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task ItemRenewTest()
         {
-            var response = await Papi.ItemRenewAsync(Settings.PatronBarcode, 1234, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -6001);
+            var response = await Papi.ItemRenewAsync(Settings.PatronBarcode, 1234, Settings.PatronPin, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(-6001, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/ItemStatusesGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ItemStatusesGetTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task ItemStatusesGetAsyncTest()
         {
-            var response = await Papi.ItemStatusesGetAsync(7);
-            Assert.IsTrue(response.Data.ItemStatusesRows.Count() == response.Data.PAPIErrorCode);
+            var response = await Papi.ItemStatusesGetAsync(7, TestContext.CancellationToken);
+            Assert.HasCount(response.Data.PAPIErrorCode, response.Data.ItemStatusesRows);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/ItemUpdateBarcodeTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ItemUpdateBarcodeTests.cs
@@ -5,13 +5,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Clc.Polaris.Api.Configuration;
 using Clc.Polaris.Api.Models;
+using Clc.Polaris.Api.Tests.TestInfrastructure;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Clc.Polaris.Api.Tests
 {
     [TestClass]
     [UnitTest]
-    public sealed class ItemUpdateBarcodeTests
+    public sealed class ItemUpdateBarcodeTests : PapiClientTestBase
     {
         [TestMethod]
         public async Task ItemUpdateBarcodeAsync_WhenUsingOldBarcode_EncodesBarcodeAndAddsIsBarcodeQueryParameter()
@@ -98,7 +99,7 @@ namespace Clc.Polaris.Api.Tests
                 {
                     AccessToken = "protected-token",
                     AccessSecret = "protected-secret",
-                    ExpirationDate = DateTime.UtcNow.AddHours(1)
+                    ExpirationDate = ValidProtectedTokenExpirationDate
                 },
                 UseProtectedTokenCache = false
             };
@@ -116,11 +117,8 @@ namespace Clc.Polaris.Api.Tests
 
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{}")
+                    Content = new StringContent(CreateEmptyJsonObject())
                 });
             }
-        }
-
-        public TestContext TestContext { get; set; }
-    }
+        }}
 }

--- a/src/polaris-api-csharpTests/Methods/LimitFiltersGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/LimitFiltersGetTests.cs
@@ -10,8 +10,10 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task LimitFiltersGetTest()
         {
-            var response = (await Papi.LimitFiltersGetAsync()).Data;
-            Assert.IsTrue(response.LimitFiltersRows.Count() == response.PAPIErrorCode);
+            var response = (await Papi.LimitFiltersGetAsync(cancellationToken: TestContext.CancellationToken)).Data;
+            Assert.HasCount(response.PAPIErrorCode, response.LimitFiltersRows);
         }
+
+        
     }
 }

--- a/src/polaris-api-csharpTests/Methods/MARCTypeOfMaterialsGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/MARCTypeOfMaterialsGetTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task MARCTypeOfMaterialsGetAsyncTest()
         {
-            var response = (await Papi.MARCTypeOfMaterialsGetAsync()).Data;
-            Assert.IsTrue(response.MARCTypeOfMaterialsRows.Count() == response.PAPIErrorCode);
+            var response = (await Papi.MARCTypeOfMaterialsGetAsync(cancellationToken: TestContext.CancellationToken)).Data;
+            Assert.HasCount(response.PAPIErrorCode, response.MARCTypeOfMaterialsRows);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/NotificationUpdateTests.cs
+++ b/src/polaris-api-csharpTests/Methods/NotificationUpdateTests.cs
@@ -14,8 +14,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = (await Papi.NotificationUpdateAsync(new NotificationUpdateParams { PatronId = Settings.PatronId, DeliveryString = "test@test.test", ReportingOrgID = 7, NotificationDeliveryDate = DateTime.Now, DeliveryOptionId = 2, Details = CreateUniqueTestArtifactText(maxLength: 80), NotificationStatusId = NotificationStatus.EmailCompleted, NotificationTypeId = 1 })).Data;
-            Assert.IsTrue(response.PAPIErrorCode == -1);
+            var response = (await Papi.NotificationUpdateAsync(new NotificationUpdateParams { PatronId = Settings.PatronId, DeliveryString = "test@test.test", ReportingOrgID = 7, NotificationDeliveryDate = DateTime.Now, DeliveryOptionId = 2, Details = CreateUniqueTestArtifactText(maxLength: 80), NotificationStatusId = NotificationStatus.EmailCompleted, NotificationTypeId = 1 }, TestContext.CancellationToken)).Data;
+            Assert.AreEqual(-1, response.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/OrganizationsGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/OrganizationsGetTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task OrganizationsGetTest()
         {
-            var response = await Papi.OrganizationsGetAsync();
-            Assert.IsTrue(response.Data.OrganizationsGetRows.Count() == response.Data.PAPIErrorCode);
+            var response = await Papi.OrganizationsGetAsync(cancellationToken: TestContext.CancellationToken);
+            Assert.HasCount(response.Data.PAPIErrorCode, response.Data.OrganizationsGetRows);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PapiClientIntegrationTestCategoryTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PapiClientIntegrationTestCategoryTests.cs
@@ -13,33 +13,33 @@ namespace Clc.Polaris.Api.Tests
         private const string LegacyProtectedIntegrationCategory = "ProtectedIntegration";
 
         private static readonly string[] IntegrationCategoryNames =
-        {
+        [
             TestCategories.ReadOnlyIntegration,
             TestCategories.ProtectedReadOnlyIntegration,
             TestCategories.MutatingIntegration,
             TestCategories.ProtectedMutatingIntegration,
-        };
+        ];
 
         private static readonly string[] ProtectedIntegrationCategoryNames =
-        {
+        [
             TestCategories.ProtectedReadOnlyIntegration,
             TestCategories.ProtectedMutatingIntegration,
-        };
+        ];
 
         private static readonly string[] MutatingIntegrationCategoryNames =
-        {
+        [
             TestCategories.MutatingIntegration,
             TestCategories.ProtectedMutatingIntegration,
-        };
+        ];
 
         private static readonly string[] ReadOnlyIntegrationCategoryNames =
-        {
+        [
             TestCategories.ReadOnlyIntegration,
             TestCategories.ProtectedReadOnlyIntegration,
-        };
+        ];
 
         private static readonly string[] KnownReadOnlyIntegrationTests =
-        {
+        [
             "ApiKeyValidateTest",
             "ApiVersionGetTest",
             "BibGetTest",
@@ -67,10 +67,10 @@ namespace Clc.Polaris.Api.Tests
             "PatronValidateTest",
             "PickupBranchesGetTest",
             "ShelfLocationsGetTest",
-        };
+        ];
 
         private static readonly string[] KnownProtectedReadOnlyIntegrationTests =
-        {
+        [
             "AuthenticateStaffUserTest",
             "HoldRequestGetListTest",
             "Patron_GetBarcodeFromIdTest",
@@ -79,10 +79,10 @@ namespace Clc.Polaris.Api.Tests
             "RecordSetRecordsGetTest",
             "SA_GetValueByOrgTest",
             "Synch_BibsByIdGetTest",
-        };
+        ];
 
         private static readonly string[] KnownMutatingIntegrationTests =
-        {
+        [
             "HoldRequestCancelTest",
             "HoldRequestCreateTest",
             "HoldRequestCreateTest2",
@@ -102,10 +102,10 @@ namespace Clc.Polaris.Api.Tests
             "PatronTitleListMoveTitleTest",
             "PatronUpdateTest",
             "PatronUpdateUserNameTest",
-        };
+        ];
 
         private static readonly string[] KnownProtectedMutatingIntegrationTests =
-        {
+        [
             "CreatePatronBlocksTest_FreeTextBlock",
             "CreatePatronBlocksTest_SystemBlock",
             "CreatePatronBlocksTest_LibraryAssignedBlock",
@@ -120,7 +120,7 @@ namespace Clc.Polaris.Api.Tests
             "RecordSetContentAddTest_List",
             "RecordSetContentRemoveTest",
             "RecordSetContentRemoveTest_List",
-        };
+        ];
 
         [TestMethod]
         public void LivePapiClientIntegrationTestsHaveExactlyOneIntegrationCategory()
@@ -135,8 +135,8 @@ namespace Clc.Polaris.Api.Tests
                 .Select(method => $"{method.Name} ({method.Categories.Length}: {string.Join(", ", method.Categories)})")
                 .ToArray();
 
-            Assert.IsFalse(
-                incorrectlyCategorized.Any(),
+            Assert.IsEmpty(
+                incorrectlyCategorized,
                 $"Expected every live PAPI client integration test method to have exactly one integration category ({string.Join(", ", IntegrationCategoryNames)}): {string.Join(", ", incorrectlyCategorized)}");
         }
 
@@ -155,12 +155,12 @@ namespace Clc.Polaris.Api.Tests
                     method.Name,
                     Categories = MethodCategories(method).Intersect(legacyCategories).ToArray(),
                 })
-                .Where(method => method.Categories.Any())
+                .Where(method => method.Categories.Length != 0)
                 .Select(method => $"{method.Name} ({string.Join(", ", method.Categories)})")
                 .ToArray();
 
-            Assert.IsFalse(
-                methodsWithLegacyCategories.Any(),
+            Assert.IsEmpty(
+                methodsWithLegacyCategories,
                 $"Expected no PAPI client integration test method to use legacy raw integration category traits: {string.Join(", ", methodsWithLegacyCategories)}");
         }
 
@@ -174,8 +174,8 @@ namespace Clc.Polaris.Api.Tests
                 .Select(method => method.Name)
                 .ToArray();
 
-            Assert.IsFalse(
-                unprotectedMethods.Any(),
+            Assert.IsEmpty(
+                unprotectedMethods,
                 $"Expected tests requiring a staff override account to use {TestCategories.ProtectedReadOnlyIntegration} or {TestCategories.ProtectedMutatingIntegration}: {string.Join(", ", unprotectedMethods)}");
         }
 
@@ -188,8 +188,8 @@ namespace Clc.Polaris.Api.Tests
                 .Select(method => method.Name)
                 .ToArray();
 
-            Assert.IsFalse(
-                missingDoNotParallelize.Any(),
+            Assert.IsEmpty(
+                missingDoNotParallelize,
                 $"Expected mutating integration tests to be marked with {nameof(DoNotParallelizeAttribute)}: {string.Join(", ", missingDoNotParallelize)}");
         }
 
@@ -205,8 +205,8 @@ namespace Clc.Polaris.Api.Tests
                 .Select(method => method.Name)
                 .ToArray();
 
-            Assert.IsFalse(
-                unexpectedlyNonParallelized.Any(),
+            Assert.IsEmpty(
+                unexpectedlyNonParallelized,
                 $"Expected read-only integration tests not to be marked with {nameof(DoNotParallelizeAttribute)} unless documented in this test: {string.Join(", ", unexpectedlyNonParallelized)}");
         }
 
@@ -243,8 +243,8 @@ namespace Clc.Polaris.Api.Tests
                 .Where(methodName => !MethodCategories(GetPapiClientIntegrationTestMethod(methodName)).Contains(expectedCategory))
                 .ToArray();
 
-            Assert.IsFalse(
-                missingCategory.Any(),
+            Assert.IsEmpty(
+                missingCategory,
                 $"Expected these PAPI client integration test methods to be marked with {expectedCategory}: {string.Join(", ", missingCategory)}");
         }
 

--- a/src/polaris-api-csharpTests/Methods/PatronAccountCreateCreditTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronAccountCreateCreditTests.cs
@@ -13,8 +13,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.PatronAccountCreateCreditAsync(Settings.PatronBarcode, .01, PaymentMethod.Cash, note: CreateUniqueTestArtifactText(maxLength: 80));
-            Assert.IsTrue(response.Data.PAPIErrorCode == 0);
+            var response = await Papi.PatronAccountCreateCreditAsync(Settings.PatronBarcode, .01, PaymentMethod.Cash, note: CreateUniqueTestArtifactText(maxLength: 80), cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(0, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronAccountCreateTitleListTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronAccountCreateTitleListTests.cs
@@ -24,7 +24,5 @@ namespace Clc.Polaris.Api.Tests
             var deleteResponse = await Papi.PatronAccountDeleteTitleListAsync(Settings.PatronBarcode, list.RecordStoreId, Settings.PatronPin, TestContext.CancellationToken);
             Assert.AreEqual(0, deleteResponse.Data.PAPIErrorCode);
         }
-
-        public TestContext TestContext { get; set; }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronAccountDepositCreditTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronAccountDepositCreditTests.cs
@@ -12,8 +12,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.PatronAccountDepositCreditAsync(Settings.PatronBarcode, .01, note: CreateUniqueTestArtifactText(maxLength: 80));
-            Assert.IsTrue(response.Data.PAPIErrorCode == 0);
+            var response = await Papi.PatronAccountDepositCreditAsync(Settings.PatronBarcode, .01, note: CreateUniqueTestArtifactText(maxLength: 80), cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(0, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronAccountGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronAccountGetTests.cs
@@ -10,9 +10,9 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task PatronAccountGetTest()
         {
-            var response = await Papi.PatronAccountGetAsync(Settings.PatronBarcode, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == 0);
-            Assert.IsTrue(response.Data.PatronAccountGetRows.Any());
+            var response = await Papi.PatronAccountGetAsync(Settings.PatronBarcode, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(0, response.Data.PAPIErrorCode);
+            Assert.IsNotEmpty(response.Data.PatronAccountGetRows);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronAccountPayAllTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronAccountPayAllTests.cs
@@ -13,8 +13,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.PatronAccountPayAllAsync(Settings.PatronBarcode, 999999.99, PaymentMethod.Cash, note: CreateUniqueTestArtifactText(maxLength: 80));
-            Assert.IsTrue(response.Data.PAPIErrorCode == -3610);
+            var response = await Papi.PatronAccountPayAllAsync(Settings.PatronBarcode, 999999.99, PaymentMethod.Cash, note: CreateUniqueTestArtifactText(maxLength: 80), cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(-3610, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronAccountPayTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronAccountPayTests.cs
@@ -13,8 +13,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = (await Papi.PatronAccountPayAsync(Settings.PatronBarcode, 1234, .01, PaymentMethod.Cash, note: CreateUniqueTestArtifactText(maxLength: 80))).Data;
-            Assert.IsTrue(response.PAPIErrorCode == -3600);
+            var response = (await Papi.PatronAccountPayAsync(Settings.PatronBarcode, 1234, .01, PaymentMethod.Cash, note: CreateUniqueTestArtifactText(maxLength: 80), cancellationToken: TestContext.CancellationToken)).Data;
+            Assert.AreEqual(-3600, response.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronAccountRefundCreditTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronAccountRefundCreditTests.cs
@@ -12,8 +12,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.PatronAccountRefundCreditAsync(Settings.PatronBarcode, 999999.99, note: CreateUniqueTestArtifactText(maxLength: 80));
-            Assert.IsTrue(response.Data.PAPIErrorCode == -3606);
+            var response = await Papi.PatronAccountRefundCreditAsync(Settings.PatronBarcode, 999999.99, note: CreateUniqueTestArtifactText(maxLength: 80), cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(-3606, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronAccountVoidTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronAccountVoidTests.cs
@@ -12,8 +12,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.PatronAccountVoidAsync(Settings.PatronBarcode, 1234, note: CreateUniqueTestArtifactText(maxLength: 80));
-            Assert.IsTrue(response.Data.PAPIErrorCode == -3606);
+            var response = await Papi.PatronAccountVoidAsync(Settings.PatronBarcode, 1234, note: CreateUniqueTestArtifactText(maxLength: 80), cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(-3606, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronBasicDataGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronBasicDataGetTests.cs
@@ -10,10 +10,10 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task PatronBasicDataGetTest()
         {
-            var response = await Papi.PatronBasicDataGetAsync(Settings.PatronBarcode, Settings.PatronPin, true);
-            Assert.IsTrue(response.Data.PAPIErrorCode == 0);
-            Assert.IsTrue(response.Data.PatronBasicData.PatronID == Settings.PatronId);
-            Assert.IsTrue(response.Data.PatronBasicData.PatronAddresses.Any());
+            var response = await Papi.PatronBasicDataGetAsync(Settings.PatronBarcode, Settings.PatronPin, true, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(0, response.Data.PAPIErrorCode);
+            Assert.AreEqual(Settings.PatronId, response.Data.PatronBasicData.PatronID);
+            Assert.IsNotEmpty(response.Data.PatronBasicData.PatronAddresses);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronCirculateBlocksGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronCirculateBlocksGetTests.cs
@@ -9,8 +9,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task PatronCirculateBlocksGetTest()
         {
-            var response = await Papi.PatronCirculateBlocksGetAsync(Settings.PatronBarcode, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == 0);
+            var response = await Papi.PatronCirculateBlocksGetAsync(Settings.PatronBarcode, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(0, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronCodesGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronCodesGetTests.cs
@@ -10,9 +10,9 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task PatronCodesGetTest()
         {
-            var response = await Papi.PatronCodesGetAsync();
-            Assert.IsTrue(response.Data.PAPIErrorCode == 0);
-            Assert.IsTrue(response.Data.PatronCodesRows.Any());
+            var response = await Papi.PatronCodesGetAsync(cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(0, response.Data.PAPIErrorCode);
+            Assert.IsNotEmpty(response.Data.PatronCodesRows);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronHoldRequestsGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronHoldRequestsGetTests.cs
@@ -11,9 +11,9 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task PatronHoldRequestsGetTest()
         {
-            var response = await Papi.PatronHoldRequestsGetAsync(Settings.PatronBarcode, PatronHoldStatus.all, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == 0);
-            //Assert.IsTrue(response.Data.PatronHoldRequestsGetRows.Any());
+            var response = await Papi.PatronHoldRequestsGetAsync(Settings.PatronBarcode, PatronHoldStatus.all, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(0, response.Data.PAPIErrorCode);
+            Assert.IsNotEmpty(response.Data.PatronHoldRequestsGetRows);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronILLRequestsGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronILLRequestsGetTests.cs
@@ -10,9 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task PatronILLRequestsGetTest()
         {
-            var response = await Papi.PatronILLRequestsGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == 0);
-            //Assert.IsTrue(response.Data.PatronILLRequestsGetRows.Any());
+            var response = await Papi.PatronILLRequestsGetAsync(Settings.PatronBarcode, password: Settings.PatronPin, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(0, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronItemsOutGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronItemsOutGetTests.cs
@@ -10,9 +10,9 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task PatronItemsOutGetTest()
         {
-            var response = await Papi.PatronItemsOutGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == 0);
-            //Assert.IsTrue(response.Data.PatronItemsOutGetRows.Any());
+            var response = await Papi.PatronItemsOutGetAsync(Settings.PatronBarcode, password: Settings.PatronPin, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(response.Data.PatronItemsOutGetRows.Count, response.Data.PAPIErrorCode);
+            Assert.IsNotEmpty(response.Data.PatronItemsOutGetRows);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronMessageDeleteTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronMessageDeleteTests.cs
@@ -11,8 +11,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronMessageDeleteTest()
         {
-            var response = await Papi.PatronMessageDeleteAsync(Settings.PatronBarcode, PatronMessageType.freetext, 1234, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -1);
+            var response = await Papi.PatronMessageDeleteAsync(Settings.PatronBarcode, PatronMessageType.freetext, 1234, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(-1, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronMessageUpdateStatusTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronMessageUpdateStatusTests.cs
@@ -11,8 +11,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronMessageUpdateStatusTest()
         {
-            var response = await Papi.PatronMessageUpdateStatusAsync(Settings.PatronBarcode, PatronMessageType.freetext, 1234, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -1);
+            var response = await Papi.PatronMessageUpdateStatusAsync(Settings.PatronBarcode, PatronMessageType.freetext, 1234, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(-1, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronMessagesGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronMessagesGetTests.cs
@@ -9,8 +9,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task PatronMessagesGetTest()
         {
-            var response = await Papi.PatronMessagesGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == 0);
+            var response = await Papi.PatronMessagesGetAsync(Settings.PatronBarcode, password: Settings.PatronPin, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(0, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronPreferencesGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronPreferencesGetTests.cs
@@ -9,8 +9,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task PatronPreferencesGetTest()
         {
-            var response = await Papi.PatronPreferencesGetAsync(Settings.PatronBarcode, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PatronPreferences.PatronID == Settings.PatronId);
+            var response = await Papi.PatronPreferencesGetAsync(Settings.PatronBarcode, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(Settings.PatronId, response.Data.PatronPreferences.PatronID);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronReadingHistoryClearTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronReadingHistoryClearTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronReadingHistoryClearTest()
         {
-            var response = await Papi.PatronReadingHistoryClearAsync(Settings.PatronBarcode, Settings.PatronPin, new[] { 1234 });
-            Assert.IsTrue(response.Data.PAPIErrorCode == -10);
+            var response = await Papi.PatronReadingHistoryClearAsync(Settings.PatronBarcode, Settings.PatronPin, [1234], TestContext.CancellationToken);
+            Assert.AreEqual(-10, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronReadingHistoryGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronReadingHistoryGetTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task PatronReadingHistoryGetTest()
         {
-            var response = await Papi.PatronReadingHistoryGetAsync(Settings.PatronBarcode, password: Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == response.Data.PatronReadingHistoryGetRows.Count());
+            var response = await Papi.PatronReadingHistoryGetAsync(Settings.PatronBarcode, password: Settings.PatronPin, cancellationToken: TestContext.CancellationToken);
+            Assert.HasCount(response.Data.PAPIErrorCode, response.Data.PatronReadingHistoryGetRows);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronRenewBlocksGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronRenewBlocksGetTests.cs
@@ -11,8 +11,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.PatronRenewBlocksGetAsync(Settings.PatronId);
-            Assert.IsTrue(response.Data.PAPIErrorCode == 0);
+            var response = await Papi.PatronRenewBlocksGetAsync(Settings.PatronId, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(0, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronSavedSearchesGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronSavedSearchesGetTests.cs
@@ -9,8 +9,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task PatronSavedSearchesGetTest()
         {
-            var response = await Papi.PatronSavedSearchesGetAsync(Settings.PatronBarcode, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == 0);
+            var response = await Papi.PatronSavedSearchesGetAsync(Settings.PatronBarcode, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(0, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronSearchTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronSearchTests.cs
@@ -11,8 +11,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.PatronSearchAsync($"PRID={Settings.PatronId}");
-            Assert.IsTrue(response.Data.PAPIErrorCode == response.Data.PatronSearchRows.Count);
+            var response = await Papi.PatronSearchAsync($"PRID={Settings.PatronId}", cancellationToken: TestContext.CancellationToken);
+            Assert.HasCount(response.Data.PAPIErrorCode, response.Data.PatronSearchRows);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronTitleListAddTitleTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronTitleListAddTitleTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListAddTitleTest()
         {
-            var response = await Papi.PatronTitleListAddTitleAsync(Settings.PatronBarcode, 1234, 1234, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -1);
+            var response = await Papi.PatronTitleListAddTitleAsync(Settings.PatronBarcode, 1234, 1234, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(-1, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronTitleListCopyAllTitlesTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronTitleListCopyAllTitlesTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListCopyAllTitlesTest()
         {
-            var response = await Papi.PatronTitleListCopyAllTitlesAsync(Settings.PatronBarcode, 1234, 1234, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -1);
+            var response = await Papi.PatronTitleListCopyAllTitlesAsync(Settings.PatronBarcode, 1234, 1234, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(-1, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronTitleListCopyTitleTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronTitleListCopyTitleTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListCopyTitleTest()
         {
-            var response = await Papi.PatronTitleListCopyTitleAsync(Settings.PatronBarcode, 1234, 1234, 1234, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -1);
+            var response = await Papi.PatronTitleListCopyTitleAsync(Settings.PatronBarcode, 1234, 1234, 1234, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(-1, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronTitleListDeleteAllTitlesTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronTitleListDeleteAllTitlesTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListDeleteAllTitlesTest()
         {
-            var response = await Papi.PatronTitleListDeleteAllTitlesAsync(Settings.PatronBarcode, 1234, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -1);
+            var response = await Papi.PatronTitleListDeleteAllTitlesAsync(Settings.PatronBarcode, 1234, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(-1, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronTitleListDeleteTitleTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronTitleListDeleteTitleTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListDeleteTitleTest()
         {
-            var response = await Papi.PatronTitleListDeleteTitleAsync(Settings.PatronBarcode, 1234, 1234, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -1);
+            var response = await Papi.PatronTitleListDeleteTitleAsync(Settings.PatronBarcode, 1234, 1234, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(-1, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronTitleListGetTitlesTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronTitleListGetTitlesTests.cs
@@ -9,8 +9,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task PatronTitleListGetTitlesTest()
         {
-            var response = await Papi.PatronTitleListGetTitlesAsync(Settings.PatronBarcode, 1234, password: Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -1);
+            var response = await Papi.PatronTitleListGetTitlesAsync(Settings.PatronBarcode, 1234, password: Settings.PatronPin, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(-1, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronTitleListMoveTitleTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronTitleListMoveTitleTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronTitleListMoveTitleTest()
         {
-            var response = await Papi.PatronTitleListMoveTitleAsync(Settings.PatronBarcode, 1234, 1234, 1234, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -1);
+            var response = await Papi.PatronTitleListMoveTitleAsync(Settings.PatronBarcode, 1234, 1234, 1234, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(-1, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronUpdateTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronUpdateTests.cs
@@ -11,8 +11,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronUpdateTest()
         {
-            var response = await Papi.PatronUpdateAsync(Settings.PatronBarcode, new PatronUpdateParams(), Settings.PatronPin);
-            Assert.IsTrue(response.Data.PAPIErrorCode == 0);
+            var response = await Papi.PatronUpdateAsync(Settings.PatronBarcode, new PatronUpdateParams(), Settings.PatronPin, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(0, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronUpdateUserNameTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronUpdateUserNameTests.cs
@@ -11,8 +11,8 @@ namespace Clc.Polaris.Api.Tests
         [DoNotParallelize]
         public async Task PatronUpdateUserNameTest()
         {
-            var response = await Papi.PatronUpdateUserNameAsync(Settings.PatronBarcode + "1234", Settings.PatronPin, Settings.PatronPin);
-            Assert.IsTrue(response.Response.StatusCode == HttpStatusCode.Unauthorized);
+            var response = await Papi.PatronUpdateUserNameAsync(Settings.PatronBarcode + "1234", Settings.PatronPin, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.Response.StatusCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PatronValidateTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PatronValidateTests.cs
@@ -9,8 +9,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task PatronValidateTest()
         {
-            var response = await Papi.PatronValidateAsync(Settings.PatronBarcode, Settings.PatronPin);
-            Assert.IsTrue(response.Data.PatronID == Settings.PatronId);
+            var response = await Papi.PatronValidateAsync(Settings.PatronBarcode, Settings.PatronPin, TestContext.CancellationToken);
+            Assert.AreEqual(Settings.PatronId, response.Data.PatronID);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/Patron_GetBarcodeFromIdTests.cs
+++ b/src/polaris-api-csharpTests/Methods/Patron_GetBarcodeFromIdTests.cs
@@ -11,8 +11,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.Patron_GetBarcodeFromIdAsync(Settings.PatronId);
-            Assert.IsTrue(response.Data.Barcode == Settings.PatronBarcode);
+            var response = await Papi.Patron_GetBarcodeFromIdAsync(Settings.PatronId, TestContext.CancellationToken);
+            Assert.AreEqual(Settings.PatronBarcode, response.Data.Barcode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/PickupBranchesGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/PickupBranchesGetTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task PickupBranchesGetTest()
         {
-            var response = await Papi.PickupBranchesGetAsync();
-            Assert.IsTrue(response.Data.PickupBranchesRows.Any());
+            var response = await Papi.PickupBranchesGetAsync(cancellationToken: TestContext.CancellationToken);
+            Assert.IsNotEmpty(response.Data.PickupBranchesRows);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/ProtectedTokens/PatronAccountGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ProtectedTokens/PatronAccountGetTests.cs
@@ -21,95 +21,87 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             ClearProtectedTokenState();
         }
 
-
         [TestMethod]
         public async Task PatronAccountGetAsync_FailedStaffAuthentication_DoesNotPopulateProtectedTokenCache()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
 
-            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123", cancellationToken: TestContext.CancellationToken));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
-
 
         [TestMethod]
         public async Task PatronAccountGetAsync_NullDataStaffAuthentication_DoesNotPopulateProtectedTokenCache()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, "{}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateEmptyJsonObject());
             var client = CreateProtectedClient(handler);
 
-            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123", cancellationToken: TestContext.CancellationToken));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
-
 
         [TestMethod]
         public async Task PatronAccountGetAsync_FailedStaffAuthentication_AfterExpiredExistingTokenClearsToken()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             client.Token = new ProtectedToken
             {
                 AccessToken = "existing-token",
                 AccessSecret = "existing-secret",
-                ExpirationDate = DateTime.Now.AddHours(-1)
+                ExpirationDate = ExpiredProtectedTokenExpirationDate
             };
 
-            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123", cancellationToken: TestContext.CancellationToken));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
-
 
         [TestMethod]
         public async Task PatronAccountGetAsync_NullDataStaffAuthentication_AfterExpiredExistingTokenClearsToken()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, "{}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateEmptyJsonObject());
             var client = CreateProtectedClient(handler);
             client.Token = new ProtectedToken
             {
                 AccessToken = "existing-token",
                 AccessSecret = "existing-secret",
-                ExpirationDate = DateTime.Now.AddHours(-1)
+                ExpirationDate = ExpiredProtectedTokenExpirationDate
             };
 
-            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123", cancellationToken: TestContext.CancellationToken));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
-
-
 
         [TestMethod]
         public async Task PatronAccountGetAsync_InvalidStaffAuthentication_AfterExpiredExistingTokenClearsTokenAndDoesNotCache()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson(string.Empty, string.Empty, DateTime.Now.AddHours(1)));
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: string.Empty, accessSecret: string.Empty, expirationDate: ValidProtectedTokenExpirationDate));
             var client = CreateProtectedClient(handler);
             client.Token = new ProtectedToken
             {
                 AccessToken = "existing-token",
                 AccessSecret = "existing-secret",
-                ExpirationDate = DateTime.Now.AddHours(-1)
+                ExpirationDate = ExpiredProtectedTokenExpirationDate
             };
 
-            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123", cancellationToken: TestContext.CancellationToken));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
@@ -117,50 +109,47 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
 
-
         [TestMethod]
         public async Task PatronAccountGetAsync_PublicStaffOverride_FailedStaffAuthentication_ThrowsBeforeFinalRequest()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
 
-            var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
+            var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123", cancellationToken: TestContext.CancellationToken));
 
-            StringAssert.Contains(exception.Message, "Staff authentication did not succeed");
+            Assert.Contains("Staff authentication did not succeed", exception.Message);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
         }
 
-
         [TestMethod]
         public async Task PatronAccountGetAsync_PublicRequestWithoutStaffOverrideAccount_ContinuesAsOrdinaryPublicRequest()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             client.StaffOverrideAccount = null;
             client.AllowStaffOverrideRequests = true;
 
-            var response = await client.PatronAccountGetAsync("ABC123");
+            var response = await client.PatronAccountGetAsync("ABC123", cancellationToken: TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
-            StringAssert.Contains(handler.RequestPaths.Single(), "/public/v1/1033/100/1/patron/ABC123/account/outstanding");
+            Assert.Contains("/public/v1/1033/100/1/patron/ABC123/account/outstanding", handler.RequestPaths.Single());
         }
-
 
         [TestMethod]
         public async Task PatronAccountGetAsync_PublicRequestWithExplicitPassword_DoesNotRequireStaffOverrideToken()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
 
-            var response = await client.PatronAccountGetAsync("ABC123", password: "patron-password");
+            var response = await client.PatronAccountGetAsync("ABC123", password: "patron-password", TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
-            StringAssert.Contains(handler.RequestPaths.Single(), "/public/v1/1033/100/1/patron/ABC123/account/outstanding");
+            Assert.Contains("/public/v1/1033/100/1/patron/ABC123/account/outstanding", handler.RequestPaths.Single());
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/ProtectedTokens/PatronSearchTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ProtectedTokens/PatronSearchTests.cs
@@ -459,7 +459,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             Assert.AreEqual(1, handlerA.AuthenticationRequestCount);
             Assert.AreEqual(1, handlerB.AuthenticationRequestCount);
             Assert.AreEqual("token-b", clientB.Token?.AccessToken);
-            Assert.AreEqual(1, GetProtectedTokenCache().Count);
+            Assert.AreEqual(1, GetProtectedTokenCacheCount());
             Assert.IsFalse(TryGetCachedToken(hostname, clientB.AccessID, clientB.AccessKey, clientB.StaffOverrideAccount, out _));
         }
 

--- a/src/polaris-api-csharpTests/Methods/ProtectedTokens/PatronSearchTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ProtectedTokens/PatronSearchTests.cs
@@ -28,26 +28,26 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         [TestMethod]
         public async Task ProtectedTokenPathRequest_ReplacesPlaceholderBeforeSending()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
-            client.Token = new ProtectedToken { AccessToken = "real-token", AccessSecret = "real-secret", ExpirationDate = DateTime.Now.AddHours(1) };
+            client.Token = new ProtectedToken { AccessToken = "real-token", AccessSecret = "real-secret", ExpirationDate = ValidProtectedTokenExpirationDate };
 
-            var response = await client.PatronSearchAsync("name=Smith", orgId: 9);
+            var response = await client.PatronSearchAsync("name=Smith", orgId: 9, cancellationToken: TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.IsNotNull(handler.LastRequest);
             Assert.IsFalse(handler.LastRequest!.RequestUri!.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
-            StringAssert.Contains(handler.LastRequest.RequestUri.AbsolutePath, "/protected/v1/1033/100/9/real-token/search/patrons/Boolean");
+            Assert.Contains("/protected/v1/1033/100/9/real-token/search/patrons/Boolean", handler.LastRequest.RequestUri.AbsolutePath);
         }
 
         [TestMethod]
         public async Task ProtectedTokenPathRequest_HashesReplacedUrlInsteadOfPlaceholderUrl()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
-            client.Token = new ProtectedToken { AccessToken = "hash-token", AccessSecret = "hash-secret", ExpirationDate = DateTime.Now.AddHours(1) };
+            client.Token = new ProtectedToken { AccessToken = "hash-token", AccessSecret = "hash-secret", ExpirationDate = ValidProtectedTokenExpirationDate };
 
-            await client.PatronSearchAsync("name=Smith", orgId: 9);
+            await client.PatronSearchAsync("name=Smith", orgId: 9, cancellationToken: TestContext.CancellationToken);
 
             Assert.IsNotNull(handler.LastRequest);
             var date = handler.LastRequest!.Headers.GetValues("PolarisDate").Single();
@@ -72,12 +72,12 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
                 Password = "secret"
             };
 
-            var response = await client.PatronSearchAsync("name=Smith", orgId: 9);
+            var response = await client.PatronSearchAsync("name=Smith", orgId: 9, cancellationToken: TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
-            Assert.AreEqual(2, handler.Requests.Count);
-            StringAssert.Contains(handler.Requests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
-            StringAssert.Contains(handler.Requests[1].RequestUri!.AbsolutePath, "/protected/v1/1033/100/9/protected-token/search/patrons/Boolean");
+            Assert.HasCount(2, handler.Requests);
+            Assert.Contains("/protected/v1/1033/100/1/authenticator/staff", handler.Requests[0].RequestUri!.AbsolutePath);
+            Assert.Contains("/protected/v1/1033/100/9/protected-token/search/patrons/Boolean", handler.Requests[1].RequestUri!.AbsolutePath);
             Assert.IsFalse(handler.Requests[1].RequestUri!.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
         }
 
@@ -97,15 +97,15 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             {
                 AccessToken = "expired-token",
                 AccessSecret = "expired-secret",
-                ExpirationDate = DateTime.Now.AddHours(-1)
+                ExpirationDate = ExpiredProtectedTokenExpirationDate
             };
 
-            var response = await client.PatronSearchAsync("name=Smith", orgId: 9);
+            var response = await client.PatronSearchAsync("name=Smith", orgId: 9, cancellationToken: TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
-            Assert.AreEqual(2, handler.Requests.Count);
-            StringAssert.Contains(handler.Requests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
-            StringAssert.Contains(handler.Requests[1].RequestUri!.AbsolutePath, "/protected/v1/1033/100/9/protected-token/search/patrons/Boolean");
+            Assert.HasCount(2, handler.Requests);
+            Assert.Contains("/protected/v1/1033/100/1/authenticator/staff", handler.Requests[0].RequestUri!.AbsolutePath);
+            Assert.Contains("/protected/v1/1033/100/9/protected-token/search/patrons/Boolean", handler.Requests[1].RequestUri!.AbsolutePath);
             Assert.IsFalse(handler.Requests[1].RequestUri!.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
             Assert.AreEqual("protected-token", client.Token!.AccessToken);
         }
@@ -126,14 +126,13 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             {
                 AccessToken = "expired-token",
                 AccessSecret = "expired-secret",
-                ExpirationDate = DateTime.Now.AddHours(-1)
+                ExpirationDate = ExpiredProtectedTokenExpirationDate
             };
 
-            var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
-                () => client.PatronSearchAsync("name=Smith", orgId: 9));
+            var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith", orgId: 9, cancellationToken: TestContext.CancellationToken));
 
-            StringAssert.Contains(exception.Message, "valid protected access token");
-            StringAssert.Contains(exception.Message, "ProtectedToken.Placeholder");
+            Assert.Contains("valid protected access token", exception.Message);
+            Assert.Contains("ProtectedToken.Placeholder", exception.Message);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.ProtectedRequestCount);
             Assert.IsNull(client.Token);
@@ -153,7 +152,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
                 Password = "secret"
             };
 
-            await firstClient.PatronSearchAsync("name=Smith", orgId: 9);
+            await firstClient.PatronSearchAsync("name=Smith", orgId: 9, cancellationToken: TestContext.CancellationToken);
 
             var secondClient = CreateClient(handler);
             secondClient.AllowStaffOverrideRequests = true;
@@ -165,13 +164,13 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
                 Password = "secret"
             };
 
-            var response = await secondClient.PatronSearchAsync("name=Jones", orgId: 9);
+            var response = await secondClient.PatronSearchAsync("name=Jones", orgId: 9, cancellationToken: TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
-            Assert.AreEqual(3, handler.Requests.Count);
-            StringAssert.Contains(handler.Requests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
-            StringAssert.Contains(handler.Requests[1].RequestUri!.AbsolutePath, "/protected/v1/1033/100/9/protected-token/search/patrons/Boolean");
-            StringAssert.Contains(handler.Requests[2].RequestUri!.AbsolutePath, "/protected/v1/1033/100/9/protected-token/search/patrons/Boolean");
+            Assert.HasCount(3, handler.Requests);
+            Assert.Contains("/protected/v1/1033/100/1/authenticator/staff", handler.Requests[0].RequestUri!.AbsolutePath);
+            Assert.Contains("/protected/v1/1033/100/9/protected-token/search/patrons/Boolean", handler.Requests[1].RequestUri!.AbsolutePath);
+            Assert.Contains("/protected/v1/1033/100/9/protected-token/search/patrons/Boolean", handler.Requests[2].RequestUri!.AbsolutePath);
             Assert.IsFalse(handler.Requests[2].RequestUri!.AbsoluteUri.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
         }
 
@@ -199,13 +198,13 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
                 Password = "secret"
             };
 
-            await firstClient.PatronSearchAsync("name=Smith", orgId: 9);
-            await secondClient.PatronSearchAsync("name=Jones", orgId: 9);
+            await firstClient.PatronSearchAsync("name=Smith", orgId: 9, cancellationToken: TestContext.CancellationToken);
+            await secondClient.PatronSearchAsync("name=Jones", orgId: 9, cancellationToken: TestContext.CancellationToken);
 
             Assert.AreEqual(2, handler.AuthenticationRequestCount);
-            Assert.AreEqual(2, handler.ProtectedRequests.Count);
-            StringAssert.Contains(handler.ProtectedRequests[0].RequestUri!.AbsolutePath, "/protected/v1/1033/100/9/protected-token-1/search/patrons/Boolean");
-            StringAssert.Contains(handler.ProtectedRequests[1].RequestUri!.AbsolutePath, "/protected/v1/1033/100/9/protected-token-2/search/patrons/Boolean");
+            Assert.HasCount(2, handler.ProtectedRequests);
+            Assert.Contains("/protected/v1/1033/100/9/protected-token-1/search/patrons/Boolean", handler.ProtectedRequests[0].RequestUri!.AbsolutePath);
+            Assert.Contains("/protected/v1/1033/100/9/protected-token-2/search/patrons/Boolean", handler.ProtectedRequests[1].RequestUri!.AbsolutePath);
         }
 
         [TestMethod]
@@ -217,11 +216,10 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             client.StaffOverrideAccount = null;
             client.Token = null;
 
-            var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
-                () => client.PatronSearchAsync("name=Smith", orgId: 9));
+            var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith", orgId: 9, cancellationToken: TestContext.CancellationToken));
 
-            StringAssert.Contains(exception.Message, "valid protected access token");
-            StringAssert.Contains(exception.Message, "ProtectedToken.Placeholder");
+            Assert.Contains("valid protected access token", exception.Message);
+            Assert.Contains("ProtectedToken.Placeholder", exception.Message);
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.ProtectedRequestCount);
         }
@@ -233,7 +231,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             var client = CreateProtectedClient(handler);
 
             var requests = Enumerable.Range(0, 8)
-                .Select(index => client.PatronSearchAsync($"name={index}"))
+                .Select(index => client.PatronSearchAsync($"name={index}", cancellationToken: TestContext.CancellationToken))
                 .ToArray();
 
             await Task.WhenAll(requests);
@@ -249,23 +247,21 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         {
             var hostname = $"https://example-{Guid.NewGuid():N}.test";
             var staff = CreateStaffUser(password: "shared-password");
-            var handler = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson("shared-token", "shared-secret", DateTime.Now.AddHours(1)));
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: "shared-token", accessSecret: "shared-secret", expirationDate: ValidProtectedTokenExpirationDate));
             var clients = Enumerable.Range(0, 6)
                 .Select(_ => CreateProtectedClient(handler, hostname, staff))
                 .ToArray();
 
-            await Task.WhenAll(clients.Select((client, index) => client.PatronSearchAsync($"name=shared-{index}")));
+            await Task.WhenAll(clients.Select((client, index) => client.PatronSearchAsync($"name=shared-{index}", cancellationToken: TestContext.CancellationToken)));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(clients.Length, handler.NonAuthenticationRequestCount);
             Assert.IsTrue(clients.All(client => client.Token?.AccessToken == "shared-token"));
             var finalRequests = handler.CapturedRequests.Where(request => !request.IsStaffAuthenticationRequest).ToArray();
-            Assert.AreEqual(clients.Length, finalRequests.Length);
+            Assert.HasCount(clients.Length, finalRequests);
             foreach (var request in finalRequests)
             {
-                StringAssert.Contains(request.Path, "/protected/v1/1033/100/1/shared-token/search/patrons/Boolean");
+                Assert.Contains("/protected/v1/1033/100/1/shared-token/search/patrons/Boolean", request.Path);
                 Assert.IsFalse(request.Path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
                 AssertAuthorizationHash(request, "shared-secret", "access-key", "access-id");
             }
@@ -279,13 +275,13 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             {
                 AccessToken = "token-for-password-a",
                 AccessSecret = "secret-for-password-a",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
             var passwordBToken = new ProtectedToken
             {
                 AccessToken = "token-for-password-b",
                 AccessSecret = "secret-for-password-b",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
             var handler = new ProtectedTokenHttpMessageHandler(request =>
             {
@@ -299,7 +295,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
                     return (HttpStatusCode.OK, CreateProtectedTokenJson(passwordBToken));
                 }
 
-                return (HttpStatusCode.BadRequest, "{\"PAPIErrorCode\":1}");
+                return (HttpStatusCode.BadRequest, CreatePapiResponseJson(1));
             });
             var clients = new[]
             {
@@ -310,10 +306,10 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             };
 
             await Task.WhenAll(
-                clients[0].PatronSearchAsync("name=alpha-0"),
-                clients[1].PatronSearchAsync("name=bravo-0"),
-                clients[2].PatronSearchAsync("name=alpha-1"),
-                clients[3].PatronSearchAsync("name=bravo-1"));
+                clients[0].PatronSearchAsync("name=alpha-0", cancellationToken: TestContext.CancellationToken),
+                clients[1].PatronSearchAsync("name=bravo-0", cancellationToken: TestContext.CancellationToken),
+                clients[2].PatronSearchAsync("name=alpha-1", cancellationToken: TestContext.CancellationToken),
+                clients[3].PatronSearchAsync("name=bravo-1", cancellationToken: TestContext.CancellationToken));
 
             Assert.AreEqual(2, handler.AuthenticationRequestCount);
             Assert.AreEqual(4, handler.NonAuthenticationRequestCount);
@@ -327,9 +323,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             var passwordAReuseClient = CreateProtectedClient(handler, hostname, CreateStaffUser(password: "password-a"));
             var passwordBReuseClient = CreateProtectedClient(handler, hostname, CreateStaffUser(password: "password-b"));
 
-            await Task.WhenAll(
-                passwordAReuseClient.PatronSearchAsync("name=reuse-a"),
-                passwordBReuseClient.PatronSearchAsync("name=reuse-b"));
+            await Task.WhenAll(passwordAReuseClient.PatronSearchAsync("name=reuse-a", cancellationToken: TestContext.CancellationToken), passwordBReuseClient.PatronSearchAsync("name=reuse-b", cancellationToken: TestContext.CancellationToken));
 
             Assert.AreEqual(2, handler.AuthenticationRequestCount);
             Assert.AreEqual(6, handler.NonAuthenticationRequestCount);
@@ -342,25 +336,23 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         [TestMethod]
         public async Task PatronSearchAsync_WhenProtectedTokenCacheDisabled_IgnoresStaticCachedTokenAndUsesNewAuthenticationToken()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson("fresh-token", "fresh-secret", DateTime.Now.AddHours(1)));
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: "fresh-token", accessSecret: "fresh-secret", expirationDate: ValidProtectedTokenExpirationDate));
             var client = CreateProtectedClient(handler);
             client.UseProtectedTokenCache = false;
             SetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, new ProtectedToken
             {
                 AccessToken = "cached-token",
                 AccessSecret = "cached-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             });
 
-            await client.PatronSearchAsync("name=Smith");
+            await client.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken);
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             Assert.AreEqual("fresh-token", client.Token?.AccessToken);
             var finalRequest = handler.CapturedRequests.Single(request => !request.IsStaffAuthenticationRequest);
-            StringAssert.Contains(finalRequest.Path, "/protected/v1/1033/100/1/fresh-token/search/patrons/Boolean");
+            Assert.Contains("/protected/v1/1033/100/1/fresh-token/search/patrons/Boolean", finalRequest.Path);
             Assert.IsFalse(finalRequest.Path.Contains("cached-token", StringComparison.Ordinal));
             AssertAuthorizationHash(finalRequest, "fresh-secret", client.AccessKey, client.AccessID);
             AssertAuthorizationHashDoesNotMatch(finalRequest, "cached-secret", client.AccessKey, client.AccessID);
@@ -371,22 +363,22 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         {
             var handler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.OK,
-                CreateProtectedTokenJson("new-protected-token", "new-protected-secret", DateTime.Now.AddHours(1)));
+                CreateProtectedTokenJson(accessToken: "new-protected-token", accessSecret: "new-protected-secret", expirationDate: ValidProtectedTokenExpirationDate));
             var client = CreateProtectedClient(handler);
             client.Token = new ProtectedToken
             {
                 AccessToken = "expired-token",
                 AccessSecret = "expired-secret",
-                ExpirationDate = DateTime.Now.AddMinutes(-1)
+                ExpirationDate = ExpiredProtectedTokenExpirationDate
             };
 
-            await client.PatronSearchAsync("name=Smith");
+            await client.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken);
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
             Assert.AreEqual("new-protected-token", client.Token?.AccessToken);
             var finalRequest = handler.CapturedRequests.Single(request => !request.IsStaffAuthenticationRequest);
-            StringAssert.Contains(finalRequest.Path, "/protected/v1/1033/100/1/new-protected-token/search/patrons/Boolean");
+            Assert.Contains("/protected/v1/1033/100/1/new-protected-token/search/patrons/Boolean", finalRequest.Path);
             Assert.IsFalse(finalRequest.Path.Contains("expired-token", StringComparison.Ordinal));
             AssertAuthorizationHash(finalRequest, "new-protected-secret", client.AccessKey, client.AccessID);
             AssertAuthorizationHashDoesNotMatch(finalRequest, "expired-secret", client.AccessKey, client.AccessID);
@@ -397,17 +389,17 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         {
             var handler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.OK,
-                CreateProtectedTokenJson("placeholder-token", "placeholder-secret", DateTime.Now.AddHours(1)));
+                CreateProtectedTokenJson(accessToken: "placeholder-token", accessSecret: "placeholder-secret", expirationDate: ValidProtectedTokenExpirationDate));
             var client = CreateProtectedClient(handler);
 
-            await client.PatronSearchAsync("name=Smith");
+            await client.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken);
 
             var capturedRequests = handler.CapturedRequests;
-            Assert.AreEqual(2, capturedRequests.Length);
+            Assert.HasCount(2, capturedRequests);
             Assert.IsTrue(capturedRequests[0].IsStaffAuthenticationRequest);
             Assert.IsFalse(capturedRequests[1].IsStaffAuthenticationRequest);
-            Assert.IsFalse(capturedRequests.Any(request => request.Path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal)));
-            StringAssert.Contains(capturedRequests[1].Path, "/protected/v1/1033/100/1/placeholder-token/search/patrons/Boolean");
+            Assert.DoesNotContain(request => request.Path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal), capturedRequests);
+            Assert.Contains("/protected/v1/1033/100/1/placeholder-token/search/patrons/Boolean", capturedRequests[1].Path);
             AssertAuthorizationHash(capturedRequests[1], "placeholder-secret", client.AccessKey, client.AccessID);
             var placeholderUri = capturedRequests[1].AbsoluteUri.Replace("placeholder-token", ProtectedToken.Placeholder, StringComparison.Ordinal);
             AssertAuthorizationHashDoesNotMatch(capturedRequests[1], "placeholder-secret", client.AccessKey, client.AccessID, placeholderUri);
@@ -422,10 +414,10 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             {
                 AccessToken = "cached-token",
                 AccessSecret = "cached-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             });
 
-            await client.PatronSearchAsync("name=Smith");
+            await client.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken);
 
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
@@ -438,23 +430,19 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             var hostname = $"https://example-{Guid.NewGuid():N}.test";
             var staffWithPassword = CreateStaffUser(password: "correct-1");
 
-            var handlerA = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson("token-a", "secret-a", DateTime.Now.AddHours(1)));
+            var handlerA = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: "token-a", accessSecret: "secret-a", expirationDate: ValidProtectedTokenExpirationDate));
             var clientA = CreateProtectedClient(handlerA);
             clientA.Hostname = hostname;
             clientA.StaffOverrideAccount = staffWithPassword;
 
-            await clientA.PatronSearchAsync("name=Smith");
+            await clientA.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken);
 
-            var handlerB = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson("token-b", "secret-b", DateTime.Now.AddHours(1)));
+            var handlerB = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: "token-b", accessSecret: "secret-b", expirationDate: ValidProtectedTokenExpirationDate));
             var clientB = CreateProtectedClient(handlerB);
             clientB.Hostname = hostname;
             clientB.StaffOverrideAccount = CreateStaffUser(password: string.Empty);
 
-            await clientB.PatronSearchAsync("name=Jones");
+            await clientB.PatronSearchAsync("name=Jones", cancellationToken: TestContext.CancellationToken);
 
             Assert.AreEqual(1, handlerA.AuthenticationRequestCount);
             Assert.AreEqual(1, handlerB.AuthenticationRequestCount);
@@ -468,23 +456,19 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         {
             var hostname = $"https://example-{Guid.NewGuid():N}.test";
 
-            var handlerA = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson("token-a", "secret-a", DateTime.Now.AddHours(1)));
+            var handlerA = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: "token-a", accessSecret: "secret-a", expirationDate: ValidProtectedTokenExpirationDate));
             var clientA = CreateProtectedClient(handlerA);
             clientA.Hostname = hostname;
             clientA.StaffOverrideAccount = CreateStaffUser(password: "correct-1");
 
-            await clientA.PatronSearchAsync("name=Smith");
+            await clientA.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken);
 
-            var handlerB = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson("token-b", "secret-b", DateTime.Now.AddHours(1)));
+            var handlerB = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: "token-b", accessSecret: "secret-b", expirationDate: ValidProtectedTokenExpirationDate));
             var clientB = CreateProtectedClient(handlerB);
             clientB.Hostname = hostname;
             clientB.StaffOverrideAccount = CreateStaffUser(password: "different-2");
 
-            await clientB.PatronSearchAsync("name=Jones");
+            await clientB.PatronSearchAsync("name=Jones", cancellationToken: TestContext.CancellationToken);
 
             Assert.AreEqual(1, handlerB.AuthenticationRequestCount);
             Assert.AreEqual("token-b", clientB.Token?.AccessToken);
@@ -502,24 +486,20 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             var hostname = $"https://example-{Guid.NewGuid():N}.test";
             var staff = CreateStaffUser(password: "correct-1");
 
-            var handlerA = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson("token-a", "secret-a", DateTime.Now.AddHours(1)));
+            var handlerA = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: "token-a", accessSecret: "secret-a", expirationDate: ValidProtectedTokenExpirationDate));
             var clientA = CreateProtectedClient(handlerA);
             clientA.Hostname = hostname;
             clientA.StaffOverrideAccount = staff;
 
-            await clientA.PatronSearchAsync("name=Smith");
+            await clientA.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken);
 
-            var handlerB = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson("token-b", "secret-b", DateTime.Now.AddHours(1)));
+            var handlerB = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: "token-b", accessSecret: "secret-b", expirationDate: ValidProtectedTokenExpirationDate));
             var clientB = CreateProtectedClient(handlerB);
             clientB.Hostname = hostname;
             clientB.AccessKey = "different-access-key";
             clientB.StaffOverrideAccount = staff;
 
-            await clientB.PatronSearchAsync("name=Jones");
+            await clientB.PatronSearchAsync("name=Jones", cancellationToken: TestContext.CancellationToken);
 
             Assert.AreEqual(1, handlerB.AuthenticationRequestCount);
             Assert.AreEqual("token-b", clientB.Token?.AccessToken);
@@ -534,16 +514,16 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         [TestMethod]
         public async Task PatronSearchAsync_ExpiredCachedToken_IsRemovedWhenEncountered()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             SetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, new ProtectedToken
             {
                 AccessToken = "expired-token",
                 AccessSecret = "expired-secret",
-                ExpirationDate = DateTime.Now.AddMinutes(-1)
+                ExpirationDate = ExpiredProtectedTokenExpirationDate
             });
 
-            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
@@ -552,18 +532,16 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         [TestMethod]
         public async Task PatronSearchAsync_CachedTokenWithBlankAccessToken_IsRemovedAndNewTokenIsUsed()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson("new-token", "new-secret", DateTime.Now.AddHours(1)));
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: "new-token", accessSecret: "new-secret", expirationDate: ValidProtectedTokenExpirationDate));
             var client = CreateProtectedClient(handler);
             SetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, new ProtectedToken
             {
                 AccessToken = " ",
                 AccessSecret = "cached-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             });
 
-            await client.PatronSearchAsync("name=Smith");
+            await client.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken);
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
@@ -573,22 +551,22 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             Assert.IsNotNull(cachedToken);
             Assert.AreEqual("new-token", cachedToken.AccessToken);
             Assert.AreEqual("new-secret", cachedToken.AccessSecret);
-            StringAssert.Contains(handler.RequestPaths.Last(), "/protected/v1/1033/100/1/new-token/search/patrons/Boolean");
+            Assert.Contains("/protected/v1/1033/100/1/new-token/search/patrons/Boolean", handler.RequestPaths.Last());
         }
 
         [TestMethod]
         public async Task PatronSearchAsync_CachedTokenWithBlankAccessSecret_IsRemovedAndNotUsedWhenAuthenticationFails()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             SetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, new ProtectedToken
             {
                 AccessToken = "cached-token",
                 AccessSecret = " ",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             });
 
-            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
@@ -599,12 +577,12 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         [TestMethod]
         public async Task PatronSearchAsync_FailedStaffAuthentication_ThrowsBeforeFinalProtectedRequest()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
 
-            var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+            var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken));
 
-            StringAssert.Contains(exception.Message, "Staff authentication did not succeed");
+            Assert.Contains("Staff authentication did not succeed", exception.Message);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
         }
@@ -615,9 +593,9 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, "null");
             var client = CreateProtectedClient(handler);
 
-            var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+            var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken));
 
-            StringAssert.Contains(exception.Message, "did not return a usable protected access token");
+            Assert.Contains("did not return a usable protected access token", exception.Message);
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
         }
@@ -625,12 +603,10 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         [TestMethod]
         public async Task PatronSearchAsync_BlankAccessTokenStaffAuthentication_ThrowsBeforeFinalProtectedRequest()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson(" ", "protected-secret", DateTime.Now.AddHours(1)));
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: " ", accessSecret: "protected-secret", expirationDate: ValidProtectedTokenExpirationDate));
             var client = CreateProtectedClient(handler);
 
-            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
@@ -639,12 +615,10 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         [TestMethod]
         public async Task PatronSearchAsync_BlankAccessSecretStaffAuthentication_ThrowsBeforeFinalProtectedRequest()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson("protected-token", " ", DateTime.Now.AddHours(1)));
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: "protected-token", accessSecret: " ", expirationDate: ValidProtectedTokenExpirationDate));
             var client = CreateProtectedClient(handler);
 
-            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
@@ -655,10 +629,10 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         {
             var handler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.OK,
-                CreateProtectedTokenJson("protected-token", "protected-secret", DateTime.Now.AddMinutes(-1)));
+                CreateProtectedTokenJson(accessToken: "protected-token", accessSecret: "protected-secret", expirationDate: ExpiredProtectedTokenExpirationDate));
             var client = CreateProtectedClient(handler);
 
-            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken));
 
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
@@ -671,14 +645,14 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             {
                 AccessToken = "failed-token",
                 AccessSecret = "failed-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
             var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.Unauthorized, CreateProtectedTokenJson(returnedToken));
             var client = CreateProtectedClient(handler);
             client.AccessKey = "failure-access-key";
             client.StaffOverrideAccount = CreateStaffUser(password: "failure-password");
 
-            var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
+            var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith", cancellationToken: TestContext.CancellationToken));
 
             Assert.IsFalse(exception.Message.Contains(client.StaffOverrideAccount.Password, StringComparison.Ordinal));
             Assert.IsFalse(exception.Message.Contains(client.AccessKey, StringComparison.Ordinal));
@@ -686,7 +660,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             Assert.IsFalse(exception.Message.Contains(returnedToken.AccessSecret, StringComparison.Ordinal));
             Assert.AreEqual(1, handler.AuthenticationRequestCount);
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
-            Assert.IsFalse(handler.RequestPaths.Any(path => path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal)));
+            Assert.DoesNotContain(path => path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal), handler.RequestPaths);
         }
 
         private sealed class FailingStaffAuthenticationHttpMessageHandler : HttpMessageHandler
@@ -703,7 +677,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
                     AuthenticationRequestCount++;
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent("{}", Encoding.UTF8, "application/json")
+                        Content = new StringContent(CreateEmptyJsonObject(), Encoding.UTF8, "application/json")
                     });
                 }
 
@@ -719,7 +693,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
 
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                    Content = new StringContent(CreatePapiResponseJson(), Encoding.UTF8, "application/json")
                 });
             }
         }
@@ -730,16 +704,17 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             private int _authenticationRequestCount;
 
             public int AuthenticationRequestCount => _authenticationRequestCount;
-            public List<HttpRequestMessage> ProtectedRequests { get; } = new();
+            public List<HttpRequestMessage> ProtectedRequests { get; } = [];
 
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 if (request.RequestUri!.AbsolutePath.Contains("/authenticator/staff", StringComparison.Ordinal))
                 {
                     var requestNumber = Interlocked.Increment(ref _authenticationRequestCount);
+                    var responseJson = CreateProtectedTokenJson(accessToken: $"protected-token-{requestNumber}", accessSecret: $"protected-secret-{requestNumber}", expirationDate: ValidProtectedTokenExpirationDate);
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent($"{{\"PAPIErrorCode\":0,\"AccessToken\":\"protected-token-{requestNumber}\",\"AccessSecret\":\"protected-secret-{requestNumber}\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}}", Encoding.UTF8, "application/json")
+                        Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
                     });
                 }
 
@@ -750,7 +725,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
 
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                    Content = new StringContent(CreatePapiResponseJson(), Encoding.UTF8, "application/json")
                 });
             }
         }

--- a/src/polaris-api-csharpTests/Methods/RecordSetContentAddTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RecordSetContentAddTests.cs
@@ -12,8 +12,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.RecordSetContentAddAsync(1234, 1234);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -11001);
+            var response = await Papi.RecordSetContentAddAsync(1234, 1234, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(-11001, response.Data.PAPIErrorCode);
         }
 
         [TestMethod]
@@ -23,8 +23,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.RecordSetContentAddAsync(1234, new[] { 1234 });
-            Assert.IsTrue(response.Data.PAPIErrorCode == -11001);
+            var response = await Papi.RecordSetContentAddAsync(1234, [1234], cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(-11001, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/RecordSetContentRemoveTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RecordSetContentRemoveTests.cs
@@ -12,8 +12,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.RecordSetContentRemoveAsync(1234, 1234);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -11001);
+            var response = await Papi.RecordSetContentRemoveAsync(1234, 1234, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(-11001, response.Data.PAPIErrorCode);
         }
 
         [TestMethod]
@@ -23,8 +23,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.RecordSetContentRemoveAsync(1234, new[] { 1234 });
-            Assert.IsTrue(response.Data.PAPIErrorCode == -11001);
+            var response = await Papi.RecordSetContentRemoveAsync(1234, [1234], cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(-11001, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/RecordSetRecordsGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RecordSetRecordsGetTests.cs
@@ -11,8 +11,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.RecordSetRecordsGetAsync(1234);
-            Assert.IsTrue(response.Data.PAPIErrorCode == -11001);
+            var response = await Papi.RecordSetRecordsGetAsync(1234, cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(-11001, response.Data.PAPIErrorCode);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/RequestShape/ApiKeyValidateTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/ApiKeyValidateTests.cs
@@ -10,18 +10,17 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
     [UnitTest]
     public class ApiKeyValidateTests : PapiClientTestBase
     {
-
         [TestMethod]
         public async Task ApiKeyValidate_RequestShape_IsStable()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
 
-            var response = await client.ApiKeyValidateAsync();
+            var response = await client.ApiKeyValidateAsync(TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
-            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/public/v1/1033/100/1/apikeyvalidate");
+            Assert.Contains("/public/v1/1033/100/1/apikeyvalidate", handler.LastRequest.RequestUri!.AbsolutePath);
             Assert.AreEqual(string.Empty, handler.LastRequest.RequestUri.Query);
             Assert.IsNull(handler.LastRequest.Content);
             Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));

--- a/src/polaris-api-csharpTests/Methods/RequestShape/AuthenticateStaffUserTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/AuthenticateStaffUserTests.cs
@@ -11,30 +11,24 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
     [UnitTest]
     public class AuthenticateStaffUserTests : PapiClientTestBase
     {
-
         [TestMethod]
         public async Task AuthenticateStaffUser_RequestShape_IsStable()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0,\"AccessToken\":\"t\",\"AccessSecret\":\"s\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}");
+            var handler = new CapturingHttpMessageHandler(CreateProtectedTokenJson(accessToken: "t", accessSecret: "s", expirationDate: ValidProtectedTokenExpirationDate));
             var client = CreateClient(handler);
 
-            var response = await client.AuthenticateStaffUserAsync(new PolarisUser
-            {
-                Domain = "main",
-                Username = "staff",
-                Password = "secret"
-            });
+            var response = await client.AuthenticateStaffUserAsync(new PolarisUser("main", "staff", "secret"), TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(HttpMethod.Post, handler.LastRequest!.Method);
-            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
+            Assert.Contains("/protected/v1/1033/100/1/authenticator/staff", handler.LastRequest.RequestUri!.AbsolutePath);
             Assert.IsNotNull(handler.LastRequest.Content);
             Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
             Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
             Assert.IsNotNull(handler.LastRequestContent);
-            StringAssert.Contains(handler.LastRequestContent, "main");
-            StringAssert.Contains(handler.LastRequestContent, "staff");
-            StringAssert.Contains(handler.LastRequestContent, "secret");
+            Assert.Contains("main", handler.LastRequestContent);
+            Assert.Contains("staff", handler.LastRequestContent);
+            Assert.Contains("secret", handler.LastRequestContent);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/RequestShape/BibSearchTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/BibSearchTests.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task BibSearch_RequestShape_IsStable()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var options = new BibSearchOptions
             {
@@ -29,12 +29,13 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
                 Limit = "3"
             };
 
-            var response = await client.BibSearchAsync(options);
+            var response = await client.BibSearchAsync(options, TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
-            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/public/v1/1033/100/1/search/bibs/keyword/KW");
-            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15&limit=3", handler.LastRequest.RequestUri.AbsoluteUri);
+            Assert.Contains("/public/v1/1033/100/1/search/bibs/keyword/KW", handler.LastRequest.RequestUri!.AbsolutePath);
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15&limit=3";
+            Assert.AreEqual(expectedUri, handler.LastRequest.RequestUri.AbsoluteUri);
             var query = ParseQuery(handler.LastRequest.RequestUri.Query);
             Assert.AreEqual("harry potter & stone", query["q"]);
             Assert.AreEqual("MP", query["sort"]);
@@ -50,21 +51,17 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task BibKeywordSearchAsync_ThroughInterface_RequestShapeIsStable()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             IPapiClient client = CreateClient(handler);
 
-            var response = await client.BibKeywordSearchAsync(
-                "harry potter & stone",
-                branchId: 7,
-                page: 2,
-                pageSize: 15,
-                sortBy: SearchSortOptions.MP);
+            var response = await client.BibKeywordSearchAsync("harry potter & stone", branchId: 7, page: 2, pageSize: 15, sortBy: SearchSortOptions.MP, TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.IsNotNull(handler.LastRequest);
             Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
-            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/public/v1/1033/100/7/search/bibs/keyword/KW");
-            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/7/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15", handler.LastRequest.RequestUri.AbsoluteUri);
+            Assert.Contains("/public/v1/1033/100/7/search/bibs/keyword/KW", handler.LastRequest.RequestUri!.AbsolutePath);
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/7/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15";
+            Assert.AreEqual(expectedUri, handler.LastRequest.RequestUri.AbsoluteUri);
             var query = ParseQuery(handler.LastRequest.RequestUri.Query);
             Assert.AreEqual("harry potter & stone", query["q"]);
             Assert.AreEqual("MP", query["sort"]);
@@ -79,37 +76,34 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task BibKeywordSearchAsync_ThroughInterfaceWithoutBranchId_UsesOrganizationId()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
-            IPapiClient client = CreateClient(handler);
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
+            var client = CreateClient(handler);
             client.OrganizationId = 42;
 
-            var response = await client.BibKeywordSearchAsync("default branch search");
+            var response = await client.BibKeywordSearchAsync("default branch search", cancellationToken: TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.IsNotNull(handler.LastRequest);
-            StringAssert.Contains(handler.LastRequest!.RequestUri!.AbsolutePath, "/public/v1/1033/100/42/search/bibs/keyword/KW");
-            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/42/search/bibs/keyword/KW?q=default%20branch%20search&sort=MP&page=1&bibsperpage=10", handler.LastRequest.RequestUri.AbsoluteUri);
+            Assert.Contains("/public/v1/1033/100/42/search/bibs/keyword/KW", handler.LastRequest!.RequestUri!.AbsolutePath);
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/42/search/bibs/keyword/KW?q=default%20branch%20search&sort=MP&page=1&bibsperpage=10";
+            Assert.AreEqual(expectedUri, handler.LastRequest.RequestUri.AbsoluteUri);
             AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
         }
 
         [TestMethod]
         public async Task BibBooleanSearchAsync_ThroughInterface_RequestShapeIsStable()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             IPapiClient client = CreateClient(handler);
 
-            var response = await client.BibBooleanSearchAsync(
-                "TI=Harry Potter",
-                branchId: 8,
-                page: 3,
-                pageSize: 20,
-                sortBy: SearchSortOptions.AU);
+            var response = await client.BibBooleanSearchAsync("TI=Harry Potter", branchId: 8, page: 3, pageSize: 20, sortBy: SearchSortOptions.AU, TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.IsNotNull(handler.LastRequest);
             Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
-            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/public/v1/1033/100/8/search/bibs/boolean");
-            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/8/search/bibs/boolean?q=TI%3DHarry%20Potter&sort=AU&page=3&bibsperpage=20", handler.LastRequest.RequestUri.AbsoluteUri);
+            Assert.Contains("/public/v1/1033/100/8/search/bibs/boolean", handler.LastRequest.RequestUri!.AbsolutePath);
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/8/search/bibs/boolean?q=TI%3DHarry%20Potter&sort=AU&page=3&bibsperpage=20";
+            Assert.AreEqual(expectedUri, handler.LastRequest.RequestUri.AbsoluteUri);
             var query = ParseQuery(handler.LastRequest.RequestUri.Query);
             Assert.AreEqual("TI=Harry Potter", query["q"]);
             Assert.AreEqual("AU", query["sort"]);
@@ -124,23 +118,24 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task BibBooleanSearchAsync_ThroughInterfaceWithoutBranchId_UsesOrganizationId()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
-            IPapiClient client = CreateClient(handler);
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
+            var client = CreateClient(handler);
             client.OrganizationId = 42;
 
-            var response = await client.BibBooleanSearchAsync("TI=Default Branch");
+            var response = await client.BibBooleanSearchAsync("TI=Default Branch", cancellationToken: TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.IsNotNull(handler.LastRequest);
-            StringAssert.Contains(handler.LastRequest!.RequestUri!.AbsolutePath, "/public/v1/1033/100/42/search/bibs/boolean");
-            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/42/search/bibs/boolean?q=TI%3DDefault%20Branch&sort=MP&page=1&bibsperpage=10", handler.LastRequest.RequestUri.AbsoluteUri);
+            Assert.Contains("/public/v1/1033/100/42/search/bibs/boolean", handler.LastRequest!.RequestUri!.AbsolutePath);
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/42/search/bibs/boolean?q=TI%3DDefault%20Branch&sort=MP&page=1&bibsperpage=10";
+            Assert.AreEqual(expectedUri, handler.LastRequest.RequestUri.AbsoluteUri);
             AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
         }
 
         [TestMethod]
         public async Task BibSearchAsync_DefaultLimit_OmitsLimitAndHashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var options = new BibSearchOptions
             {
@@ -153,11 +148,12 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
                 PageSize = 15
             };
 
-            var response = await client.BibSearchAsync(options);
+            var response = await client.BibSearchAsync(options, TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.IsNotNull(handler.LastRequest);
-            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15";
+            Assert.AreEqual(expectedUri, handler.LastRequest!.RequestUri!.AbsoluteUri);
             var query = ParseQuery(handler.LastRequest.RequestUri.Query);
             Assert.IsFalse(query.ContainsKey("limit"));
             AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);

--- a/src/polaris-api-csharpTests/Methods/RequestShape/CreatePatronBlocksTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/CreatePatronBlocksTests.cs
@@ -14,21 +14,20 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
     [UnitTest]
     public class CreatePatronBlocksTests : PapiClientTestBase
     {
-
         [TestMethod]
         public async Task CreatePatronBlocks_EncodesBarcodeInProtectedRoute_PreservesTokenPath()
         {
-            var handler = new CaptureHttpMessageHandler();
+            var handler = new CapturingHttpMessageHandler();
             var client = CreateUrlEncodingClient(handler);
             var barcode = "AB C/+#?=";
             client.Token = new ProtectedToken
             {
                 AccessToken = "token-segment",
                 AccessSecret = "token-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
 
-            await client.CreatePatronBlocksAsync(barcode, BlockType.FreeText, "note", userId: 888, workstationId: 999);
+            await client.CreatePatronBlocksAsync(barcode, BlockType.FreeText, "note", userId: 888, workstationId: 999, TestContext.CancellationToken);
 
             var expectedPath = $"/PAPIService/REST/protected/v1/1033/100/1/token-segment/patron/{WebUtility.UrlEncode(barcode)}/blocks";
             var expectedQuery = "?wsid=999&userid=888";
@@ -36,6 +35,5 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
             Assert.IsNotNull(handler.LastRequest);
             Assert.AreEqual(expectedPath, handler.LastRequest!.RequestUri!.AbsolutePath);
             Assert.AreEqual(expectedQuery, handler.LastRequest.RequestUri.Query);
-        }
-    }
+        }}
 }

--- a/src/polaris-api-csharpTests/Methods/RequestShape/HoldRequestCancelTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/HoldRequestCancelTests.cs
@@ -16,11 +16,11 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task HoldRequestCancel_EncodesBarcode_PreservesWsidAndUseridQueryStringValues()
         {
-            var handler = new CaptureHttpMessageHandler();
+            var handler = new CapturingHttpMessageHandler();
             var client = CreateUrlEncodingClient(handler);
             var barcode = "AB C/+#?=";
 
-            await client.HoldRequestCancelAsync(barcode, 9876, "pin", userId: 888, workstationId: 999);
+            await client.HoldRequestCancelAsync(barcode, 9876, "pin", userId: 888, workstationId: 999, TestContext.CancellationToken);
 
             var expectedPath = $"/PAPIService/REST/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/9876/cancelled";
             var expectedQuery = "?wsid=999&userid=888";

--- a/src/polaris-api-csharpTests/Methods/RequestShape/NotificationQueueGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/NotificationQueueGetTests.cs
@@ -13,20 +13,19 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
     [UnitTest]
     public class NotificationQueueGetTests : PapiClientTestBase
     {
-
         [TestMethod]
         public async Task NotificationQueueGet_RequestsCorrectUrl()
         {
-            var handler = new CaptureHttpMessageHandler();
+            var handler = new CapturingHttpMessageHandler();
             var client = CreateUrlEncodingClient(handler);
             client.Token = new ProtectedToken
             {
                 AccessToken = "token-segment",
                 AccessSecret = "token-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
 
-            await client.NotificationQueueGetAsync(1);
+            await client.NotificationQueueGetAsync(1, TestContext.CancellationToken);
 
             var expectedPath = $"/PAPIService/REST/protected/v1/1033/24/1/token-segment/notification/";
             Assert.IsNotNull(handler.LastRequest);

--- a/src/polaris-api-csharpTests/Methods/RequestShape/PatronMessagesGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/PatronMessagesGetTests.cs
@@ -18,14 +18,14 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task PatronMessages_RequestShape_PreservesBooleanLikeQueryValue()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
 
-            var response = await client.PatronMessagesGetAsync("ABC 123", unreadOnly: true, password: "1234");
+            var response = await client.PatronMessagesGetAsync("ABC 123", unreadOnly: true, password: "1234", TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
-            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/public/v1/1033/100/1/patron/ABC+123/messages");
+            Assert.Contains("/public/v1/1033/100/1/patron/ABC+123/messages", handler.LastRequest.RequestUri!.AbsolutePath);
             var query = ParseQuery(handler.LastRequest.RequestUri.Query);
             Assert.AreEqual("1", query["unreadonly"]);
             Assert.IsNull(handler.LastRequest.Content);
@@ -46,7 +46,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
                 Password = "secret"
             };
 
-            var response = await client.PatronMessagesGetAsync("ABC123", password: "patron-password");
+            var response = await client.PatronMessagesGetAsync("ABC123", password: "patron-password", cancellationToken: TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(0, handler.AuthenticationRequestCount);
@@ -70,7 +70,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
                     AuthenticationRequestCount++;
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent("{}", Encoding.UTF8, "application/json")
+                        Content = new StringContent(CreateEmptyJsonObject(), Encoding.UTF8, "application/json")
                     });
                 }
 
@@ -86,7 +86,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
 
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                    Content = new StringContent(CreatePapiResponseJson(), Encoding.UTF8, "application/json")
                 });
             }
         }

--- a/src/polaris-api-csharpTests/Methods/RequestShape/PatronReadingHistoryClearTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/PatronReadingHistoryClearTests.cs
@@ -12,15 +12,14 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
     [UnitTest]
     public class PatronReadingHistoryClearTests : PapiClientTestBase
     {
-
         [TestMethod]
         public async Task PatronReadingHistoryClearAsync_EnumeratesIdsOnceAndSendsCommaSeparatedIds()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var ids = new ThrowOnSecondEnumerationEnumerable(new[] { 101, 202, 303 });
 
-            var response = await client.PatronReadingHistoryClearAsync("ABC123", "patron-password", ids);
+            var response = await client.PatronReadingHistoryClearAsync("ABC123", "patron-password", ids, TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(1, ids.EnumerationCount);

--- a/src/polaris-api-csharpTests/Methods/RequestShape/PatronSearchTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/PatronSearchTests.cs
@@ -12,23 +12,22 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
     [UnitTest]
     public class PatronSearchTests : PapiClientTestBase
     {
-
-
         [TestMethod]
         public async Task PatronSearch_RequestShape_PreservesEncodedQuerySemantics()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
-            client.Token = new ProtectedToken { AccessToken = "token", AccessSecret = "secret", ExpirationDate = DateTime.Now.AddHours(1) };
+            client.Token = new ProtectedToken { AccessToken = "token", AccessSecret = "secret", ExpirationDate = ValidProtectedTokenExpirationDate };
 
-            var response = await client.PatronSearchAsync("name = Smith & status: active", page: 3, pageSize: 25, sortBy: PatronSortKeys.PATNL, orgId: 9);
+            var response = await client.PatronSearchAsync("name = Smith & status: active", page: 3, pageSize: 25, sortBy: PatronSortKeys.PATNL, orgId: 9, TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
-            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/protected/v1/1033/100/9/token/search/patrons/Boolean");
+            Assert.Contains("/protected/v1/1033/100/9/token/search/patrons/Boolean", handler.LastRequest.RequestUri!.AbsolutePath);
             var query = ParseQuery(handler.LastRequest.RequestUri.Query);
             Assert.AreEqual("name = Smith & status: active", query["q"]);
-            Assert.AreEqual("25", query["patronsperpage"]);
+            Assert.AreEqual("25", query["patrons" +
+                "perpage"]);
             Assert.AreEqual("3", query["page"]);
             Assert.AreEqual("PATNL", query["sort"]);
             Assert.IsNull(handler.LastRequest.Content);

--- a/src/polaris-api-csharpTests/Methods/RequestShape/PatronUpdateTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/PatronUpdateTests.cs
@@ -12,26 +12,25 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
     [UnitTest]
     public class PatronUpdateTests : PapiClientTestBase
     {
-
         [TestMethod]
         public async Task PatronUpdate_RequestShape_IsStable()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
 
-            var response = await client.PatronUpdateAsync("AB C/+#?=", new PatronUpdateParams { EmailAddress = "patron@example.test" }, "1234", ignoresa: true);
+            var response = await client.PatronUpdateAsync("AB C/+#?=", new PatronUpdateParams { EmailAddress = "patron@example.test" }, "1234", ignoresa: true, TestContext.CancellationToken);
 
             Assert.IsNotNull(response);
             Assert.AreEqual(HttpMethod.Put, handler.LastRequest!.Method);
             var encodedBarcode = WebUtility.UrlEncode("AB C/+#?=");
-            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, $"/public/v1/1033/100/1/patron/{encodedBarcode}");
+            Assert.Contains($"/public/v1/1033/100/1/patron/{encodedBarcode}", handler.LastRequest.RequestUri!.AbsolutePath);
             var query = ParseQuery(handler.LastRequest.RequestUri.Query);
             Assert.AreEqual("True", query["ignoresa"]);
             Assert.IsNotNull(handler.LastRequest.Content);
             Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
             Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
             Assert.IsNotNull(handler.LastRequestContent);
-            StringAssert.Contains(handler.LastRequestContent, "patron@example.test");
+            Assert.Contains("patron@example.test", handler.LastRequestContent);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/RequestShape/PatronUpdateUserNameTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/PatronUpdateUserNameTests.cs
@@ -16,12 +16,12 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task PatronUpdateUserName_EncodesBarcodeAndNewUsername()
         {
-            var handler = new CaptureHttpMessageHandler();
+            var handler = new CapturingHttpMessageHandler();
             var client = CreateUrlEncodingClient(handler);
             var barcode = "AB C/+#?=";
             var newUsername = "new user+/name?=";
 
-            await client.PatronUpdateUserNameAsync(barcode, newUsername, "pin");
+            await client.PatronUpdateUserNameAsync(barcode, newUsername, "pin", TestContext.CancellationToken);
 
             var expectedPath = $"/PAPIService/REST/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/username/{WebUtility.UrlEncode(newUsername)}";
             Assert.IsNotNull(handler.LastRequest);

--- a/src/polaris-api-csharpTests/Methods/RequestShape/PatronValidateTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/PatronValidateTests.cs
@@ -16,11 +16,11 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task PatronValidate_NormalBarcode_PreservesBarcodePath()
         {
-            var handler = new CaptureHttpMessageHandler();
+            var handler = new CapturingHttpMessageHandler();
             var client = CreateUrlEncodingClient(handler);
             var barcode = "21945001234567";
 
-            await client.PatronValidateAsync(barcode, "pin");
+            await client.PatronValidateAsync(barcode, "pin", TestContext.CancellationToken);
 
             var expectedPath = $"/PAPIService/REST/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}";
             Assert.IsNotNull(handler.LastRequest);
@@ -31,11 +31,11 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task PatronValidate_SpecialCharacters_EncodesBarcodePathSegment()
         {
-            var handler = new CaptureHttpMessageHandler();
+            var handler = new CapturingHttpMessageHandler();
             var client = CreateUrlEncodingClient(handler);
             var barcode = "AB C/+#?=";
 
-            await client.PatronValidateAsync(barcode, "pin");
+            await client.PatronValidateAsync(barcode, "pin", TestContext.CancellationToken);
 
             var expectedPath = $"/PAPIService/REST/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}";
             Assert.IsNotNull(handler.LastRequest);

--- a/src/polaris-api-csharpTests/Methods/RequestShape/Patron_GetBarcodeFromIdTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/Patron_GetBarcodeFromIdTests.cs
@@ -13,21 +13,20 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
     [UnitTest]
     public class Patron_GetBarcodeFromIdTests : PapiClientTestBase
     {
-
         [TestMethod]
         public async Task Patron_GetBarcodeFromId_FormatsUrlCorrectly()
         {
-            var handler = new CaptureHttpMessageHandler();
+            var handler = new CapturingHttpMessageHandler();
             var client = CreateUrlEncodingClient(handler);
             var patronId = 12345;
             client.Token = new ProtectedToken
             {
                 AccessToken = "token-segment",
                 AccessSecret = "token-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
 
-            await client.Patron_GetBarcodeFromIdAsync(patronId);
+            await client.Patron_GetBarcodeFromIdAsync(patronId, TestContext.CancellationToken);
 
             var expectedPath = "/PAPIService/REST/protected/v1/1033/100/1/token-segment/patron/barcode";
             var expectedQuery = $"?patronid={patronId}";

--- a/src/polaris-api-csharpTests/Methods/RequestShape/UpdatePickupBranchIDTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/UpdatePickupBranchIDTests.cs
@@ -16,13 +16,13 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task UpdatePickupBranchID_EncodesBarcodeAndConstructsQuery()
         {
-            var handler = new CaptureHttpMessageHandler();
+            var handler = new CapturingHttpMessageHandler();
             var client = CreateUrlEncodingClient(handler);
             var barcode = "AB C/+#?=";
             var requestId = 1234;
             var pickupBranchId = 5678;
 
-            await client.UpdatePickupBranchIDAsync(barcode, requestId, pickupBranchId, "pin", userId: 888, workstationId: 999);
+            await client.UpdatePickupBranchIDAsync(barcode, requestId, pickupBranchId, "pin", userId: 888, workstationId: 999, TestContext.CancellationToken);
 
             var expectedPath = $"/PAPIService/REST/public/v1/1033/100/1/patron/{WebUtility.UrlEncode(barcode)}/holdrequests/{requestId}/pickupbranch";
             var expectedQuery = $"?userid=888&wsid=999&pickupbranchid={pickupBranchId}";

--- a/src/polaris-api-csharpTests/Methods/SA_GetValueByOrgTests.cs
+++ b/src/polaris-api-csharpTests/Methods/SA_GetValueByOrgTests.cs
@@ -11,8 +11,8 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.SA_GetValueByOrgAsync("ORGEMAIL");
-            Assert.IsTrue(response.Data.Value == Settings.OrgEmail);
+            var response = await Papi.SA_GetValueByOrgAsync("ORGEMAIL", cancellationToken: TestContext.CancellationToken);
+            Assert.AreEqual(Settings.OrgEmail, response.Data.Value);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/ShelfLocationsGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ShelfLocationsGetTests.cs
@@ -10,8 +10,8 @@ namespace Clc.Polaris.Api.Tests
         [ReadOnlyIntegrationTest]
         public async Task ShelfLocationsGetTest()
         {
-            var response = await Papi.ShelfLocationsGetAsync(7);
-            Assert.IsTrue(response.Data.PAPIErrorCode == response.Data.ShelfLocationsRows.Count());
+            var response = await Papi.ShelfLocationsGetAsync(7, TestContext.CancellationToken);
+            Assert.HasCount(response.Data.PAPIErrorCode, response.Data.ShelfLocationsRows);
         }
     }
 }

--- a/src/polaris-api-csharpTests/Methods/Synch_BibsByIdGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/Synch_BibsByIdGetTests.cs
@@ -11,7 +11,7 @@ namespace Clc.Polaris.Api.Tests
         {
             IntegrationTestRequirements.RequireStaffOverrideAccount(PapiSettings);
 
-            var response = await Papi.Synch_BibsByIdGetAsync(478907);
+            var response = await Papi.Synch_BibsByIdGetAsync(478907, cancellationToken: TestContext.CancellationToken);
             Assert.IsTrue(response.Response.IsSuccessStatusCode);
         }
     }

--- a/src/polaris-api-csharpTests/Models/PapiRestRequestConstructorTests.cs
+++ b/src/polaris-api-csharpTests/Models/PapiRestRequestConstructorTests.cs
@@ -36,10 +36,7 @@ namespace Clc.Polaris.Api.Tests.Models
         [TestMethod]
         public void PapiRestRequest_CopyConstructor_PreservesValuesWithoutSharingMutableCollections()
         {
-            var request = PapiRestRequest.Post(
-                "/protected/v1/1033/100/1/test",
-                new { Value = 1 },
-                "password");
+            var request = PapiRestRequest.Post("/protected/v1/1033/100/1/test", new { Value = 1 }, "password");
 
             request.AuthRequired = false;
             request.JsonSerializerIgnoreNulls = false;

--- a/src/polaris-api-csharpTests/PapiClientBehavior/AuthenticateStaffUserTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/AuthenticateStaffUserTests.cs
@@ -23,16 +23,16 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task AuthenticateStaffUserAsync_ReturnsTokenButDoesNotSetClientToken()
         {
-            var handler = new CapturingHttpMessageHandler(CreateProtectedTokenJson("returned-token", "returned-secret", DateTime.Now.AddHours(1)));
+            var handler = new CapturingHttpMessageHandler(CreateProtectedTokenJson(accessToken: "returned-token", accessSecret: "returned-secret", expirationDate: ValidProtectedTokenExpirationDate));
             var client = CreateClient(handler);
             client.Token = new ProtectedToken
             {
                 AccessToken = "existing-token",
                 AccessSecret = "existing-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
 
-            var response = await client.AuthenticateStaffUserAsync(CreateStaffUser());
+            var response = await client.AuthenticateStaffUserAsync(CreateStaffUser(), TestContext.CancellationToken);
 
             Assert.IsNotNull(response.Data);
             Assert.AreEqual("returned-token", response.Data.AccessToken);
@@ -41,7 +41,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             Assert.AreEqual(1, handler.RequestCount);
             Assert.IsNotNull(handler.LastRequest);
             Assert.AreEqual(HttpMethod.Post, handler.LastRequest.Method);
-            StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/protected/v1/1033/100/1/authenticator/staff");
+            Assert.Contains("/protected/v1/1033/100/1/authenticator/staff", handler.LastRequest.RequestUri!.AbsolutePath);
             Assert.IsTrue(handler.LastRequest.Headers.Contains("PolarisDate"));
             Assert.IsTrue(handler.LastRequest.Headers.Contains("Authorization"));
             Assert.IsFalse(handler.LastRequest.Headers.Contains("X-PAPI-AccessToken"));
@@ -53,7 +53,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var handler = new ProtectedTokenHttpMessageHandler();
             var client = CreateProtectedClient(handler);
 
-            var response = await client.AuthenticateStaffUserAsync(CreateStaffUser());
+            var response = await client.AuthenticateStaffUserAsync(CreateStaffUser(), TestContext.CancellationToken);
 
             Assert.IsNotNull(response.Data);
             Assert.AreEqual("protected-token", response.Data.AccessToken);
@@ -63,7 +63,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var request = handler.CapturedRequests.Single();
             Assert.IsTrue(request.IsStaffAuthenticationRequest);
             Assert.AreEqual("POST", request.Method);
-            StringAssert.EndsWith(request.Path, "/protected/v1/1033/100/1/authenticator/staff");
+            Assert.EndsWith("/protected/v1/1033/100/1/authenticator/staff", request.Path);
             AssertAuthorizationHash(request, string.Empty, client.AccessKey, client.AccessID);
         }
     }

--- a/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiContractTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiContractTests.cs
@@ -46,10 +46,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
 
         private static bool InvokeIsStaffAuthenticatorRequest(PapiRestRequest? request)
         {
-            var isStaffAuthenticatorRequest = typeof(PapiClient)
-                .GetMethod("IsStaffAuthenticatorRequest", BindingFlags.Static | BindingFlags.NonPublic)!;
-
-            return (bool)isStaffAuthenticatorRequest.Invoke(null, new object?[] { request })!;
+            return PapiRequestClassifier.IsStaffAuthenticatorRequest(request);
         }
 
         private static PapiRestRequest CreateStaffAuthenticatorRequestWithPath(string? path)

--- a/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs
@@ -24,9 +24,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_ProtectedRequestWithoutPlaceholderOrPassword_AcquiresProtectedToken()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson("route-token", "route-secret", DateTime.Now.AddHours(1)));
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: "route-token", accessSecret: "route-secret", expirationDate: ValidProtectedTokenExpirationDate));
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get("/protected/v1/1033/100/1/patron/ABC123/account/outstanding");
 
@@ -45,7 +43,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         {
             var handler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.OK,
-                CreateProtectedTokenJson("malformed-token", "malformed-secret", DateTime.Now.AddHours(1)));
+                CreateProtectedTokenJson(accessToken: "malformed-token", accessSecret: "malformed-secret", expirationDate: ValidProtectedTokenExpirationDate));
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Post("/protected/v1/1033/100/1/authenticator/staff/extra");
 
@@ -137,9 +135,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var handler = new ProtectedTokenHttpMessageHandler();
             var client = CreateProtectedClient(handler);
             client.StaffOverrideAccount = null;
-            var request = PapiRestRequest.Post(
-                "/public/v1/1033/100/1/custom/unsupported",
-                body: new { Message = "custom-body", Count = 3 });
+            var request = PapiRestRequest.Post("/public/v1/1033/100/1/custom/unsupported", body: new { Message = "custom-body", Count = 3 });
 
             await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
@@ -157,7 +153,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         {
             var handler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.OK,
-                CreateProtectedTokenJson("custom-placeholder-token", "custom-placeholder-secret", DateTime.Now.AddHours(1)));
+                CreateProtectedTokenJson(accessToken: "custom-placeholder-token", accessSecret: "custom-placeholder-secret", expirationDate: ValidProtectedTokenExpirationDate));
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
 
@@ -176,7 +172,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         {
             var handler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.OK,
-                CreateProtectedTokenJson("custom-placeholder-token", "custom-placeholder-secret", DateTime.Now.AddHours(1)));
+                CreateProtectedTokenJson(accessToken: "custom-placeholder-token", accessSecret: "custom-placeholder-secret", expirationDate: ValidProtectedTokenExpirationDate));
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
             var originalPath = request.Path;
@@ -191,9 +187,9 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         {
             var handler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.OK,
-                CreateProtectedTokenJson("error-path-token", "error-path-secret", DateTime.Now.AddHours(1)),
+                CreateProtectedTokenJson(accessToken: "error-path-token", accessSecret: "error-path-secret", expirationDate: ValidProtectedTokenExpirationDate),
                 HttpStatusCode.InternalServerError,
-                "{\"PAPIErrorCode\":1}");
+                CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
             var originalPath = request.Path;
@@ -210,9 +206,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_CustomPublicPatronRequest_UsesStaffOverrideTokenWhenAllowed()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson("override-token", "override-secret", DateTime.Now.AddHours(1)));
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: "override-token", accessSecret: "override-secret", expirationDate: ValidProtectedTokenExpirationDate));
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get("/public/v1/1033/100/1/patron/ABC123/basicdata");
 
@@ -246,9 +240,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_CustomPublicNonPatronRequest_WithStaffOverrideConfigured_DoesNotAcquireProtectedToken()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.Unauthorized,
-                "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.Unauthorized, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get("/public/v1/1033/100/1/api");
 
@@ -265,13 +257,9 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_CustomPublicPatronRequestWithPassword_DoesNotAcquireStaffOverrideToken()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.Unauthorized,
-                "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.Unauthorized, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
-            var request = PapiRestRequest.Get(
-                "/public/v1/1033/100/1/patron/ABC123/basicdata",
-                password: "patron-password");
+            var request = PapiRestRequest.Get("/public/v1/1033/100/1/patron/ABC123/basicdata", password: "patron-password");
 
             await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
@@ -286,9 +274,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_CustomPublicPatronNamedLookupRequest_DoesNotAcquireProtectedToken()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.Unauthorized,
-                "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.Unauthorized, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get("/public/v1/1033/100/1/patronlanguages");
 
@@ -300,8 +286,5 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var finalRequest = handler.CapturedRequests.Single();
             Assert.IsFalse(finalRequest.Headers.ContainsKey("X-PAPI-AccessToken"));
             AssertAuthorizationHash(finalRequest, string.Empty, client.AccessKey, client.AccessID);
-        }
-
-        public TestContext TestContext { get; set; }
-    }
+        }}
 }

--- a/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiQueryParameterTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiQueryParameterTests.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_QueryParameterWithNullValue_OmitsParameterAndHashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
             request.QueryParameters.Add("q", "harry potter");
@@ -33,7 +33,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_QueryParameterWithEmptyStringValue_OmitsParameterAndHashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
             request.QueryParameters.Add("q", "harry potter");
@@ -51,7 +51,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_QueryParameterWithWhitespaceValue_OmitsParameterAndHashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
             request.QueryParameters.Add("q", "harry potter");
@@ -69,7 +69,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_QueryParameterWithBlankKey_OmitsParameterAndHashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
             request.QueryParameters.Add("q", "harry potter");
@@ -80,7 +80,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             Assert.IsNotNull(handler.LastRequest);
             Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter", handler.LastRequest!.RequestUri!.AbsoluteUri);
             var query = ParseQuery(handler.LastRequest.RequestUri.Query);
-            Assert.AreEqual(1, query.Count);
+            Assert.HasCount(1, query);
             Assert.IsTrue(query.ContainsKey("q"));
             AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
         }
@@ -88,7 +88,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_OnlyIneffectiveQueryParameters_OmitsQueryStringAndHashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
             request.QueryParameters.Add(" ", "blank key");
@@ -112,7 +112,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
                 CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
-                var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+                var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
                 var client = CreateClient(handler);
                 var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
                 request.QueryParameters.Add("amount", 12.34m);
@@ -133,7 +133,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_NonEmptyQueryParameters_HashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
             request.QueryParameters.Add("q", "harry potter & stone");
@@ -149,7 +149,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_ExistingQueryString_AppendsQueryParametersAndHashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW?existing=1");
             request.QueryParameters.Add("q", "harry potter");

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientConfigurationValidationTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientConfigurationValidationTests.cs
@@ -22,7 +22,7 @@ namespace Clc.Polaris.Api.Tests
 
             var exception = Assert.ThrowsExactly<InvalidOperationException>(() => client.PreformatRestRequest(request));
 
-            StringAssert.Contains(exception.Message, nameof(PapiClient.Hostname));
+            Assert.Contains(nameof(PapiClient.Hostname), exception.Message);
         }
 
         [TestMethod]
@@ -40,7 +40,7 @@ namespace Clc.Polaris.Api.Tests
 
             var exception = Assert.ThrowsExactly<InvalidOperationException>(() => client.PreformatRestRequest(request));
 
-            StringAssert.Contains(exception.Message, nameof(PapiClient.AccessID));
+            Assert.Contains(nameof(PapiClient.AccessID), exception.Message);
         }
 
         [TestMethod]
@@ -58,7 +58,7 @@ namespace Clc.Polaris.Api.Tests
 
             var exception = Assert.ThrowsExactly<InvalidOperationException>(() => client.PreformatRestRequest(request));
 
-            StringAssert.Contains(exception.Message, nameof(PapiClient.AccessKey));
+            Assert.Contains(nameof(PapiClient.AccessKey), exception.Message);
         }
 
         [TestMethod]
@@ -76,7 +76,7 @@ namespace Clc.Polaris.Api.Tests
 
             var exception = Assert.ThrowsExactly<InvalidOperationException>(() => client.PreformatRestRequest(request));
 
-            StringAssert.Contains(exception.Message, nameof(PapiClient.Hostname));
+            Assert.Contains(nameof(PapiClient.Hostname), exception.Message);
         }
 
         [TestMethod]
@@ -94,7 +94,7 @@ namespace Clc.Polaris.Api.Tests
 
             var exception = Assert.ThrowsExactly<InvalidOperationException>(() => client.PreformatRestRequest(request));
 
-            StringAssert.Contains(exception.Message, nameof(PapiClient.Hostname));
+            Assert.Contains(nameof(PapiClient.Hostname), exception.Message);
         }
 
         [TestMethod]
@@ -114,7 +114,7 @@ namespace Clc.Polaris.Api.Tests
 
             Assert.IsTrue(formattedRequest.Headers.ContainsKey("PolarisDate"));
             Assert.IsTrue(formattedRequest.Headers.ContainsKey("Authorization"));
-            StringAssert.StartsWith(formattedRequest.Headers["Authorization"], "PWS access-id:");
+            Assert.StartsWith("PWS access-id:", formattedRequest.Headers["Authorization"]);
         }
     }
 }

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientProtectedTokenCacheLockTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientProtectedTokenCacheLockTests.cs
@@ -1,7 +1,4 @@
-﻿using Clc.Polaris.Api.Tests;
-using Clc.Polaris.Api.Tests.TestInfrastructure;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -9,6 +6,9 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Clc.Polaris.Api.Tests;
+using Clc.Polaris.Api.Tests.TestInfrastructure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Clc.Polaris.Api.Tests.PapiClientBehavior
 {
@@ -91,9 +91,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             public int NonAuthenticationRequestCount => _nonAuthenticationRequestCount;
             public List<HttpRequestMessage> ProtectedRequests { get; } = [];
 
-            protected override async Task<HttpResponseMessage> SendAsync(
-                HttpRequestMessage request,
-                CancellationToken cancellationToken)
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 if (request.RequestUri!.AbsolutePath.Contains("/authenticator/staff", StringComparison.Ordinal))
                 {
@@ -108,21 +106,17 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
                         BlockedAuthenticationStarted.TrySetResult();
                         await CompleteBlockedAuthentication.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
 
+                        var responseJson = CreateProtectedTokenJson(accessToken: "blocked-token", accessSecret: "blocked-secret", expirationDate: ValidProtectedTokenExpirationDate);
                         return new HttpResponseMessage(HttpStatusCode.OK)
                         {
-                            Content = new StringContent(
-                                "{\"PAPIErrorCode\":0,\"AccessToken\":\"blocked-token\",\"AccessSecret\":\"blocked-secret\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}",
-                                Encoding.UTF8,
-                                "application/json")
+                            Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
                         };
                     }
 
+                    var independentResponseJson = CreateProtectedTokenJson(accessToken: "independent-token", accessSecret: "independent-secret", expirationDate: ValidProtectedTokenExpirationDate);
                     return new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent(
-                            "{\"PAPIErrorCode\":0,\"AccessToken\":\"independent-token\",\"AccessSecret\":\"independent-secret\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}",
-                            Encoding.UTF8,
-                            "application/json")
+                        Content = new StringContent(independentResponseJson, Encoding.UTF8, "application/json")
                     };
                 }
 
@@ -135,11 +129,9 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
 
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                    Content = new StringContent(CreatePapiResponseJson(), Encoding.UTF8, "application/json")
                 };
             }
         }
-
-        public TestContext TestContext { get; set; } = null!;
     }
 }

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientProtectedTokenCacheLockTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientProtectedTokenCacheLockTests.cs
@@ -30,37 +30,20 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
 
             try
             {
-                blockedRequest = blockedClient.PatronSearchAsync(
-                    "name=Blocked",
-                    orgId: 9,
-                    cancellationToken: TestContext.CancellationToken);
+                blockedRequest = blockedClient.PatronSearchAsync("name=Blocked", orgId: 9, cancellationToken: TestContext.CancellationToken);
+                await handler.BlockedAuthenticationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
 
-                await handler.BlockedAuthenticationStarted.Task.WaitAsync(
-                    TimeSpan.FromSeconds(5),
-                    TestContext.CancellationToken);
+                independentRequest = independentClient.PatronSearchAsync("name=Independent", orgId: 9, cancellationToken: TestContext.CancellationToken);
+                var completed = await Task.WhenAny(independentRequest, Task.Delay(TimeSpan.FromSeconds(1), TestContext.CancellationToken));
 
-                independentRequest = independentClient.PatronSearchAsync(
-                    "name=Independent",
-                    orgId: 9,
-                    cancellationToken: TestContext.CancellationToken);
-
-                var completed = await Task.WhenAny(
-                    independentRequest,
-                    Task.Delay(TimeSpan.FromSeconds(1), TestContext.CancellationToken));
-
-                Assert.AreSame(
-                    independentRequest,
-                    completed,
-                    "An authentication request for a different protected-token cache key should not wait behind the blocked cache key.");
+                Assert.AreSame(independentRequest, completed, "An authentication request for a different protected-token cache key should not wait behind the blocked cache key.");
 
                 await independentRequest.ConfigureAwait(false);
 
                 Assert.IsTrue(independentRequest.IsCompletedSuccessfully);
                 Assert.AreEqual(2, handler.AuthenticationRequestCount);
                 Assert.AreEqual(1, handler.NonAuthenticationRequestCount);
-                Assert.Contains(
-                    "/protected/v1/1033/100/9/independent-token/search/patrons/Boolean",
-                    handler.ProtectedRequests.Single().RequestUri!.AbsolutePath);
+                Assert.Contains("/protected/v1/1033/100/9/independent-token/search/patrons/Boolean", handler.ProtectedRequests.Single().RequestUri!.AbsolutePath);
 
                 handler.CompleteBlockedAuthentication.TrySetResult();
 
@@ -101,11 +84,8 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             private int _authenticationRequestCount;
             private int _nonAuthenticationRequestCount;
 
-            public TaskCompletionSource BlockedAuthenticationStarted { get; } =
-                new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-            public TaskCompletionSource CompleteBlockedAuthentication { get; } =
-                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            public TaskCompletionSource BlockedAuthenticationStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            public TaskCompletionSource CompleteBlockedAuthentication { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
             public int AuthenticationRequestCount => _authenticationRequestCount;
             public int NonAuthenticationRequestCount => _nonAuthenticationRequestCount;

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientProtectedTokenCacheTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientProtectedTokenCacheTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Clc.Polaris.Api.Models;
+using Clc.Polaris.Api.Tests.TestInfrastructure;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Clc.Polaris.Api.Tests
@@ -7,7 +8,7 @@ namespace Clc.Polaris.Api.Tests
     [TestClass]
     [UnitTest]
     [DoNotParallelize]
-    public sealed class PapiClientProtectedTokenCacheTests
+    public sealed class PapiClientProtectedTokenCacheTests : PapiClientTestBase
     {
         [TestInitialize]
         public void TestInitialize()
@@ -24,8 +25,8 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod]
         public void PruneProtectedTokenCache_RemovesExpiredToken()
         {
-            ProtectedTokenCache.AddForTesting("expired", CreateToken(DateTime.UtcNow.AddMinutes(-5)));
-            ProtectedTokenCache.AddForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
+            ProtectedTokenCache.AddForTesting("expired", CreateToken(ExpiredProtectedTokenExpirationDate));
+            ProtectedTokenCache.AddForTesting("valid", CreateToken(ValidProtectedTokenExpirationDate));
 
             var removedCount = ProtectedTokenCache.PruneExpired();
 
@@ -38,7 +39,7 @@ namespace Clc.Polaris.Api.Tests
         public void PruneProtectedTokenCache_RemovesTokenWithoutExpirationDate()
         {
             ProtectedTokenCache.AddForTesting("missing-expiration", CreateToken(expirationDate: null));
-            ProtectedTokenCache.AddForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
+            ProtectedTokenCache.AddForTesting("valid", CreateToken(ValidProtectedTokenExpirationDate));
 
             var removedCount = ProtectedTokenCache.PruneExpired();
 
@@ -50,8 +51,8 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod]
         public void PruneProtectedTokenCache_RemovesTokenWithoutAccessToken()
         {
-            ProtectedTokenCache.AddForTesting("missing-access-token", CreateToken(DateTime.UtcNow.AddMinutes(5), accessToken: ""));
-            ProtectedTokenCache.AddForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
+            ProtectedTokenCache.AddForTesting("missing-access-token", CreateToken(ValidProtectedTokenExpirationDate, accessToken: ""));
+            ProtectedTokenCache.AddForTesting("valid", CreateToken(ValidProtectedTokenExpirationDate));
 
             var removedCount = ProtectedTokenCache.PruneExpired();
 
@@ -63,8 +64,8 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod]
         public void PruneProtectedTokenCache_RemovesTokenWithoutAccessSecret()
         {
-            ProtectedTokenCache.AddForTesting("missing-access-secret", CreateToken(DateTime.UtcNow.AddMinutes(5), accessSecret: ""));
-            ProtectedTokenCache.AddForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
+            ProtectedTokenCache.AddForTesting("missing-access-secret", CreateToken(ValidProtectedTokenExpirationDate, accessSecret: ""));
+            ProtectedTokenCache.AddForTesting("valid", CreateToken(ValidProtectedTokenExpirationDate));
 
             var removedCount = ProtectedTokenCache.PruneExpired();
 
@@ -77,7 +78,7 @@ namespace Clc.Polaris.Api.Tests
         public void PruneProtectedTokenCache_RemovesTokenInsideExpirationSkew()
         {
             ProtectedTokenCache.AddForTesting("inside-skew", CreateToken(DateTime.UtcNow.AddSeconds(30)));
-            ProtectedTokenCache.AddForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
+            ProtectedTokenCache.AddForTesting("valid", CreateToken(ValidProtectedTokenExpirationDate));
 
             var removedCount = ProtectedTokenCache.PruneExpired();
 
@@ -89,8 +90,8 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod]
         public void PruneProtectedTokenCache_DoesNotRemoveUsableTokens()
         {
-            ProtectedTokenCache.AddForTesting("valid-1", CreateToken(DateTime.UtcNow.AddMinutes(5)));
-            ProtectedTokenCache.AddForTesting("valid-2", CreateToken(DateTime.UtcNow.AddMinutes(10)));
+            ProtectedTokenCache.AddForTesting("valid-1", CreateToken(ValidProtectedTokenExpirationDate));
+            ProtectedTokenCache.AddForTesting("valid-2", CreateToken(ValidProtectedTokenExpirationDate));
 
             var removedCount = ProtectedTokenCache.PruneExpired();
 
@@ -99,10 +100,7 @@ namespace Clc.Polaris.Api.Tests
             Assert.IsTrue(ProtectedTokenCache.ContainsKey("valid-2"));
         }
 
-        private static ProtectedToken CreateToken(
-            DateTime? expirationDate,
-            string accessToken = "access-token",
-            string accessSecret = "access-secret")
+        private static ProtectedToken CreateToken(DateTime? expirationDate, string accessToken = "access-token", string accessSecret = "access-secret")
         {
             return new ProtectedToken
             {

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientProtectedTokenCacheTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientProtectedTokenCacheTests.cs
@@ -12,97 +12,97 @@ namespace Clc.Polaris.Api.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            PapiClient.ClearProtectedTokenCache();
+            ProtectedTokenCache.ClearForTesting();
         }
 
         [TestCleanup]
         public void TestCleanup()
         {
-            PapiClient.ClearProtectedTokenCache();
+            ProtectedTokenCache.ClearForTesting();
         }
 
         [TestMethod]
         public void PruneProtectedTokenCache_RemovesExpiredToken()
         {
-            PapiClient.AddProtectedTokenToCacheForTesting("expired", CreateToken(DateTime.UtcNow.AddMinutes(-5)));
-            PapiClient.AddProtectedTokenToCacheForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
+            ProtectedTokenCache.AddForTesting("expired", CreateToken(DateTime.UtcNow.AddMinutes(-5)));
+            ProtectedTokenCache.AddForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
 
-            var removedCount = PapiClient.PruneProtectedTokenCache();
+            var removedCount = ProtectedTokenCache.PruneExpired();
 
             Assert.AreEqual(1, removedCount);
-            Assert.IsFalse(PapiClient.ProtectedTokenCacheContainsKey("expired"));
-            Assert.IsTrue(PapiClient.ProtectedTokenCacheContainsKey("valid"));
+            Assert.IsFalse(ProtectedTokenCache.ContainsKey("expired"));
+            Assert.IsTrue(ProtectedTokenCache.ContainsKey("valid"));
         }
 
         [TestMethod]
         public void PruneProtectedTokenCache_RemovesTokenWithoutExpirationDate()
         {
-            PapiClient.AddProtectedTokenToCacheForTesting("missing-expiration", CreateToken(expirationDate: null));
-            PapiClient.AddProtectedTokenToCacheForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
+            ProtectedTokenCache.AddForTesting("missing-expiration", CreateToken(expirationDate: null));
+            ProtectedTokenCache.AddForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
 
-            var removedCount = PapiClient.PruneProtectedTokenCache();
+            var removedCount = ProtectedTokenCache.PruneExpired();
 
             Assert.AreEqual(1, removedCount);
-            Assert.IsFalse(PapiClient.ProtectedTokenCacheContainsKey("missing-expiration"));
-            Assert.IsTrue(PapiClient.ProtectedTokenCacheContainsKey("valid"));
+            Assert.IsFalse(ProtectedTokenCache.ContainsKey("missing-expiration"));
+            Assert.IsTrue(ProtectedTokenCache.ContainsKey("valid"));
         }
 
         [TestMethod]
         public void PruneProtectedTokenCache_RemovesTokenWithoutAccessToken()
         {
-            PapiClient.AddProtectedTokenToCacheForTesting(
+            ProtectedTokenCache.AddForTesting(
                 "missing-access-token",
                 CreateToken(DateTime.UtcNow.AddMinutes(5), accessToken: ""));
 
-            PapiClient.AddProtectedTokenToCacheForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
+            ProtectedTokenCache.AddForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
 
-            var removedCount = PapiClient.PruneProtectedTokenCache();
+            var removedCount = ProtectedTokenCache.PruneExpired();
 
             Assert.AreEqual(1, removedCount);
-            Assert.IsFalse(PapiClient.ProtectedTokenCacheContainsKey("missing-access-token"));
-            Assert.IsTrue(PapiClient.ProtectedTokenCacheContainsKey("valid"));
+            Assert.IsFalse(ProtectedTokenCache.ContainsKey("missing-access-token"));
+            Assert.IsTrue(ProtectedTokenCache.ContainsKey("valid"));
         }
 
         [TestMethod]
         public void PruneProtectedTokenCache_RemovesTokenWithoutAccessSecret()
         {
-            PapiClient.AddProtectedTokenToCacheForTesting(
+            ProtectedTokenCache.AddForTesting(
                 "missing-access-secret",
                 CreateToken(DateTime.UtcNow.AddMinutes(5), accessSecret: ""));
 
-            PapiClient.AddProtectedTokenToCacheForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
+            ProtectedTokenCache.AddForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
 
-            var removedCount = PapiClient.PruneProtectedTokenCache();
+            var removedCount = ProtectedTokenCache.PruneExpired();
 
             Assert.AreEqual(1, removedCount);
-            Assert.IsFalse(PapiClient.ProtectedTokenCacheContainsKey("missing-access-secret"));
-            Assert.IsTrue(PapiClient.ProtectedTokenCacheContainsKey("valid"));
+            Assert.IsFalse(ProtectedTokenCache.ContainsKey("missing-access-secret"));
+            Assert.IsTrue(ProtectedTokenCache.ContainsKey("valid"));
         }
 
         [TestMethod]
         public void PruneProtectedTokenCache_RemovesTokenInsideExpirationSkew()
         {
-            PapiClient.AddProtectedTokenToCacheForTesting("inside-skew", CreateToken(DateTime.UtcNow.AddSeconds(30)));
-            PapiClient.AddProtectedTokenToCacheForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
+            ProtectedTokenCache.AddForTesting("inside-skew", CreateToken(DateTime.UtcNow.AddSeconds(30)));
+            ProtectedTokenCache.AddForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
 
-            var removedCount = PapiClient.PruneProtectedTokenCache();
+            var removedCount = ProtectedTokenCache.PruneExpired();
 
             Assert.AreEqual(1, removedCount);
-            Assert.IsFalse(PapiClient.ProtectedTokenCacheContainsKey("inside-skew"));
-            Assert.IsTrue(PapiClient.ProtectedTokenCacheContainsKey("valid"));
+            Assert.IsFalse(ProtectedTokenCache.ContainsKey("inside-skew"));
+            Assert.IsTrue(ProtectedTokenCache.ContainsKey("valid"));
         }
 
         [TestMethod]
         public void PruneProtectedTokenCache_DoesNotRemoveUsableTokens()
         {
-            PapiClient.AddProtectedTokenToCacheForTesting("valid-1", CreateToken(DateTime.UtcNow.AddMinutes(5)));
-            PapiClient.AddProtectedTokenToCacheForTesting("valid-2", CreateToken(DateTime.UtcNow.AddMinutes(10)));
+            ProtectedTokenCache.AddForTesting("valid-1", CreateToken(DateTime.UtcNow.AddMinutes(5)));
+            ProtectedTokenCache.AddForTesting("valid-2", CreateToken(DateTime.UtcNow.AddMinutes(10)));
 
-            var removedCount = PapiClient.PruneProtectedTokenCache();
+            var removedCount = ProtectedTokenCache.PruneExpired();
 
             Assert.AreEqual(0, removedCount);
-            Assert.IsTrue(PapiClient.ProtectedTokenCacheContainsKey("valid-1"));
-            Assert.IsTrue(PapiClient.ProtectedTokenCacheContainsKey("valid-2"));
+            Assert.IsTrue(ProtectedTokenCache.ContainsKey("valid-1"));
+            Assert.IsTrue(ProtectedTokenCache.ContainsKey("valid-2"));
         }
 
         private static ProtectedToken CreateToken(

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientProtectedTokenCacheTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientProtectedTokenCacheTests.cs
@@ -50,10 +50,7 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod]
         public void PruneProtectedTokenCache_RemovesTokenWithoutAccessToken()
         {
-            ProtectedTokenCache.AddForTesting(
-                "missing-access-token",
-                CreateToken(DateTime.UtcNow.AddMinutes(5), accessToken: ""));
-
+            ProtectedTokenCache.AddForTesting("missing-access-token", CreateToken(DateTime.UtcNow.AddMinutes(5), accessToken: ""));
             ProtectedTokenCache.AddForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
 
             var removedCount = ProtectedTokenCache.PruneExpired();
@@ -66,10 +63,7 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod]
         public void PruneProtectedTokenCache_RemovesTokenWithoutAccessSecret()
         {
-            ProtectedTokenCache.AddForTesting(
-                "missing-access-secret",
-                CreateToken(DateTime.UtcNow.AddMinutes(5), accessSecret: ""));
-
+            ProtectedTokenCache.AddForTesting("missing-access-secret", CreateToken(DateTime.UtcNow.AddMinutes(5), accessSecret: ""));
             ProtectedTokenCache.AddForTesting("valid", CreateToken(DateTime.UtcNow.AddMinutes(5)));
 
             var removedCount = ProtectedTokenCache.PruneExpired();

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientProtectedTokenExpirationTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientProtectedTokenExpirationTests.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using Clc.Polaris.Api.Models;
+using Clc.Polaris.Api.Tests.TestInfrastructure;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Clc.Polaris.Api.Tests
 {
     [TestClass]
     [UnitTest]
-    public sealed class PapiClientProtectedTokenExpirationTests
+    public sealed class PapiClientProtectedTokenExpirationTests : PapiClientTestBase
     {
         [TestMethod]
         public void Token_WhenTokenIsNull_ReturnsNull()
@@ -90,7 +91,7 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod]
         public void Token_WhenLocalExpirationDateIsOutsideExpirationSkew_ReturnsToken()
         {
-            var token = CreateToken(DateTime.Now.AddMinutes(5));
+            var token = CreateToken(ValidProtectedTokenExpirationDate);
             var client = new PapiClient
             {
                 Token = token

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientRequestMutationTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientRequestMutationTests.cs
@@ -4,13 +4,14 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Clc.Polaris.Api.Models;
+using Clc.Polaris.Api.Tests.TestInfrastructure;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Clc.Polaris.Api.Tests
 {
     [TestClass]
     [UnitTest]
-    public sealed class PapiClientRequestMutationTests
+    public sealed class PapiClientRequestMutationTests : PapiClientTestBase
     {
         [TestMethod]
         public void PapiRestRequest_CopyConstructor_CopiesHeadersWithoutSharingCollection()
@@ -63,13 +64,13 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod]
         public async Task ExecutePapiAsync_DoesNotMutateCallerRequestPath_WhenReplacingProtectedTokenPlaceholder()
         {
-            var handler = new CaptureHttpMessageHandler();
-            var client = CreateClient(handler);
+            var handler = new MutationCapturingHttpMessageHandler();
+            var client = CreateMutationClient(handler);
             client.Token = new ProtectedToken
             {
                 AccessToken = "protected-token",
                 AccessSecret = "protected-secret",
-                ExpirationDate = DateTime.UtcNow.AddMinutes(5)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
 
             var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/patron/barcode");
@@ -77,23 +78,23 @@ namespace Clc.Polaris.Api.Tests
 
             var originalPath = request.Path;
 
-            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
             Assert.AreEqual(originalPath, request.Path);
             Assert.IsNotNull(handler.LastRequest);
-            StringAssert.Contains(handler.LastRequest!.RequestUri!.AbsolutePath, "/protected-token/");
+            Assert.Contains("/protected-token/", handler.LastRequest!.RequestUri!.AbsolutePath);
         }
 
         [TestMethod]
         public async Task ExecutePapiAsync_DoesNotMutateCallerRequestHeaders_WhenSigningRequest()
         {
-            var handler = new CaptureHttpMessageHandler();
-            var client = CreateClient(handler);
+            var handler = new MutationCapturingHttpMessageHandler();
+            var client = CreateMutationClient(handler);
 
             var request = PapiRestRequest.Get("/public/v1/1033/100/1/test");
             request.Headers["X-Caller"] = "preserve";
 
-            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
             Assert.AreEqual("preserve", request.Headers["X-Caller"]);
             Assert.IsFalse(request.Headers.ContainsKey("PolarisDate"));
@@ -104,19 +105,19 @@ namespace Clc.Polaris.Api.Tests
         [TestMethod]
         public async Task ExecutePapiAsync_DoesNotMutateCallerRequestQueryParameters()
         {
-            var handler = new CaptureHttpMessageHandler();
-            var client = CreateClient(handler);
+            var handler = new MutationCapturingHttpMessageHandler();
+            var client = CreateMutationClient(handler);
 
             var request = PapiRestRequest.Get("/public/v1/1033/100/1/test");
             request.QueryParameters["first"] = "original";
 
-            await client.ExecutePapiAsync<PapiResponseCommon>(request);
+            await client.ExecutePapiAsync<PapiResponseCommon>(request, TestContext.CancellationToken);
 
-            Assert.AreEqual(1, request.QueryParameters.Count);
+            Assert.HasCount(1, request.QueryParameters);
             Assert.AreEqual("original", request.QueryParameters["first"]);
         }
 
-        private static PapiClient CreateClient(HttpMessageHandler handler)
+        private static PapiClient CreateMutationClient(HttpMessageHandler handler)
         {
             return new PapiClient(new HttpClient(handler), null)
             {
@@ -126,7 +127,7 @@ namespace Clc.Polaris.Api.Tests
             };
         }
 
-        private sealed class CaptureHttpMessageHandler : HttpMessageHandler
+        private sealed class MutationCapturingHttpMessageHandler : HttpMessageHandler
         {
             public HttpRequestMessage? LastRequest { get; private set; }
 
@@ -136,7 +137,7 @@ namespace Clc.Polaris.Api.Tests
 
                 var response = new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}")
+                    Content = new StringContent(CreatePapiResponseJson())
                 };
 
                 response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PreformatRestRequestAuthorizationHashTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PreformatRestRequestAuthorizationHashTests.cs
@@ -36,7 +36,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 AccessToken = "protected-token",
                 AccessSecret = "protected-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
             var request = new PapiRestRequest(HttpMethod.Get, "/protected/v1/1033/100/1/protected-token/search/patrons/Boolean");
 

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PreformatRestRequestHeaderTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PreformatRestRequestHeaderTests.cs
@@ -22,7 +22,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             Assert.AreEqual("/public/v1/1033/100/1/apikeyvalidate", formatted.Path);
             Assert.IsTrue(formatted.Headers.ContainsKey("PolarisDate"));
             Assert.IsTrue(formatted.Headers.ContainsKey("Authorization"));
-            StringAssert.StartsWith(formatted.Headers["Authorization"], "PWS access-id:");
+            Assert.StartsWith("PWS access-id:", formatted.Headers["Authorization"]);
         }
 
         [TestMethod]

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PreformatRestRequestIdempotencyTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PreformatRestRequestIdempotencyTests.cs
@@ -26,11 +26,11 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var second = (PapiRestRequest)client.PreformatRestRequest(first);
 
             Assert.AreSame(first, second);
-            Assert.AreEqual(firstHeaderCount, second.Headers.Count);
+            Assert.HasCount(firstHeaderCount, second.Headers);
             Assert.AreEqual("keep", second.Headers["X-Custom"]);
             Assert.AreSame(body, second.Body);
-            Assert.AreEqual(1, second.Headers.Keys.Count(key => key == "PolarisDate"));
-            Assert.AreEqual(1, second.Headers.Keys.Count(key => key == "Authorization"));
+            Assert.ContainsSingle(key => key == "PolarisDate", second.Headers.Keys);
+            Assert.ContainsSingle(key => key == "Authorization", second.Headers.Keys);
             var date = second.Headers["PolarisDate"];
             var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/patron/ABC123?ignoresa=False";
             var expectedHash = PapiSignature.ComputeHash("access-key", "PUT", expectedUri, date, "1234");

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PreformatRestRequestStaffOverrideTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PreformatRestRequestStaffOverrideTests.cs
@@ -22,7 +22,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 AccessToken = "staff-token",
                 AccessSecret = "staff-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
 
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/patron/ABC123/basicdata");
@@ -46,7 +46,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 AccessToken = "staff-token",
                 AccessSecret = "staff-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
 
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/patron/ABC123/basicdata")
@@ -72,7 +72,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 AccessToken = "staff-token",
                 AccessSecret = "staff-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
 
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/patron/ABC123/basicdata");
@@ -95,7 +95,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 AccessToken = "staff-token",
                 AccessSecret = "staff-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
 
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/api");
@@ -118,7 +118,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 AccessToken = "staff-token",
                 AccessSecret = "staff-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/patron/ABC123/basicdata");
 

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PreformatRestRequestTokenTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PreformatRestRequestTokenTests.cs
@@ -28,7 +28,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 AccessToken = "expired-token",
                 AccessSecret = "expired-secret",
-                ExpirationDate = DateTime.Now.AddHours(-1)
+                ExpirationDate = ExpiredProtectedTokenExpirationDate
             };
             var request = new PapiRestRequest(HttpMethod.Get, "/protected/v1/1033/100/1/expired-token/search/patrons/Boolean");
 
@@ -52,7 +52,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 AccessToken = "expired-token",
                 AccessSecret = "expired-secret",
-                ExpirationDate = DateTime.Now.AddHours(-1)
+                ExpirationDate = ExpiredProtectedTokenExpirationDate
             };
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/patron/ABC");
             request.Headers["X-PAPI-AccessToken"] = "stale-token";
@@ -79,7 +79,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 AccessToken = " ",
                 AccessSecret = "manual-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
 
             var formatted = (PapiRestRequest)client.PreformatRestRequest(new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/patron/ABC"));

--- a/src/polaris-api-csharpTests/PapiClientBehavior/ProtectedTokenCacheTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/ProtectedTokenCacheTests.cs
@@ -44,9 +44,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             var hostname = $"https://example-{Guid.NewGuid():N}.test";
             var staff = CreateStaffUser();
 
-            var handlerA = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson("token-a", "secret-a", DateTime.Now.AddHours(1)));
+            var handlerA = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: "token-a", accessSecret: "secret-a", expirationDate: ValidProtectedTokenExpirationDate));
             var clientA = CreateProtectedClient(handlerA);
             clientA.Hostname = hostname;
             clientA.AccessID = "access-a";
@@ -61,9 +59,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             Assert.IsNotNull(cachedTokenA);
             Assert.AreEqual("token-a", cachedTokenA.AccessToken);
 
-            var handlerB = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.OK,
-                CreateProtectedTokenJson("token-b", "secret-b", DateTime.Now.AddHours(1)));
+            var handlerB = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateProtectedTokenJson(accessToken: "token-b", accessSecret: "secret-b", expirationDate: ValidProtectedTokenExpirationDate));
             var clientB = CreateProtectedClient(handlerB);
             clientB.Hostname = hostname;
             clientB.AccessID = "access-b";
@@ -114,14 +110,12 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 AccessToken = "cached-token",
                 AccessSecret = "cached-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
 
             SetCachedToken(hostname, "access-id", "access-key", staff, cachedToken);
 
-            var failingHandler = new ProtectedTokenHttpMessageHandler(
-                HttpStatusCode.Unauthorized,
-                "{\"PAPIErrorCode\":1}");
+            var failingHandler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.Unauthorized, CreatePapiResponseJson(1));
             var cacheDisabledClient = CreateProtectedClient(failingHandler, hostname, staff);
             cacheDisabledClient.UseProtectedTokenCache = false;
 
@@ -146,8 +140,5 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             Assert.Contains(
                 "/protected/v1/1033/100/1/cached-token/search/patrons/Boolean",
                 cacheEnabledHandler.CapturedRequests.Single(request => !request.IsStaffAuthenticationRequest).Path);
-        }
-
-        public TestContext TestContext { get; set; }
-    }
+        }}
 }

--- a/src/polaris-api-csharpTests/PapiClientBehavior/TokenPropertyTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/TokenPropertyTests.cs
@@ -42,7 +42,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 AccessToken = "cached-token",
                 AccessSecret = "cached-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             });
 
             var token = client.Token;
@@ -61,7 +61,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 AccessToken = "existing-token",
                 AccessSecret = "existing-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             };
 
             var token = client.Token;
@@ -83,13 +83,13 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 AccessToken = "expired-token",
                 AccessSecret = "expired-secret",
-                ExpirationDate = DateTime.Now.AddHours(-1)
+                ExpirationDate = ExpiredProtectedTokenExpirationDate
             };
             SetCachedToken(client.Hostname, client.AccessID, client.AccessKey, staff, new ProtectedToken
             {
                 AccessToken = "cached-token",
                 AccessSecret = "cached-secret",
-                ExpirationDate = DateTime.Now.AddHours(1)
+                ExpirationDate = ValidProtectedTokenExpirationDate
             });
 
             var token = client.Token;
@@ -108,7 +108,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 AccessToken = "expired-token",
                 AccessSecret = "expired-secret",
-                ExpirationDate = DateTime.Now.AddHours(-1)
+                ExpirationDate = ExpiredProtectedTokenExpirationDate
             };
 
             var token = client.Token;

--- a/src/polaris-api-csharpTests/TestInfrastructure/PapiClientTestBase.cs
+++ b/src/polaris-api-csharpTests/TestInfrastructure/PapiClientTestBase.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -159,12 +158,7 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
 
         protected static void ClearProtectedTokenState()
         {
-            var cache = GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache");
-            cache?.Clear();
-
-            var locksProperty = typeof(PapiClient).GetProperty("ProtectedTokenCacheLocks", BindingFlags.NonPublic | BindingFlags.Static);
-            var locks = locksProperty?.GetValue(null);
-            locks?.GetType().GetMethod("Clear")?.Invoke(locks, null);
+            ProtectedTokenCache.ClearForTesting();
         }
 
         protected static void SetCachedToken(string hostname, string accessId, string accessKey, PolarisUser? staffUser, ProtectedToken token)
@@ -172,7 +166,7 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
             var cacheKey = BuildCacheKey(hostname, accessId, accessKey, staffUser);
             if (cacheKey != null)
             {
-                GetProtectedTokenCache().TryAdd(cacheKey, token);
+                ProtectedTokenCache.AddForTesting(cacheKey, token);
             }
         }
 
@@ -180,19 +174,12 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
         {
             token = null;
             var cacheKey = BuildCacheKey(hostname, accessId, accessKey, staffUser);
-            return cacheKey != null && GetProtectedTokenCache().TryGetValue(cacheKey, out token);
+            return cacheKey != null && ProtectedTokenCache.TryGet(cacheKey, useCache: true, out token);
         }
 
-        protected static ConcurrentDictionary<string, ProtectedToken> GetProtectedTokenCache()
+        protected static int GetProtectedTokenCacheCount()
         {
-            return GetPrivateStaticProperty<ConcurrentDictionary<string, ProtectedToken>>("ProtectedTokenCache")
-                ?? throw new InvalidOperationException("Protected token cache was not available.");
-        }
-
-        protected static T? GetPrivateStaticProperty<T>(string propertyName) where T : class
-        {
-            var cacheProperty = typeof(PapiClient).GetProperty(propertyName, BindingFlags.NonPublic | BindingFlags.Static);
-            return cacheProperty?.GetValue(null) as T;
+            return ProtectedTokenCache.CountForTesting();
         }
 
         protected static string? BuildCacheKey(string hostname, string accessId, string accessKey, PolarisUser? staffUser)
@@ -212,9 +199,7 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
 
         protected static string? BuildCacheKey(PapiClient client)
         {
-            var buildCacheKeyMethod = typeof(PapiClient).GetMethod("BuildProtectedTokenCacheKey", BindingFlags.Instance | BindingFlags.NonPublic)
-                ?? throw new InvalidOperationException("Protected token cache-key builder was not available.");
-            return buildCacheKeyMethod.Invoke(client, Array.Empty<object>()) as string;
+            return ProtectedTokenCache.BuildKey(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount);
         }
 
         protected sealed class TestPapiSettings : IPapiSettings

--- a/src/polaris-api-csharpTests/TestInfrastructure/PapiClientTestBase.cs
+++ b/src/polaris-api-csharpTests/TestInfrastructure/PapiClientTestBase.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Clc.Polaris.Api;
@@ -16,6 +18,8 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
 {
     public abstract class PapiClientTestBase
     {
+        public TestContext TestContext { get; set; } = null!;
+
         protected static PapiClient CreateClient(HttpMessageHandler? handler = null)
         {
             var settings = new TestPapiSettings();
@@ -27,7 +31,7 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
             };
         }
 
-        protected static PapiClient CreateUrlEncodingClient(CaptureHttpMessageHandler handler)
+        protected static PapiClient CreateUrlEncodingClient(CapturingHttpMessageHandler handler)
         {
             var settings = new PapiSettings
             {
@@ -92,20 +96,42 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
             };
         }
 
+        protected static DateTime ValidProtectedTokenExpirationDate => DateTime.Now.AddHours(1);
+
+        protected static DateTime ExpiredProtectedTokenExpirationDate => DateTime.Now.AddMinutes(-1);
+
+        protected static string CreateJson(object value)
+        {
+            return JsonSerializer.Serialize(value);
+        }
+
+        protected static string CreatePapiResponseJson(int papiErrorCode = 0)
+        {
+            return CreateJson(new
+            {
+                PAPIErrorCode = papiErrorCode
+            });
+        }
+
+        protected static string CreateEmptyJsonObject()
+        {
+            return CreateJson(new { });
+        }
+
         protected static string CreateProtectedTokenJson(string accessToken, string accessSecret, DateTime expirationDate)
         {
-            return
-                "{" +
-                $"\"PAPIErrorCode\":0," +
-                $"\"AccessToken\":\"{accessToken}\"," +
-                $"\"AccessSecret\":\"{accessSecret}\"," +
-                $"\"AuthExpDate\":\"{expirationDate:O}\"" +
-                "}";
+            return CreateJson(new
+            {
+                PAPIErrorCode = 0,
+                AccessToken = accessToken,
+                AccessSecret = accessSecret,
+                AuthExpDate = expirationDate.ToString("O", CultureInfo.InvariantCulture)
+            });
         }
 
         protected static string CreateProtectedTokenJson(ProtectedToken token)
         {
-            return CreateProtectedTokenJson(token.AccessToken!, token.AccessSecret!, token.ExpirationDate!.Value);
+            return CreateProtectedTokenJson(accessToken: token.AccessToken!, accessSecret: token.AccessSecret!, expirationDate: token.ExpirationDate!.Value);
         }
 
         protected static async Task ExecuteRawPapiRequestAsync(PapiClient client, PapiRestRequest request)
@@ -133,10 +159,10 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
             var matchingRequests = handler.CapturedRequests
                 .Where(request => !request.IsStaffAuthenticationRequest && request.AbsoluteUri.Contains(queryMarker, StringComparison.Ordinal))
                 .ToArray();
-            Assert.IsTrue(matchingRequests.Length > 0, $"Expected at least one final request containing '{queryMarker}'.");
+            Assert.IsNotEmpty(matchingRequests, $"Expected at least one final request containing '{queryMarker}'.");
             foreach (var request in matchingRequests)
             {
-                StringAssert.Contains(request.Path, $"/protected/v1/1033/100/1/{expectedToken}/search/patrons/Boolean");
+                Assert.Contains($"/protected/v1/1033/100/1/{expectedToken}/search/patrons/Boolean", request.Path);
                 Assert.IsFalse(request.Path.Contains(ProtectedToken.Placeholder, StringComparison.Ordinal));
                 AssertAuthorizationHash(request, expectedSecret, "access-key", "access-id");
             }
@@ -213,22 +239,6 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
             public PolarisUser? PolarisOverrideAccount { get; set; }
         }
 
-        protected sealed class CaptureHttpMessageHandler : HttpMessageHandler
-        {
-            public HttpRequestMessage? LastRequest { get; private set; }
-
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                LastRequest = request;
-                var response = new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}")
-                };
-                response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-                return Task.FromResult(response);
-            }
-        }
-
         protected sealed class CapturingHttpMessageHandler : HttpMessageHandler
         {
             private readonly string _responseJson;
@@ -241,7 +251,7 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
 
             public CapturingHttpMessageHandler(string? responseJson = null)
             {
-                _responseJson = responseJson ?? CreateProtectedTokenJson("new-token", "new-secret", DateTime.Now.AddHours(1));
+                _responseJson = responseJson ?? CreateProtectedTokenJson(accessToken: "new-token", accessSecret: "new-secret", expirationDate: ValidProtectedTokenExpirationDate);
             }
 
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -292,13 +302,13 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
             private readonly string _nonAuthenticationResponseJson;
             private int _authenticationRequestCount;
             private int _nonAuthenticationRequestCount;
-            private readonly ConcurrentQueue<string> _requestPaths = new ConcurrentQueue<string>();
-            private readonly ConcurrentQueue<CapturedPapiRequest> _capturedRequests = new ConcurrentQueue<CapturedPapiRequest>();
+            private readonly ConcurrentQueue<string> _requestPaths = new();
+            private readonly ConcurrentQueue<CapturedPapiRequest> _capturedRequests = new();
 
             public int AuthenticationRequestCount => _authenticationRequestCount;
             public int NonAuthenticationRequestCount => _nonAuthenticationRequestCount;
-            public string[] RequestPaths => _requestPaths.ToArray();
-            public CapturedPapiRequest[] CapturedRequests => _capturedRequests.ToArray();
+            public string[] RequestPaths => [.. _requestPaths];
+            public CapturedPapiRequest[] CapturedRequests => [.. _capturedRequests];
 
             public ProtectedTokenHttpMessageHandler(
                 HttpStatusCode authenticationStatusCode = HttpStatusCode.OK,
@@ -307,9 +317,9 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
                 string? nonAuthenticationResponseJson = null)
             {
                 _authenticationStatusCode = authenticationStatusCode;
-                _authenticationResponseJson = authenticationResponseJson ?? CreateProtectedTokenJson("protected-token", "protected-secret", DateTime.Now.AddHours(1));
+                _authenticationResponseJson = authenticationResponseJson ?? CreateProtectedTokenJson(accessToken: "protected-token", accessSecret: "protected-secret", expirationDate: ValidProtectedTokenExpirationDate);
                 _nonAuthenticationStatusCode = nonAuthenticationStatusCode;
-                _nonAuthenticationResponseJson = nonAuthenticationResponseJson ?? "{\"PAPIErrorCode\":0}";
+                _nonAuthenticationResponseJson = nonAuthenticationResponseJson ?? CreatePapiResponseJson();
             }
 
             public ProtectedTokenHttpMessageHandler(Func<CapturedPapiRequest, (HttpStatusCode StatusCode, string ResponseJson)> authenticationResponseFactory)
@@ -320,7 +330,7 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
 
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
-                var body = request.Content == null ? string.Empty : await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var body = request.Content == null ? string.Empty : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
                 var capturedRequest = new CapturedPapiRequest(request, body);
                 _requestPaths.Enqueue(capturedRequest.Path);
                 _capturedRequests.Enqueue(capturedRequest);
@@ -329,10 +339,10 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
                 {
                     Interlocked.Increment(ref _authenticationRequestCount);
                     await Task.Delay(50, cancellationToken).ConfigureAwait(false);
-                    var authenticationResponse = _authenticationResponseFactory?.Invoke(capturedRequest) ?? (_authenticationStatusCode, _authenticationResponseJson);
-                    return new HttpResponseMessage(authenticationResponse.StatusCode)
+                    var (StatusCode, ResponseJson) = _authenticationResponseFactory?.Invoke(capturedRequest) ?? (_authenticationStatusCode, _authenticationResponseJson);
+                    return new HttpResponseMessage(StatusCode)
                     {
-                        Content = new StringContent(authenticationResponse.ResponseJson, Encoding.UTF8, "application/json")
+                        Content = new StringContent(ResponseJson, Encoding.UTF8, "application/json")
                     };
                 }
 
@@ -346,8 +356,8 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
 
         protected sealed class ProtectedTokenCancellationHttpMessageHandler : HttpMessageHandler
         {
-            public List<HttpRequestMessage> Requests { get; } = new();
-            public List<CancellationToken> CancellationTokens { get; } = new();
+            public List<HttpRequestMessage> Requests { get; } = [];
+            public List<CancellationToken> CancellationTokens { get; } = [];
 
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
@@ -356,8 +366,8 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
                 var requestNumber = Requests.Count;
 
                 var responseJson = requestNumber == 1
-                    ? "{\"PAPIErrorCode\":0,\"AccessToken\":\"protected-token\",\"AccessSecret\":\"protected-secret\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}"
-                    : "{\"PAPIErrorCode\":0}";
+                    ? CreateProtectedTokenJson(accessToken: "protected-token", accessSecret: "protected-secret", expirationDate: ValidProtectedTokenExpirationDate)
+                    : CreatePapiResponseJson();
 
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {


### PR DESCRIPTION
### Motivation

- Reduce the size and improve cohesion of `PapiClient` by extracting protected-token cache, request-classification, and request-validation responsibilities into focused internal helpers.
- Preserve existing PAPI signing, protected-token acquisition, staff override, request execution, and public API behavior while making the implementation easier to reason about.
- Replace brittle test reflection with minimal internal helper hooks.
- Clean up related test infrastructure, formatting, analyzer guidance, and generated-change instructions while the affected areas are being touched.

### Description

- Introduced `internal static ProtectedTokenCache` to own protected-token cache behavior, including:
  - Cache key generation.
  - Credential fingerprinting.
  - Token usability and expiration-skew checks.
  - Defensive-copy get/set behavior.
  - Cache removal and expired-token pruning.
  - Per-cache-key async lock acquisition.
  - Bounded lock-entry pruning.
  - Internal test helpers such as `ClearForTesting`, `AddForTesting`, `ContainsKey`, and `CountForTesting`.

- Hardened protected-token lock pruning so retired lock entries are removed only when the dictionary still maps the key to the exact `LockEntry` instance being pruned.

- Introduced `internal static PapiRequestClassifier` for request and route classification, including:
  - Protected-token requirement detection.
  - Staff override patron request detection.
  - Patron barcode route-segment detection.
  - Staff authenticator request detection.
  - `ProtectedToken.Placeholder` path detection.

- Introduced `internal static PapiRequestValidator` for executable custom PAPI request validation, including:
  - Non-empty relative path validation.
  - Absolute URL rejection.
  - Protocol-relative URL rejection.
  - Leading-slash enforcement.
  - Authenticated custom path restriction to `/public/` or `/protected/`.

- Updated `PapiClient` to delegate protected-token cache, route classification, and custom request validation responsibilities to the new helpers while keeping `PapiClient` as the orchestration point.

- Preserved behavior for:
  - Authorization signing.
  - `PolarisDate` generation.
  - Staff authentication.
  - Protected-token acquisition.
  - Protected-token placeholder replacement.
  - Staff override requests.
  - Existing exception behavior for invalid requests and unusable tokens.

- Updated tests to use internal helper hooks instead of reflection-based cache access.

- Added shared test helpers and properties to `PapiClientTestBase`, including:
  - `CreateJson`
  - `CreatePapiResponseJson`
  - `CreateEmptyJsonObject`
  - `CreateProtectedTokenJson(...)`
  - `ValidProtectedTokenExpirationDate`
  - `ExpiredProtectedTokenExpirationDate`
  - `TestContext`

- Replaced raw escaped JSON response strings with shared helper calls where the JSON shape is equivalent.

- Preserved intentional special-case response values such as JSON `"null"` and tests that require explicit UTC, unspecified, expiration-skew, or null expiration behavior.

- Removed duplicate/confusing test handler infrastructure and standardized on `CapturingHttpMessageHandler` where request and body capture are needed.

- Cleaned up MSTest analyzer issues in touched tests:
  - Replaced `StringAssert.Contains(actual, expected)` with `Assert.Contains(expected, actual)`.
  - Verified `Assert.Contains` argument order.
  - Replaced generic boolean assertions with more specific assertions where appropriate.
  - Passed `TestContext.CancellationToken` to async calls where suitable overloads exist.

- Added analyzer severity settings in `src/.editorconfig` for:
  - `MSTEST0037`
  - `MSTEST0046`
  - `MSTEST0049`

- Added `AGENTS.md` with repository guidance for future generated changes, including:
  - Formatting expectations.
  - JSON helper usage.
  - Protected-token date usage.
  - Test handler naming/reuse.
  - `Assert.Contains` argument order.
  - `TestContext.CancellationToken`.
  - Analyzer cleanup expectations.
  - Validation expectations.

- Kept production behavior changes out of scope; production changes are intended to be refactoring, extraction, and readability improvements only.

### Testing

- Ran:

  ```bash
  dotnet build src/polaris-api-csharp/Clc.Polaris.Api.csproj
  ```

- Ran:

  ```bash
  dotnet build src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj
  ```

- Ran:

  ```bash
  dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Unit"
  ```

- GitHub Actions `build-test-publish` passed on the latest PR head.

### Notes

- This PR is intended to be behavior-preserving.
- Most of the production change is extraction from `PapiClient` into focused internal helpers.
- Most of the remaining churn is test readability, analyzer cleanup, and shared test infrastructure cleanup.
- No package references were added.