### PR TITLE
Clean up JSON response formatting in tests

### DIFF
--- a/src/polaris-api-csharp/Extensions/SynchBibsByIdGetExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/SynchBibsByIdGetExtensions.cs
@@ -1,7 +1,7 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
 using System.Threading;
 using System.Threading.Tasks;
+using Clc.Polaris.Api.Models;
+using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {
@@ -14,7 +14,7 @@ namespace Clc.Polaris.Api
             CancellationToken cancellationToken = default)
         {
             return client.Synch_BibsByIdGetAsync(
-                new[] { bibId },
+                [bibId],
                 includeItems,
                 cancellationToken);
         }

--- a/src/polaris-api-csharpTests/Methods/AuthenticatePatronTests.cs
+++ b/src/polaris-api-csharpTests/Methods/AuthenticatePatronTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Clc.Polaris.Api;
@@ -25,9 +26,16 @@ namespace Clc.Polaris.Api.Tests
                 {
                     RequestContent = await request.Content.ReadAsStringAsync(cancellationToken);
                 }
+                var responseJson = JsonSerializer.Serialize(new
+                {
+                    PAPIErrorCode = 0,
+                    AccessToken = "mock-token",
+                    AccessSecret = "mock-secret",
+                    PatronID = 123
+                });
                 var response = new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0, \"AccessToken\":\"mock-token\", \"AccessSecret\":\"mock-secret\", \"PatronID\":123}")
+                    Content = new StringContent(responseJson)
                 };
                 response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
                 return response;
@@ -66,8 +74,10 @@ namespace Clc.Polaris.Api.Tests
             Assert.AreEqual(expectedPath, handler.LastRequest.RequestUri!.AbsolutePath);
 
             Assert.IsNotNull(handler.RequestContent);
-            Assert.IsTrue(handler.RequestContent.Contains($"\"Barcode\":\"{barcode}\"") || handler.RequestContent.Contains($"\"barcode\":\"{barcode}\""), "Body should contain barcode");
-            Assert.IsTrue(handler.RequestContent.Contains($"\"Password\":\"{password}\"") || handler.RequestContent.Contains($"\"password\":\"{password}\""), "Body should contain password");
+            var bodyContainsBarcode = handler.RequestContent.Contains($"\"Barcode\":\"{barcode}\"") || handler.RequestContent.Contains($"\"barcode\":\"{barcode}\"");
+            var bodyContainsPassword = handler.RequestContent.Contains($"\"Password\":\"{password}\"") || handler.RequestContent.Contains($"\"password\":\"{password}\"");
+            Assert.IsTrue(bodyContainsBarcode, "Body should contain barcode");
+            Assert.IsTrue(bodyContainsPassword, "Body should contain password");
 
             Assert.IsNotNull(response.Data);
             Assert.AreEqual(0, response.Data.PAPIErrorCode);

--- a/src/polaris-api-csharpTests/Methods/Cancellation/ApiKeyValidateTests.cs
+++ b/src/polaris-api-csharpTests/Methods/Cancellation/ApiKeyValidateTests.cs
@@ -14,7 +14,7 @@ namespace Clc.Polaris.Api.Tests.Methods.Cancellation
         [TestMethod]
         public async Task ApiKeyValidateAsync_PassesCancellationToken()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             using var cts = new CancellationTokenSource();
 

--- a/src/polaris-api-csharpTests/Methods/Cancellation/PatronSearchProtectedTokenTests.cs
+++ b/src/polaris-api-csharpTests/Methods/Cancellation/PatronSearchProtectedTokenTests.cs
@@ -92,9 +92,11 @@ namespace Clc.Polaris.Api.Tests.Methods.Cancellation
                     Interlocked.Increment(ref _authenticationRequestCount);
                     AuthenticationStarted.TrySetResult();
                     await CompleteAuthentication.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    var responseJson = CreateProtectedTokenJson("blocked-token", "blocked-secret", new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
                     return new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent("{\"PAPIErrorCode\":0,\"AccessToken\":\"blocked-token\",\"AccessSecret\":\"blocked-secret\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}", Encoding.UTF8, "application/json")
+                        Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
                     };
                 }
 
@@ -105,7 +107,7 @@ namespace Clc.Polaris.Api.Tests.Methods.Cancellation
 
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                    Content = new StringContent(CreatePapiResponseJson(), Encoding.UTF8, "application/json")
                 };
             }
         }
@@ -138,7 +140,7 @@ namespace Clc.Polaris.Api.Tests.Methods.Cancellation
 
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                    Content = new StringContent(CreatePapiResponseJson(), Encoding.UTF8, "application/json")
                 };
             }
         }

--- a/src/polaris-api-csharpTests/Methods/ProtectedTokens/PatronAccountGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ProtectedTokens/PatronAccountGetTests.cs
@@ -21,11 +21,10 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             ClearProtectedTokenState();
         }
 
-
         [TestMethod]
         public async Task PatronAccountGetAsync_FailedStaffAuthentication_DoesNotPopulateProtectedTokenCache()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
 
             await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
@@ -35,12 +34,11 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
-
 
         [TestMethod]
         public async Task PatronAccountGetAsync_NullDataStaffAuthentication_DoesNotPopulateProtectedTokenCache()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, "{}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateEmptyJsonObject());
             var client = CreateProtectedClient(handler);
 
             await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
@@ -50,12 +48,11 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
-
 
         [TestMethod]
         public async Task PatronAccountGetAsync_FailedStaffAuthentication_AfterExpiredExistingTokenClearsToken()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             client.Token = new ProtectedToken
             {
@@ -71,12 +68,11 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
-
 
         [TestMethod]
         public async Task PatronAccountGetAsync_NullDataStaffAuthentication_AfterExpiredExistingTokenClearsToken()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, "{}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.OK, CreateEmptyJsonObject());
             var client = CreateProtectedClient(handler);
             client.Token = new ProtectedToken
             {
@@ -92,8 +88,6 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             Assert.IsNull(client.Token);
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
-
-
 
         [TestMethod]
         public async Task PatronAccountGetAsync_InvalidStaffAuthentication_AfterExpiredExistingTokenClearsTokenAndDoesNotCache()
@@ -117,11 +111,10 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             Assert.IsFalse(TryGetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, out _));
         }
 
-
         [TestMethod]
         public async Task PatronAccountGetAsync_PublicStaffOverride_FailedStaffAuthentication_ThrowsBeforeFinalRequest()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
 
             var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronAccountGetAsync("ABC123"));
@@ -131,11 +124,10 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             Assert.AreEqual(0, handler.NonAuthenticationRequestCount);
         }
 
-
         [TestMethod]
         public async Task PatronAccountGetAsync_PublicRequestWithoutStaffOverrideAccount_ContinuesAsOrdinaryPublicRequest()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             client.StaffOverrideAccount = null;
             client.AllowStaffOverrideRequests = true;
@@ -148,11 +140,10 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
             StringAssert.Contains(handler.RequestPaths.Single(), "/public/v1/1033/100/1/patron/ABC123/account/outstanding");
         }
 
-
         [TestMethod]
         public async Task PatronAccountGetAsync_PublicRequestWithExplicitPassword_DoesNotRequireStaffOverrideToken()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
 
             var response = await client.PatronAccountGetAsync("ABC123", password: "patron-password");

--- a/src/polaris-api-csharpTests/Methods/ProtectedTokens/PatronSearchTests.cs
+++ b/src/polaris-api-csharpTests/Methods/ProtectedTokens/PatronSearchTests.cs
@@ -28,7 +28,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         [TestMethod]
         public async Task ProtectedTokenPathRequest_ReplacesPlaceholderBeforeSending()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             client.Token = new ProtectedToken { AccessToken = "real-token", AccessSecret = "real-secret", ExpirationDate = DateTime.Now.AddHours(1) };
 
@@ -43,7 +43,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         [TestMethod]
         public async Task ProtectedTokenPathRequest_HashesReplacedUrlInsteadOfPlaceholderUrl()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             client.Token = new ProtectedToken { AccessToken = "hash-token", AccessSecret = "hash-secret", ExpirationDate = DateTime.Now.AddHours(1) };
 
@@ -299,7 +299,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
                     return (HttpStatusCode.OK, CreateProtectedTokenJson(passwordBToken));
                 }
 
-                return (HttpStatusCode.BadRequest, "{\"PAPIErrorCode\":1}");
+                return (HttpStatusCode.BadRequest, CreatePapiResponseJson(1));
             });
             var clients = new[]
             {
@@ -534,7 +534,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         [TestMethod]
         public async Task PatronSearchAsync_ExpiredCachedToken_IsRemovedWhenEncountered()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             SetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, new ProtectedToken
             {
@@ -579,7 +579,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         [TestMethod]
         public async Task PatronSearchAsync_CachedTokenWithBlankAccessSecret_IsRemovedAndNotUsedWhenAuthenticationFails()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             SetCachedToken(client.Hostname, client.AccessID, client.AccessKey, client.StaffOverrideAccount, new ProtectedToken
             {
@@ -599,7 +599,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
         [TestMethod]
         public async Task PatronSearchAsync_FailedStaffAuthentication_ThrowsBeforeFinalProtectedRequest()
         {
-            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, "{\"PAPIErrorCode\":1}");
+            var handler = new ProtectedTokenHttpMessageHandler(HttpStatusCode.InternalServerError, CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
 
             var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => client.PatronSearchAsync("name=Smith"));
@@ -703,7 +703,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
                     AuthenticationRequestCount++;
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent("{}", Encoding.UTF8, "application/json")
+                        Content = new StringContent(CreateEmptyJsonObject(), Encoding.UTF8, "application/json")
                     });
                 }
 
@@ -719,7 +719,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
 
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                    Content = new StringContent(CreatePapiResponseJson(), Encoding.UTF8, "application/json")
                 });
             }
         }
@@ -737,9 +737,14 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
                 if (request.RequestUri!.AbsolutePath.Contains("/authenticator/staff", StringComparison.Ordinal))
                 {
                     var requestNumber = Interlocked.Increment(ref _authenticationRequestCount);
+                    var responseJson = CreateProtectedTokenJson(
+                        $"protected-token-{requestNumber}",
+                        $"protected-secret-{requestNumber}",
+                        new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent($"{{\"PAPIErrorCode\":0,\"AccessToken\":\"protected-token-{requestNumber}\",\"AccessSecret\":\"protected-secret-{requestNumber}\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}}", Encoding.UTF8, "application/json")
+                        Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
                     });
                 }
 
@@ -750,7 +755,7 @@ namespace Clc.Polaris.Api.Tests.Methods.ProtectedTokens
 
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                    Content = new StringContent(CreatePapiResponseJson(), Encoding.UTF8, "application/json")
                 });
             }
         }

--- a/src/polaris-api-csharpTests/Methods/RequestShape/ApiKeyValidateTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/ApiKeyValidateTests.cs
@@ -14,7 +14,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task ApiKeyValidate_RequestShape_IsStable()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
 
             var response = await client.ApiKeyValidateAsync();

--- a/src/polaris-api-csharpTests/Methods/RequestShape/AuthenticateStaffUserTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/AuthenticateStaffUserTests.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task AuthenticateStaffUser_RequestShape_IsStable()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0,\"AccessToken\":\"t\",\"AccessSecret\":\"s\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}");
+            var handler = new CapturingHttpMessageHandler(CreateProtectedTokenJson("t", "s", new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc)));
             var client = CreateClient(handler);
 
             var response = await client.AuthenticateStaffUserAsync(new PolarisUser

--- a/src/polaris-api-csharpTests/Methods/RequestShape/BibSearchTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/BibSearchTests.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task BibSearch_RequestShape_IsStable()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var options = new BibSearchOptions
             {
@@ -34,7 +34,8 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
             Assert.IsNotNull(response);
             Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
             StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/public/v1/1033/100/1/search/bibs/keyword/KW");
-            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15&limit=3", handler.LastRequest.RequestUri.AbsoluteUri);
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15&limit=3";
+            Assert.AreEqual(expectedUri, handler.LastRequest.RequestUri.AbsoluteUri);
             var query = ParseQuery(handler.LastRequest.RequestUri.Query);
             Assert.AreEqual("harry potter & stone", query["q"]);
             Assert.AreEqual("MP", query["sort"]);
@@ -50,7 +51,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task BibKeywordSearchAsync_ThroughInterface_RequestShapeIsStable()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             IPapiClient client = CreateClient(handler);
 
             var response = await client.BibKeywordSearchAsync(
@@ -64,7 +65,8 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
             Assert.IsNotNull(handler.LastRequest);
             Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
             StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/public/v1/1033/100/7/search/bibs/keyword/KW");
-            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/7/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15", handler.LastRequest.RequestUri.AbsoluteUri);
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/7/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15";
+            Assert.AreEqual(expectedUri, handler.LastRequest.RequestUri.AbsoluteUri);
             var query = ParseQuery(handler.LastRequest.RequestUri.Query);
             Assert.AreEqual("harry potter & stone", query["q"]);
             Assert.AreEqual("MP", query["sort"]);
@@ -79,7 +81,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task BibKeywordSearchAsync_ThroughInterfaceWithoutBranchId_UsesOrganizationId()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             IPapiClient client = CreateClient(handler);
             client.OrganizationId = 42;
 
@@ -88,14 +90,15 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
             Assert.IsNotNull(response);
             Assert.IsNotNull(handler.LastRequest);
             StringAssert.Contains(handler.LastRequest!.RequestUri!.AbsolutePath, "/public/v1/1033/100/42/search/bibs/keyword/KW");
-            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/42/search/bibs/keyword/KW?q=default%20branch%20search&sort=MP&page=1&bibsperpage=10", handler.LastRequest.RequestUri.AbsoluteUri);
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/42/search/bibs/keyword/KW?q=default%20branch%20search&sort=MP&page=1&bibsperpage=10";
+            Assert.AreEqual(expectedUri, handler.LastRequest.RequestUri.AbsoluteUri);
             AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
         }
 
         [TestMethod]
         public async Task BibBooleanSearchAsync_ThroughInterface_RequestShapeIsStable()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             IPapiClient client = CreateClient(handler);
 
             var response = await client.BibBooleanSearchAsync(
@@ -109,7 +112,8 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
             Assert.IsNotNull(handler.LastRequest);
             Assert.AreEqual(HttpMethod.Get, handler.LastRequest!.Method);
             StringAssert.Contains(handler.LastRequest.RequestUri!.AbsolutePath, "/public/v1/1033/100/8/search/bibs/boolean");
-            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/8/search/bibs/boolean?q=TI%3DHarry%20Potter&sort=AU&page=3&bibsperpage=20", handler.LastRequest.RequestUri.AbsoluteUri);
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/8/search/bibs/boolean?q=TI%3DHarry%20Potter&sort=AU&page=3&bibsperpage=20";
+            Assert.AreEqual(expectedUri, handler.LastRequest.RequestUri.AbsoluteUri);
             var query = ParseQuery(handler.LastRequest.RequestUri.Query);
             Assert.AreEqual("TI=Harry Potter", query["q"]);
             Assert.AreEqual("AU", query["sort"]);
@@ -124,7 +128,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task BibBooleanSearchAsync_ThroughInterfaceWithoutBranchId_UsesOrganizationId()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             IPapiClient client = CreateClient(handler);
             client.OrganizationId = 42;
 
@@ -133,14 +137,15 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
             Assert.IsNotNull(response);
             Assert.IsNotNull(handler.LastRequest);
             StringAssert.Contains(handler.LastRequest!.RequestUri!.AbsolutePath, "/public/v1/1033/100/42/search/bibs/boolean");
-            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/42/search/bibs/boolean?q=TI%3DDefault%20Branch&sort=MP&page=1&bibsperpage=10", handler.LastRequest.RequestUri.AbsoluteUri);
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/42/search/bibs/boolean?q=TI%3DDefault%20Branch&sort=MP&page=1&bibsperpage=10";
+            Assert.AreEqual(expectedUri, handler.LastRequest.RequestUri.AbsoluteUri);
             AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);
         }
 
         [TestMethod]
         public async Task BibSearchAsync_DefaultLimit_OmitsLimitAndHashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var options = new BibSearchOptions
             {
@@ -157,7 +162,8 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
 
             Assert.IsNotNull(response);
             Assert.IsNotNull(handler.LastRequest);
-            Assert.AreEqual("https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15", handler.LastRequest!.RequestUri!.AbsoluteUri);
+            var expectedUri = "https://example.test/PAPIService/REST/public/v1/1033/100/1/search/bibs/keyword/KW?q=harry%20potter%20%26%20stone&sort=MP&page=2&bibsperpage=15";
+            Assert.AreEqual(expectedUri, handler.LastRequest!.RequestUri!.AbsoluteUri);
             var query = ParseQuery(handler.LastRequest.RequestUri.Query);
             Assert.IsFalse(query.ContainsKey("limit"));
             AssertAuthorizationHashesSentUri(handler.LastRequest, string.Empty);

--- a/src/polaris-api-csharpTests/Methods/RequestShape/PatronMessagesGetTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/PatronMessagesGetTests.cs
@@ -18,7 +18,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task PatronMessages_RequestShape_PreservesBooleanLikeQueryValue()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
 
             var response = await client.PatronMessagesGetAsync("ABC 123", unreadOnly: true, password: "1234");
@@ -70,7 +70,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
                     AuthenticationRequestCount++;
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent("{}", Encoding.UTF8, "application/json")
+                        Content = new StringContent(CreateEmptyJsonObject(), Encoding.UTF8, "application/json")
                     });
                 }
 
@@ -86,7 +86,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
 
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                    Content = new StringContent(CreatePapiResponseJson(), Encoding.UTF8, "application/json")
                 });
             }
         }

--- a/src/polaris-api-csharpTests/Methods/RequestShape/PatronReadingHistoryClearTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/PatronReadingHistoryClearTests.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task PatronReadingHistoryClearAsync_EnumeratesIdsOnceAndSendsCommaSeparatedIds()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var ids = new ThrowOnSecondEnumerationEnumerable(new[] { 101, 202, 303 });
 

--- a/src/polaris-api-csharpTests/Methods/RequestShape/PatronSearchTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/PatronSearchTests.cs
@@ -17,7 +17,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task PatronSearch_RequestShape_PreservesEncodedQuerySemantics()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             client.Token = new ProtectedToken { AccessToken = "token", AccessSecret = "secret", ExpirationDate = DateTime.Now.AddHours(1) };
 

--- a/src/polaris-api-csharpTests/Methods/RequestShape/PatronUpdateTests.cs
+++ b/src/polaris-api-csharpTests/Methods/RequestShape/PatronUpdateTests.cs
@@ -16,7 +16,7 @@ namespace Clc.Polaris.Api.Tests.Methods.RequestShape
         [TestMethod]
         public async Task PatronUpdate_RequestShape_IsStable()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
 
             var response = await client.PatronUpdateAsync("AB C/+#?=", new PatronUpdateParams { EmailAddress = "patron@example.test" }, "1234", ignoresa: true);

--- a/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiProtectedRequestTests.cs
@@ -193,7 +193,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
                 HttpStatusCode.OK,
                 CreateProtectedTokenJson("error-path-token", "error-path-secret", DateTime.Now.AddHours(1)),
                 HttpStatusCode.InternalServerError,
-                "{\"PAPIErrorCode\":1}");
+                CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get($"/protected/v1/1033/100/1/{ProtectedToken.Placeholder}/custom/unsupported");
             var originalPath = request.Path;
@@ -248,7 +248,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         {
             var handler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.Unauthorized,
-                "{\"PAPIErrorCode\":1}");
+                CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get("/public/v1/1033/100/1/api");
 
@@ -267,7 +267,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         {
             var handler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.Unauthorized,
-                "{\"PAPIErrorCode\":1}");
+                CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get(
                 "/public/v1/1033/100/1/patron/ABC123/basicdata",
@@ -288,7 +288,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         {
             var handler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.Unauthorized,
-                "{\"PAPIErrorCode\":1}");
+                CreatePapiResponseJson(1));
             var client = CreateProtectedClient(handler);
             var request = PapiRestRequest.Get("/public/v1/1033/100/1/patronlanguages");
 

--- a/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiQueryParameterTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/ExecutePapiQueryParameterTests.cs
@@ -15,7 +15,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_QueryParameterWithNullValue_OmitsParameterAndHashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
             request.QueryParameters.Add("q", "harry potter");
@@ -33,7 +33,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_QueryParameterWithEmptyStringValue_OmitsParameterAndHashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
             request.QueryParameters.Add("q", "harry potter");
@@ -51,7 +51,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_QueryParameterWithWhitespaceValue_OmitsParameterAndHashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
             request.QueryParameters.Add("q", "harry potter");
@@ -69,7 +69,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_QueryParameterWithBlankKey_OmitsParameterAndHashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
             request.QueryParameters.Add("q", "harry potter");
@@ -88,7 +88,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_OnlyIneffectiveQueryParameters_OmitsQueryStringAndHashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
             request.QueryParameters.Add(" ", "blank key");
@@ -112,7 +112,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
             {
                 CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
                 CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
-                var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+                var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
                 var client = CreateClient(handler);
                 var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
                 request.QueryParameters.Add("amount", 12.34m);
@@ -133,7 +133,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_NonEmptyQueryParameters_HashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW");
             request.QueryParameters.Add("q", "harry potter & stone");
@@ -149,7 +149,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
         [TestMethod]
         public async Task ExecutePapiAsync_ExistingQueryString_AppendsQueryParametersAndHashesSentUri()
         {
-            var handler = new CapturingHttpMessageHandler("{\"PAPIErrorCode\":0}");
+            var handler = new CapturingHttpMessageHandler(CreatePapiResponseJson());
             var client = CreateClient(handler);
             var request = new PapiRestRequest(HttpMethod.Get, "/public/v1/1033/100/1/search/bibs/keyword/KW?existing=1");
             request.QueryParameters.Add("q", "harry potter");

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientProtectedTokenCacheLockTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientProtectedTokenCacheLockTests.cs
@@ -108,21 +108,19 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
                         BlockedAuthenticationStarted.TrySetResult();
                         await CompleteBlockedAuthentication.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
 
+                        var blockedResponseJson = CreateProtectedTokenJson("blocked-token", "blocked-secret", new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
                         return new HttpResponseMessage(HttpStatusCode.OK)
                         {
-                            Content = new StringContent(
-                                "{\"PAPIErrorCode\":0,\"AccessToken\":\"blocked-token\",\"AccessSecret\":\"blocked-secret\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}",
-                                Encoding.UTF8,
-                                "application/json")
+                            Content = new StringContent(blockedResponseJson, Encoding.UTF8, "application/json")
                         };
                     }
 
+                    var independentResponseJson = CreateProtectedTokenJson("independent-token", "independent-secret", new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
                     return new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent(
-                            "{\"PAPIErrorCode\":0,\"AccessToken\":\"independent-token\",\"AccessSecret\":\"independent-secret\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}",
-                            Encoding.UTF8,
-                            "application/json")
+                        Content = new StringContent(independentResponseJson, Encoding.UTF8, "application/json")
                     };
                 }
 
@@ -135,7 +133,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
 
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}", Encoding.UTF8, "application/json")
+                    Content = new StringContent(CreatePapiResponseJson(), Encoding.UTF8, "application/json")
                 };
             }
         }

--- a/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientRequestMutationTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/PapiClientRequestMutationTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Clc.Polaris.Api.Models;
@@ -136,7 +137,7 @@ namespace Clc.Polaris.Api.Tests
 
                 var response = new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}")
+                    Content = new StringContent(JsonSerializer.Serialize(new { PAPIErrorCode = 0 }))
                 };
 
                 response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");

--- a/src/polaris-api-csharpTests/PapiClientBehavior/ProtectedTokenCacheTests.cs
+++ b/src/polaris-api-csharpTests/PapiClientBehavior/ProtectedTokenCacheTests.cs
@@ -121,7 +121,7 @@ namespace Clc.Polaris.Api.Tests.PapiClientBehavior
 
             var failingHandler = new ProtectedTokenHttpMessageHandler(
                 HttpStatusCode.Unauthorized,
-                "{\"PAPIErrorCode\":1}");
+                CreatePapiResponseJson(1));
             var cacheDisabledClient = CreateProtectedClient(failingHandler, hostname, staff);
             cacheDisabledClient.UseProtectedTokenCache = false;
 

--- a/src/polaris-api-csharpTests/TestInfrastructure/PapiClientTestBase.cs
+++ b/src/polaris-api-csharpTests/TestInfrastructure/PapiClientTestBase.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Clc.Polaris.Api;
@@ -92,15 +94,33 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
             };
         }
 
+        protected static string CreateJson(object value)
+        {
+            return JsonSerializer.Serialize(value);
+        }
+
+        protected static string CreatePapiResponseJson(int papiErrorCode = 0)
+        {
+            return CreateJson(new
+            {
+                PAPIErrorCode = papiErrorCode
+            });
+        }
+
+        protected static string CreateEmptyJsonObject()
+        {
+            return CreateJson(new { });
+        }
+
         protected static string CreateProtectedTokenJson(string accessToken, string accessSecret, DateTime expirationDate)
         {
-            return
-                "{" +
-                $"\"PAPIErrorCode\":0," +
-                $"\"AccessToken\":\"{accessToken}\"," +
-                $"\"AccessSecret\":\"{accessSecret}\"," +
-                $"\"AuthExpDate\":\"{expirationDate:O}\"" +
-                "}";
+            return CreateJson(new
+            {
+                PAPIErrorCode = 0,
+                AccessToken = accessToken,
+                AccessSecret = accessSecret,
+                AuthExpDate = expirationDate.ToString("O", CultureInfo.InvariantCulture)
+            });
         }
 
         protected static string CreateProtectedTokenJson(ProtectedToken token)
@@ -222,7 +242,7 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
                 LastRequest = request;
                 var response = new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("{\"PAPIErrorCode\":0}")
+                    Content = new StringContent(CreatePapiResponseJson())
                 };
                 response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
                 return Task.FromResult(response);
@@ -309,7 +329,7 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
                 _authenticationStatusCode = authenticationStatusCode;
                 _authenticationResponseJson = authenticationResponseJson ?? CreateProtectedTokenJson("protected-token", "protected-secret", DateTime.Now.AddHours(1));
                 _nonAuthenticationStatusCode = nonAuthenticationStatusCode;
-                _nonAuthenticationResponseJson = nonAuthenticationResponseJson ?? "{\"PAPIErrorCode\":0}";
+                _nonAuthenticationResponseJson = nonAuthenticationResponseJson ?? CreatePapiResponseJson();
             }
 
             public ProtectedTokenHttpMessageHandler(Func<CapturedPapiRequest, (HttpStatusCode StatusCode, string ResponseJson)> authenticationResponseFactory)
@@ -356,8 +376,8 @@ namespace Clc.Polaris.Api.Tests.TestInfrastructure
                 var requestNumber = Requests.Count;
 
                 var responseJson = requestNumber == 1
-                    ? "{\"PAPIErrorCode\":0,\"AccessToken\":\"protected-token\",\"AccessSecret\":\"protected-secret\",\"AuthExpDate\":\"2030-01-01T00:00:00Z\"}"
-                    : "{\"PAPIErrorCode\":0}";
+                    ? CreateProtectedTokenJson("protected-token", "protected-secret", new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+                    : CreatePapiResponseJson();
 
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {


### PR DESCRIPTION
### Motivation
- Replace repeatedly hand-constructed escaped JSON literals in test code with centralized helpers to improve readability and reduce visual noise.
- Preserve exact PAPI JSON property names and the explicit round-trip `AuthExpDate` formatting while avoiding behavioral changes.
- Make test HTTP handler implementations and long expected-URI assertions easier to read without changing test semantics.

### Description
- Added JSON helpers to `PapiClientTestBase`: `CreateJson(object)`, `CreatePapiResponseJson(int)`, `CreateEmptyJsonObject()` and `CreateProtectedTokenJson(...)` which explicitly formats `AuthExpDate` with `ToString("O", CultureInfo.InvariantCulture)` and uses `JsonSerializer.Serialize` internally (file: `TestInfrastructure/PapiClientTestBase.cs`).
- Replaced escaped JSON literals and inlined JSON strings across test handlers and tests with the new helpers (e.g. `CreatePapiResponseJson()`, `CreatePapiResponseJson(1)`, `CreateProtectedTokenJson(...)`, `CreateEmptyJsonObject()`), and introduced local `responseJson` variables in handlers where that improved readability.
- Improved readability of long expected URI assertions by assigning to `expectedUri` locals before `Assert.AreEqual`, and simplified some dense request-body assertions into named booleans for clarity (not changing assertions).
- Normalized using order in touched files and converted a single-item `new[] { bibId }` to collection-expression syntax `[bibId]` in `SynchBibsByIdGetExtensions.cs` (no API or behavioral changes).

### Testing
- Built the projects with `dotnet build src/polaris-api-csharp/Clc.Polaris.Api.csproj` and `dotnet build src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj`, both succeeded.
- Ran unit tests with `dotnet test src/polaris-api-csharpTests/Clc.Polaris.Api.Tests.csproj --filter "TestCategory=Unit"` and all unit tests passed (Passed: 199, Failed: 0).
- Searched for remaining escaped protected/PAPI JSON literals and related tokens and found none after changes (`rg` checks); no package reference changes were introduced.
- All changes are formatting/readability-only or test-infrastructure helpers and preserve runtime behavior and existing assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b61c530b08323aeafa265521e9a05)