### PR TITLE
Add GlobalUsings.cs and remove redundant local usings from library

### DIFF
--- a/src/polaris-api-csharp/Configuration/PapiSettings.cs
+++ b/src/polaris-api-csharp/Configuration/PapiSettings.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Configuration
 {
     public class PapiSettings : IPapiSettings

--- a/src/polaris-api-csharp/Configuration/PapiSettings.cs
+++ b/src/polaris-api-csharp/Configuration/PapiSettings.cs
@@ -1,4 +1,3 @@
-﻿using Clc.Polaris.Api.Models;
 
 namespace Clc.Polaris.Api.Configuration
 {

--- a/src/polaris-api-csharp/Extensions/BibSearchExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/BibSearchExtensions.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public static class BibSearchExtensions

--- a/src/polaris-api-csharp/Extensions/BibSearchExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/BibSearchExtensions.cs
@@ -1,7 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Extensions/CreatePatronBlocksExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/CreatePatronBlocksExtensions.cs
@@ -1,9 +1,4 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 using System.Globalization;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Extensions/HoldRequestCreateExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/HoldRequestCreateExtensions.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Extensions/HoldRequestCreateExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/HoldRequestCreateExtensions.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public static class HoldRequestCreateExtensions

--- a/src/polaris-api-csharp/Extensions/ItemRenewExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/ItemRenewExtensions.cs
@@ -1,7 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Extensions/ItemRenewExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/ItemRenewExtensions.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public static class ItemRenewExtensions

--- a/src/polaris-api-csharp/Extensions/PatronReadingHistoryClearExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/PatronReadingHistoryClearExtensions.cs
@@ -1,9 +1,4 @@
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Extensions/PatronReadingHistoryClearExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/PatronReadingHistoryClearExtensions.cs
@@ -1,5 +1,3 @@
-
-
 namespace Clc.Polaris.Api
 {
     public static class PatronReadingHistoryClearExtensions

--- a/src/polaris-api-csharp/Extensions/RecordSetContentPutExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/RecordSetContentPutExtensions.cs
@@ -1,5 +1,3 @@
-
-
 namespace Clc.Polaris.Api
 {
     public static class RecordSetContentPutExtensions

--- a/src/polaris-api-csharp/Extensions/RecordSetContentPutExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/RecordSetContentPutExtensions.cs
@@ -1,9 +1,4 @@
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Extensions/SynchBibsByIdGetExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/SynchBibsByIdGetExtensions.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public static class SynchBibsByIdGetExtensions

--- a/src/polaris-api-csharp/Extensions/SynchBibsByIdGetExtensions.cs
+++ b/src/polaris-api-csharp/Extensions/SynchBibsByIdGetExtensions.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/GlobalUsings.cs
+++ b/src/polaris-api-csharp/GlobalUsings.cs
@@ -1,0 +1,10 @@
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Net;
+global using System.Threading;
+global using System.Threading.Tasks;
+
+global using Clc.Polaris.Api.Models;
+global using Clc.Polaris.Api.Validation;
+global using Clc.Rest;

--- a/src/polaris-api-csharp/IPapiClient.cs
+++ b/src/polaris-api-csharp/IPapiClient.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/IPapiClient.cs
+++ b/src/polaris-api-csharp/IPapiClient.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public interface IPapiClient

--- a/src/polaris-api-csharp/Methods/ApiKeyValidate.cs
+++ b/src/polaris-api-csharp/Methods/ApiKeyValidate.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/ApiKeyValidate.cs
+++ b/src/polaris-api-csharp/Methods/ApiKeyValidate.cs
@@ -1,7 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/ApiVersionGet.cs
+++ b/src/polaris-api-csharp/Methods/ApiVersionGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/ApiVersionGet.cs
+++ b/src/polaris-api-csharp/Methods/ApiVersionGet.cs
@@ -1,7 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/AuthenticatePatron.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticatePatron.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/AuthenticatePatron.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticatePatron.cs
@@ -1,7 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
+++ b/src/polaris-api-csharp/Methods/AuthenticateStaffUser.cs
@@ -1,7 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
@@ -13,7 +9,6 @@ namespace Clc.Polaris.Api
 
             return await ExecutePapiAsync<ProtectedToken>(request, cancellationToken).ConfigureAwait(false);
         }
-
 
     }
 }

--- a/src/polaris-api-csharp/Methods/BibGet.cs
+++ b/src/polaris-api-csharp/Methods/BibGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/BibGet.cs
+++ b/src/polaris-api-csharp/Methods/BibGet.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
@@ -13,7 +8,6 @@ namespace Clc.Polaris.Api
         /// </summary>
         /// <param name="bibId"></param>
         /// <returns></returns>
-
 
         public async Task<IRestResponse<BibGetResult>> BibGetAsync(int bibId, int? branchId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/BibGetByTypeV2.cs
+++ b/src/polaris-api-csharp/Methods/BibGetByTypeV2.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/BibGetByTypeV2.cs
+++ b/src/polaris-api-csharp/Methods/BibGetByTypeV2.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/BibSearch.cs
+++ b/src/polaris-api-csharp/Methods/BibSearch.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/BibSearch.cs
+++ b/src/polaris-api-csharp/Methods/BibSearch.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/CollectionsGet.cs
+++ b/src/polaris-api-csharp/Methods/CollectionsGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<CollectionsGetResult>> CollectionsGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {
             Require.PositiveIfProvided(branchId);

--- a/src/polaris-api-csharp/Methods/CollectionsGet.cs
+++ b/src/polaris-api-csharp/Methods/CollectionsGet.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<CollectionsGetResult>> CollectionsGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
+++ b/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
+++ b/src/polaris-api-csharp/Methods/CreatePatronBlocks.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/DatesClosedGet.cs
+++ b/src/polaris-api-csharp/Methods/DatesClosedGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/DatesClosedGet.cs
+++ b/src/polaris-api-csharp/Methods/DatesClosedGet.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/HeadingsSearch.cs
+++ b/src/polaris-api-csharp/Methods/HeadingsSearch.cs
@@ -1,8 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/HeadingsSearch.cs
+++ b/src/polaris-api-csharp/Methods/HeadingsSearch.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/HoldRequestCancel.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestCancel.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/HoldRequestCreate.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestCreate.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<HoldRequestCreateResult>> HoldRequestCreateAsync(HoldRequestCreateParams holdParams, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(holdParams);

--- a/src/polaris-api-csharp/Methods/HoldRequestCreate.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestCreate.cs
@@ -1,15 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<HoldRequestCreateResult>> HoldRequestCreateAsync(HoldRequestCreateParams holdParams, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestGetList.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/HoldRequestReactivate.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestReactivate.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/HoldRequestReactivate.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestReactivate.cs
@@ -1,9 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/HoldRequestReply.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestReply.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/HoldRequestReply.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestReply.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/HoldRequestSuspend.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestSuspend.cs
@@ -1,5 +1,3 @@
-
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/HoldRequestSuspend.cs
+++ b/src/polaris-api-csharp/Methods/HoldRequestSuspend.cs
@@ -1,10 +1,4 @@
 
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/HoldingsGet.cs
+++ b/src/polaris-api-csharp/Methods/HoldingsGet.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
@@ -13,7 +8,6 @@ namespace Clc.Polaris.Api
         /// <param name="bibId">BibliograhpicRecordID of the record.</param>
         /// <returns>An object containing a list of holdings information for specified BibliographicRecordID.</returns>
         /// <seealso cref="BibHoldingsGetResult"/>
-
 
         public async Task<IRestResponse<BibHoldingsGetResult>> HoldingsGetAsync(int bibId, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/ILLRequestCancel.cs
+++ b/src/polaris-api-csharp/Methods/ILLRequestCancel.cs
@@ -1,8 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/ILLRequestCancel.cs
+++ b/src/polaris-api-csharp/Methods/ILLRequestCancel.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/ItemCheckInPost.cs
+++ b/src/polaris-api-csharp/Methods/ItemCheckInPost.cs
@@ -1,8 +1,3 @@
-﻿using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/ItemCheckInPost.cs
+++ b/src/polaris-api-csharp/Methods/ItemCheckInPost.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/ItemCheckOutPost.cs
+++ b/src/polaris-api-csharp/Methods/ItemCheckOutPost.cs
@@ -1,8 +1,3 @@
-﻿using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/ItemCheckOutPost.cs
+++ b/src/polaris-api-csharp/Methods/ItemCheckOutPost.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/ItemRenew.cs
+++ b/src/polaris-api-csharp/Methods/ItemRenew.cs
@@ -1,8 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/ItemRenew.cs
+++ b/src/polaris-api-csharp/Methods/ItemRenew.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/ItemStatusesGet.cs
+++ b/src/polaris-api-csharp/Methods/ItemStatusesGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<ItemStatusesGetResult>> ItemStatusesGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {
             Require.PositiveIfProvided(branchId);

--- a/src/polaris-api-csharp/Methods/ItemStatusesGet.cs
+++ b/src/polaris-api-csharp/Methods/ItemStatusesGet.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<ItemStatusesGetResult>> ItemStatusesGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
+++ b/src/polaris-api-csharp/Methods/ItemUpdateBarcode.cs
@@ -1,9 +1,4 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 using System.Globalization;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/LimitFiltersGet.cs
+++ b/src/polaris-api-csharp/Methods/LimitFiltersGet.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<LimitFiltersGetResult>> LimitFiltersGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/LimitFiltersGet.cs
+++ b/src/polaris-api-csharp/Methods/LimitFiltersGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<LimitFiltersGetResult>> LimitFiltersGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {
             Require.PositiveIfProvided(branchId);

--- a/src/polaris-api-csharp/Methods/MARCTypeOfMaterialsGet.cs
+++ b/src/polaris-api-csharp/Methods/MARCTypeOfMaterialsGet.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<MARCTypeOfMaterialsGetResult>> MARCTypeOfMaterialsGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/MARCTypeOfMaterialsGet.cs
+++ b/src/polaris-api-csharp/Methods/MARCTypeOfMaterialsGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<MARCTypeOfMaterialsGetResult>> MARCTypeOfMaterialsGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {
             Require.PositiveIfProvided(branchId);

--- a/src/polaris-api-csharp/Methods/MaterialTypesGet.cs
+++ b/src/polaris-api-csharp/Methods/MaterialTypesGet.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<MaterialTypesGetResult>> MaterialTypesGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/MaterialTypesGet.cs
+++ b/src/polaris-api-csharp/Methods/MaterialTypesGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<MaterialTypesGetResult>> MaterialTypesGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {
             Require.PositiveIfProvided(branchId);

--- a/src/polaris-api-csharp/Methods/MultipartGet.cs
+++ b/src/polaris-api-csharp/Methods/MultipartGet.cs
@@ -1,8 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/MultipartGet.cs
+++ b/src/polaris-api-csharp/Methods/MultipartGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
+++ b/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
+++ b/src/polaris-api-csharp/Methods/NotificationQueueGet.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/NotificationUpdate.cs
+++ b/src/polaris-api-csharp/Methods/NotificationUpdate.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/NotificationUpdate.cs
+++ b/src/polaris-api-csharp/Methods/NotificationUpdate.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/OrganizationsGet.cs
+++ b/src/polaris-api-csharp/Methods/OrganizationsGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/OrganizationsGet.cs
+++ b/src/polaris-api-csharp/Methods/OrganizationsGet.cs
@@ -1,7 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountCreateCredit.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/PatronAccountCreateTitleList.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountCreateTitleList.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronAccountCreateTitleListResult>> PatronAccountCreateTitleListAsync(string barcode, string listName, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{OrganizationId}/patron/{EncodeBarcodePathSegment(barcode)}/patronaccountcreatetitlelist";

--- a/src/polaris-api-csharp/Methods/PatronAccountCreateTitleList.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountCreateTitleList.cs
@@ -1,13 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronAccountCreateTitleListResult>> PatronAccountCreateTitleListAsync(string barcode, string listName, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronAccountDeleteTitleList.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDeleteTitleList.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronAccountDeleteTitleListResult>> PatronAccountDeleteTitleListAsync(string barcode, int listId, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronAccountDeleteTitleList.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDeleteTitleList.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronAccountDeleteTitleListResult>> PatronAccountDeleteTitleListAsync(string barcode, int listId, string password = "", CancellationToken cancellationToken = default)
         {
             Require.Positive(listId);

--- a/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronAccountDepositCreditResult>> PatronAccountDepositCreditAsync(string barcode, double txnAmount, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountDepositCredit.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronAccountDepositCreditResult>> PatronAccountDepositCreditAsync(string barcode, double txnAmount, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
             Require.PositiveIfProvided(workstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountGet.cs
@@ -1,13 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronAccountGetResult>> PatronAccountGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronAccountGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronAccountGetResult>> PatronAccountGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{OrganizationId}/patron/{EncodeBarcodePathSegment(barcode)}/account/outstanding";

--- a/src/polaris-api-csharp/Methods/PatronAccountGetTitleLists.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountGetTitleLists.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronAccountGetTitleListsResult>> PatronAccountGetTitleListsAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{OrganizationId}/patron/{EncodeBarcodePathSegment(barcode)}/patronaccountgettitlelists";

--- a/src/polaris-api-csharp/Methods/PatronAccountGetTitleLists.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountGetTitleLists.cs
@@ -1,13 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronAccountGetTitleListsResult>> PatronAccountGetTitleListsAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronAccountPay.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPay.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronAccountPayResult>> PatronAccountPayAsync(string barcode, int txnId, double txnAmount, PaymentMethod paymentMethod, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
             Require.Positive(txnId);

--- a/src/polaris-api-csharp/Methods/PatronAccountPay.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPay.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronAccountPayResult>> PatronAccountPayAsync(string barcode, int txnId, double txnAmount, PaymentMethod paymentMethod, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountPayAll.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronAccountRefundCreditResult>> PatronAccountRefundCreditAsync(string barcode, double txnAmount, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
             Require.PositiveIfProvided(workstationId);

--- a/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountRefundCredit.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronAccountRefundCreditResult>> PatronAccountRefundCreditAsync(string barcode, double txnAmount, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronAccountVoidPaymentResult>> PatronAccountVoidAsync(string barcode, int paymentTxnId, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
+++ b/src/polaris-api-csharp/Methods/PatronAccountVoid.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronAccountVoidPaymentResult>> PatronAccountVoidAsync(string barcode, int paymentTxnId, int? workstationId = null, int? userId = null, string note = "", CancellationToken cancellationToken = default)
         {
             Require.Positive(paymentTxnId);

--- a/src/polaris-api-csharp/Methods/PatronBasicDataGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronBasicDataGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronBasicDataGetResult>> PatronBasicDataGetAsync(string barcode, string password = "", bool addresses = false, bool notes = false, CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{OrganizationId}/patron/{EncodeBarcodePathSegment(barcode)}/basicdata";

--- a/src/polaris-api-csharp/Methods/PatronBasicDataGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronBasicDataGet.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronBasicDataGetResult>> PatronBasicDataGetAsync(string barcode, string password = "", bool addresses = false, bool notes = false, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronCirculateBlocksGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronCirculateBlocksGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronCirculateBlocksResult>> PatronCirculateBlocksGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{OrganizationId}/patron/{EncodeBarcodePathSegment(barcode)}/circulationblocks";

--- a/src/polaris-api-csharp/Methods/PatronCirculateBlocksGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronCirculateBlocksGet.cs
@@ -1,13 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronCirculateBlocksResult>> PatronCirculateBlocksGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronCodesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronCodesGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronCodesGetResult>> PatronCodesGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {
             Require.PositiveIfProvided(branchId);

--- a/src/polaris-api-csharp/Methods/PatronCodesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronCodesGet.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronCodesGetResult>> PatronCodesGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronHoldRequestsGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronHoldRequestsGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronHoldRequestsGetResult>> PatronHoldRequestsGetAsync(string barcode, PatronHoldStatus status = PatronHoldStatus.all, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{OrganizationId}/patron/{EncodeBarcodePathSegment(barcode)}/holdrequests/{status}";

--- a/src/polaris-api-csharp/Methods/PatronHoldRequestsGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronHoldRequestsGet.cs
@@ -1,13 +1,8 @@
 
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronHoldRequestsGetResult>> PatronHoldRequestsGetAsync(string barcode, PatronHoldStatus status = PatronHoldStatus.all, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronILLRequestsGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronILLRequestsGet.cs
@@ -1,13 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronILLRequestsGetResult>> PatronILLRequestsGetAsync(string barcode, ILLStatus status = ILLStatus.All, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronILLRequestsGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronILLRequestsGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronILLRequestsGetResult>> PatronILLRequestsGetAsync(string barcode, ILLStatus status = ILLStatus.All, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{OrganizationId}/patron/{EncodeBarcodePathSegment(barcode)}/illrequests/{status}";

--- a/src/polaris-api-csharp/Methods/PatronItemsOutGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronItemsOutGet.cs
@@ -1,12 +1,7 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronItemsOutGetResult>> PatronItemsOutGetAsync(string barcode, PatronItemsOutGetStatus status = PatronItemsOutGetStatus.All, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronItemsOutGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronItemsOutGet.cs
@@ -2,7 +2,6 @@ namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronItemsOutGetResult>> PatronItemsOutGetAsync(string barcode, PatronItemsOutGetStatus status = PatronItemsOutGetStatus.All, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{OrganizationId}/patron/{EncodeBarcodePathSegment(barcode)}/itemsout/{status}";

--- a/src/polaris-api-csharp/Methods/PatronLanguagesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronLanguagesGet.cs
@@ -1,8 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/PatronLanguagesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronLanguagesGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/PatronMessageDelete.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessageDelete.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PAPIResult>> PatronMessageDeleteAsync(string barcode, PatronMessageType messageType, int messageId, string password = "", CancellationToken cancellationToken = default)
         {
             Require.Positive(messageId);

--- a/src/polaris-api-csharp/Methods/PatronMessageDelete.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessageDelete.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PAPIResult>> PatronMessageDeleteAsync(string barcode, PatronMessageType messageType, int messageId, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronMessageUpdateStatus.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessageUpdateStatus.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PAPIResult>> PatronMessageUpdateStatusAsync(string barcode, PatronMessageType messageType, int messageId, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronMessageUpdateStatus.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessageUpdateStatus.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PAPIResult>> PatronMessageUpdateStatusAsync(string barcode, PatronMessageType messageType, int messageId, string password = "", CancellationToken cancellationToken = default)
         {
             Require.Positive(messageId);

--- a/src/polaris-api-csharp/Methods/PatronMessagesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessagesGet.cs
@@ -1,13 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronMessagesGetResult>> PatronMessagesGetAsync(string barcode, bool unreadOnly = false, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronMessagesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronMessagesGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronMessagesGetResult>> PatronMessagesGetAsync(string barcode, bool unreadOnly = false, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{OrganizationId}/patron/{EncodeBarcodePathSegment(barcode)}/messages";

--- a/src/polaris-api-csharp/Methods/PatronNotesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronNotesGet.cs
@@ -1,7 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/PatronNotesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronNotesGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/PatronPreferencesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronPreferencesGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronPreferencesGetResult>> PatronPreferencesGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{OrganizationId}/patron/{EncodeBarcodePathSegment(barcode)}/preferences";

--- a/src/polaris-api-csharp/Methods/PatronPreferencesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronPreferencesGet.cs
@@ -1,13 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronPreferencesGetResult>> PatronPreferencesGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
+++ b/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
+++ b/src/polaris-api-csharp/Methods/PatronReadingHistoryClear.cs
@@ -1,10 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
@@ -18,7 +11,6 @@ namespace Clc.Polaris.Api
             {
                 Require.Positive(id);
             }
-
 
             var url = $"/public/v1/1033/100/{OrganizationId}/patron/{EncodeBarcodePathSegment(barcode)}/readinghistory";
             var request = PapiRestRequest.Delete(url, password: password ?? "");

--- a/src/polaris-api-csharp/Methods/PatronReadingHistoryGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronReadingHistoryGet.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronReadingHistoryGetResult>> PatronReadingHistoryGetAsync(string barcode, int page = 1, int rowsPerPage = 50, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronReadingHistoryGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronReadingHistoryGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronReadingHistoryGetResult>> PatronReadingHistoryGetAsync(string barcode, int page = 1, int rowsPerPage = 50, string password = "", CancellationToken cancellationToken = default)
         {
             Require.Positive(page);

--- a/src/polaris-api-csharp/Methods/PatronRegistrationCreate.cs
+++ b/src/polaris-api-csharp/Methods/PatronRegistrationCreate.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/PatronRegistrationCreate.cs
+++ b/src/polaris-api-csharp/Methods/PatronRegistrationCreate.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/PatronRegistrationUpdateV2.cs
+++ b/src/polaris-api-csharp/Methods/PatronRegistrationUpdateV2.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/PatronRegistrationUpdateV2.cs
+++ b/src/polaris-api-csharp/Methods/PatronRegistrationUpdateV2.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/PatronRenewBlocksGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronRenewBlocksGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronRenewBlocksResult>> PatronRenewBlocksGetAsync(int patronId, int? branchId = null, CancellationToken cancellationToken = default)
         {
             Require.Positive(patronId);

--- a/src/polaris-api-csharp/Methods/PatronRenewBlocksGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronRenewBlocksGet.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronRenewBlocksResult>> PatronRenewBlocksGetAsync(int patronId, int? branchId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronSavedSearchesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronSavedSearchesGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronSavedSearchesGetResult>> PatronSavedSearchesGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{OrganizationId}/patron/{EncodeBarcodePathSegment(barcode)}/savedsearches";

--- a/src/polaris-api-csharp/Methods/PatronSavedSearchesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronSavedSearchesGet.cs
@@ -1,13 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronSavedSearchesGetResult>> PatronSavedSearchesGetAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronSearch.cs
+++ b/src/polaris-api-csharp/Methods/PatronSearch.cs
@@ -1,13 +1,7 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronSearchResult>> PatronSearchAsync(string query, int page = 1, int pageSize = 10, PatronSortKeys sortBy = PatronSortKeys.PATN, int? orgId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronSearch.cs
+++ b/src/polaris-api-csharp/Methods/PatronSearch.cs
@@ -2,7 +2,6 @@ namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronSearchResult>> PatronSearchAsync(string query, int page = 1, int pageSize = 10, PatronSortKeys sortBy = PatronSortKeys.PATN, int? orgId = null, CancellationToken cancellationToken = default)
         {
             Require.Positive(page);

--- a/src/polaris-api-csharp/Methods/PatronStatisticalClassesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronStatisticalClassesGet.cs
@@ -1,8 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/PatronStatisticalClassesGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronStatisticalClassesGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/PatronTitleListAddTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListAddTitle.cs
@@ -1,10 +1,7 @@
-
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronTitleListAddTitleResult>> PatronTitleListAddTitleAsync(string barcode, int recordStoreId, int localControlNumber, string password = "", CancellationToken cancellationToken = default)
         {
             Require.Positive(recordStoreId);

--- a/src/polaris-api-csharp/Methods/PatronTitleListAddTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListAddTitle.cs
@@ -1,15 +1,9 @@
 
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronTitleListAddTitleResult>> PatronTitleListAddTitleAsync(string barcode, int recordStoreId, int localControlNumber, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronTitleListCopyAllTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListCopyAllTitles.cs
@@ -1,15 +1,9 @@
 
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronTitleListCopyAllTitlesResult>> PatronTitleListCopyAllTitlesAsync(string barcode, int fromRecordStoreId, int toRecordStoreId, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronTitleListCopyAllTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListCopyAllTitles.cs
@@ -1,10 +1,7 @@
-
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronTitleListCopyAllTitlesResult>> PatronTitleListCopyAllTitlesAsync(string barcode, int fromRecordStoreId, int toRecordStoreId, string password = "", CancellationToken cancellationToken = default)
         {
             Require.Positive(fromRecordStoreId);

--- a/src/polaris-api-csharp/Methods/PatronTitleListCopyTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListCopyTitle.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/PatronTitleListCopyTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListCopyTitle.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/PatronTitleListDeleteAllTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListDeleteAllTitles.cs
@@ -1,10 +1,7 @@
-
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronTitleListDeleteAllTitlesResult>> PatronTitleListDeleteAllTitlesAsync(string barcode, int listId, string password = "", CancellationToken cancellationToken = default)
         {
             Require.Positive(listId);

--- a/src/polaris-api-csharp/Methods/PatronTitleListDeleteAllTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListDeleteAllTitles.cs
@@ -1,15 +1,9 @@
 
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronTitleListDeleteAllTitlesResult>> PatronTitleListDeleteAllTitlesAsync(string barcode, int listId, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs
@@ -1,5 +1,3 @@
-
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs
@@ -1,9 +1,4 @@
 
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
@@ -17,7 +12,6 @@ namespace Clc.Polaris.Api
         /// <param name="position">starts at 1, not 0</param>
         /// <param name="password"></param>
         /// <returns></returns>
-
 
         public async Task<IRestResponse<PatronTitleListDeleteTitleResult>> PatronTitleListDeleteTitleAsync(string barcode, int listId, int position, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronTitleListGetTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListGetTitles.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronTitleListGetTitlesResult>> PatronTitleListGetTitlesAsync(string barcode, int listId, int startPosition = 1, int endPosition = 100, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronTitleListGetTitles.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListGetTitles.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronTitleListGetTitlesResult>> PatronTitleListGetTitlesAsync(string barcode, int listId, int startPosition = 1, int endPosition = 100, string password = "", CancellationToken cancellationToken = default)
         {
             Require.Positive(listId);

--- a/src/polaris-api-csharp/Methods/PatronTitleListMoveTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListMoveTitle.cs
@@ -1,5 +1,3 @@
-
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/PatronTitleListMoveTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListMoveTitle.cs
@@ -1,9 +1,4 @@
 
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
@@ -18,7 +13,6 @@ namespace Clc.Polaris.Api
         /// <param name="toRecordStoreId"></param>
         /// <param name="password"></param>
         /// <returns></returns>
-
 
         public async Task<IRestResponse<PatronTitleListMoveTitleResult>> PatronTitleListMoveTitleAsync(string barcode, int fromRecordStoreId, int fromPosition, int toRecordStoreId, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronUdfConfigsGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronUdfConfigsGet.cs
@@ -1,8 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/PatronUdfConfigsGet.cs
+++ b/src/polaris-api-csharp/Methods/PatronUdfConfigsGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/PatronUpdate.cs
+++ b/src/polaris-api-csharp/Methods/PatronUpdate.cs
@@ -1,5 +1,3 @@
-
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/PatronUpdate.cs
+++ b/src/polaris-api-csharp/Methods/PatronUpdate.cs
@@ -1,10 +1,4 @@
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/PatronUpdateUserName.cs
+++ b/src/polaris-api-csharp/Methods/PatronUpdateUserName.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronUpdateResult>> PatronUpdateUserNameAsync(string barcode, string newUsername, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronUpdateUserName.cs
+++ b/src/polaris-api-csharp/Methods/PatronUpdateUserName.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronUpdateResult>> PatronUpdateUserNameAsync(string barcode, string newUsername, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{OrganizationId}/patron/{EncodeBarcodePathSegment(barcode)}/username/{WebUtility.UrlEncode(newUsername)}";

--- a/src/polaris-api-csharp/Methods/PatronValidate.cs
+++ b/src/polaris-api-csharp/Methods/PatronValidate.cs
@@ -1,12 +1,7 @@
-using Clc.Polaris.Api.Models;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PatronValidateResult>> PatronValidateAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PatronValidate.cs
+++ b/src/polaris-api-csharp/Methods/PatronValidate.cs
@@ -2,7 +2,6 @@ namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PatronValidateResult>> PatronValidateAsync(string barcode, string password = "", CancellationToken cancellationToken = default)
         {
             var url = $"/public/v1/1033/100/{OrganizationId}/patron/{EncodeBarcodePathSegment(barcode)}";

--- a/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
+++ b/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
@@ -2,7 +2,6 @@ namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<GetBarcodeAndPatronIDResult>> Patron_GetBarcodeFromIdAsync(int patronId, CancellationToken cancellationToken = default)
         {
             Require.Positive(patronId);

--- a/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
+++ b/src/polaris-api-csharp/Methods/Patron_GetBarcodeFromID.cs
@@ -1,13 +1,7 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<GetBarcodeAndPatronIDResult>> Patron_GetBarcodeFromIdAsync(int patronId, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/PickupAreasGet.cs
+++ b/src/polaris-api-csharp/Methods/PickupAreasGet.cs
@@ -1,8 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/PickupAreasGet.cs
+++ b/src/polaris-api-csharp/Methods/PickupAreasGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/PickupBranchesGet.cs
+++ b/src/polaris-api-csharp/Methods/PickupBranchesGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PickupBranchesGetResult>> PickupBranchesGetAsync(int? organizationId = null, CancellationToken cancellationToken = default)
         {
             Require.PositiveIfProvided(organizationId);

--- a/src/polaris-api-csharp/Methods/PickupBranchesGet.cs
+++ b/src/polaris-api-csharp/Methods/PickupBranchesGet.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PickupBranchesGetResult>> PickupBranchesGetAsync(int? organizationId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PAPIResult>> RecordSetContentPutAsync(int recordSetId, IEnumerable<int> records, RecordSetContentPutActions action, int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {
             Require.Positive(recordSetId);

--- a/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetContentPut.cs
@@ -1,17 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PAPIResult>> RecordSetContentPutAsync(int recordSetId, IEnumerable<int> records, RecordSetContentPutActions action, int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<RecordSetRecordsGetResult>> RecordSetRecordsGetAsync(int recordSetId, int? userId = null, int? workstationId = null, int startIndex = 0, int numRecords = 1000, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
+++ b/src/polaris-api-csharp/Methods/RecordSetRecordsGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<RecordSetRecordsGetResult>> RecordSetRecordsGetAsync(int recordSetId, int? userId = null, int? workstationId = null, int startIndex = 0, int numRecords = 1000, CancellationToken cancellationToken = default)
         {
             Require.Positive(recordSetId);

--- a/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
+++ b/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<RemoteStorageItemsGetResult>> RemoteStorageItemsGetAsync(int branchId, string startDate, string endDate, int maxItems, int listType, int? startItemRecordId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
+++ b/src/polaris-api-csharp/Methods/RemoteStorageItemsGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<RemoteStorageItemsGetResult>> RemoteStorageItemsGetAsync(int branchId, string startDate, string endDate, int maxItems, int listType, int? startItemRecordId = null, CancellationToken cancellationToken = default)
         {
             Require.Positive(branchId);

--- a/src/polaris-api-csharp/Methods/RequestsUpdateStatus.cs
+++ b/src/polaris-api-csharp/Methods/RequestsUpdateStatus.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/RequestsUpdateStatus.cs
+++ b/src/polaris-api-csharp/Methods/RequestsUpdateStatus.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/SAMobilePhoneCarriersGet.cs
+++ b/src/polaris-api-csharp/Methods/SAMobilePhoneCarriersGet.cs
@@ -1,8 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/SAMobilePhoneCarriersGet.cs
+++ b/src/polaris-api-csharp/Methods/SAMobilePhoneCarriersGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
+++ b/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
+++ b/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
@@ -14,7 +9,6 @@ namespace Clc.Polaris.Api
         /// <param name="orgId"></param>
         /// <param name="attribute"></param>
         /// <returns></returns>
-
 
         public async Task<IRestResponse<StringResult>> SA_GetValueByOrgAsync(string attribute, int? organizationId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/ShelfLocationsGet.cs
+++ b/src/polaris-api-csharp/Methods/ShelfLocationsGet.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<ShelfLocationsGetResult>> ShelfLocationsGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {
             Require.PositiveIfProvided(branchId);

--- a/src/polaris-api-csharp/Methods/ShelfLocationsGet.cs
+++ b/src/polaris-api-csharp/Methods/ShelfLocationsGet.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<ShelfLocationsGetResult>> ShelfLocationsGetAsync(int? branchId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/SortOptionsGet.cs
+++ b/src/polaris-api-csharp/Methods/SortOptionsGet.cs
@@ -1,8 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/SortOptionsGet.cs
+++ b/src/polaris-api-csharp/Methods/SortOptionsGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
+++ b/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
+++ b/src/polaris-api-csharp/Methods/Synch_BibsByIdGet.cs
@@ -1,9 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/SysHoldStatusesGet.cs
+++ b/src/polaris-api-csharp/Methods/SysHoldStatusesGet.cs
@@ -1,8 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/SysHoldStatusesGet.cs
+++ b/src/polaris-api-csharp/Methods/SysHoldStatusesGet.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient

--- a/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePatronNotesData.cs
@@ -1,8 +1,3 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Methods/UpdatePickupBranchID.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePickupBranchID.cs
@@ -1,14 +1,8 @@
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
 
         public async Task<IRestResponse<PAPIResult>> UpdatePickupBranchIDAsync(string barcode, int requestId, int pickupBranchId, string password = "", int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {

--- a/src/polaris-api-csharp/Methods/UpdatePickupBranchID.cs
+++ b/src/polaris-api-csharp/Methods/UpdatePickupBranchID.cs
@@ -1,9 +1,7 @@
-
 namespace Clc.Polaris.Api
 {
     public partial class PapiClient
     {
-
         public async Task<IRestResponse<PAPIResult>> UpdatePickupBranchIDAsync(string barcode, int requestId, int pickupBranchId, string password = "", int? userId = null, int? workstationId = null, CancellationToken cancellationToken = default)
         {
             Require.Positive(requestId);

--- a/src/polaris-api-csharp/Models/BibGetByTypeResult.cs
+++ b/src/polaris-api-csharp/Models/BibGetByTypeResult.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace Clc.Polaris.Api.Models

--- a/src/polaris-api-csharp/Models/BibGetResult.cs
+++ b/src/polaris-api-csharp/Models/BibGetResult.cs
@@ -1,5 +1,3 @@
-﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace Clc.Polaris.Api.Models
 {
@@ -205,7 +203,6 @@ namespace Clc.Polaris.Api.Models
             return BibGetRows.Where(b => b.ElementID == id).Select(b => b.Value).OfType<string>().ToList();
         }
     }
-
 
     /// <summary>
     /// Contains a the value of a bibliographic record field.

--- a/src/polaris-api-csharp/Models/BibGetResult.cs
+++ b/src/polaris-api-csharp/Models/BibGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/BibHoldingsGetResult.cs
+++ b/src/polaris-api-csharp/Models/BibHoldingsGetResult.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace Clc.Polaris.Api.Models

--- a/src/polaris-api-csharp/Models/BibSearchResult.cs
+++ b/src/polaris-api-csharp/Models/BibSearchResult.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/BibSearchResult.cs
+++ b/src/polaris-api-csharp/Models/BibSearchResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/CollectionsGetResult.cs
+++ b/src/polaris-api-csharp/Models/CollectionsGetResult.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/CollectionsGetResult.cs
+++ b/src/polaris-api-csharp/Models/CollectionsGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class CollectionsGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/DatesClosedGetResult.cs
+++ b/src/polaris-api-csharp/Models/DatesClosedGetResult.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/DatesClosedGetResult.cs
+++ b/src/polaris-api-csharp/Models/DatesClosedGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class DatesClosedGetResult

--- a/src/polaris-api-csharp/Models/GetBarcodeAndPatronIDResult.cs
+++ b/src/polaris-api-csharp/Models/GetBarcodeAndPatronIDResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/GetBarcodeAndPatronIDResult.cs
+++ b/src/polaris-api-csharp/Models/GetBarcodeAndPatronIDResult.cs
@@ -1,5 +1,3 @@
-﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/HeadingsSearchResult.cs
+++ b/src/polaris-api-csharp/Models/HeadingsSearchResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class HeadingsSearchResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/HeadingsSearchResult.cs
+++ b/src/polaris-api-csharp/Models/HeadingsSearchResult.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/HoldRequestActivationData.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestActivationData.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class HoldRequestActivationData

--- a/src/polaris-api-csharp/Models/HoldRequestActivationData.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestActivationData.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/HoldRequestActivationResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestActivationResult.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/HoldRequestActivationResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestActivationResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/HoldRequestCancelResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestCancelResult.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/HoldRequestCancelResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestCancelResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/HoldRequestCreateParams.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestCreateParams.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/HoldRequestCreateParams.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestCreateParams.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/HoldRequestCreateResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestCreateResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/HoldRequestCreateResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestCreateResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/HoldRequestGetListResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestGetListResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class HoldRequestGetListResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/HoldRequestGetListResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestGetListResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/ILLRequestCancelResult.cs
+++ b/src/polaris-api-csharp/Models/ILLRequestCancelResult.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace Clc.Polaris.Api.Models

--- a/src/polaris-api-csharp/Models/ItemCheckInResult.cs
+++ b/src/polaris-api-csharp/Models/ItemCheckInResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class ItemCheckInResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/ItemCheckInResult.cs
+++ b/src/polaris-api-csharp/Models/ItemCheckInResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/ItemCheckOutResult.cs
+++ b/src/polaris-api-csharp/Models/ItemCheckOutResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class ItemCheckOutResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/ItemCheckOutResult.cs
+++ b/src/polaris-api-csharp/Models/ItemCheckOutResult.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/ItemRenewResultWrapper.cs
+++ b/src/polaris-api-csharp/Models/ItemRenewResultWrapper.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/ItemRenewResultWrapper.cs
+++ b/src/polaris-api-csharp/Models/ItemRenewResultWrapper.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class ItemRenewResultWrapper : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/ItemStatusesGetResult.cs
+++ b/src/polaris-api-csharp/Models/ItemStatusesGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class ItemStatusesGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/ItemStatusesGetResult.cs
+++ b/src/polaris-api-csharp/Models/ItemStatusesGetResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/LimitFiltersGetResult.cs
+++ b/src/polaris-api-csharp/Models/LimitFiltersGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class LimitFiltersGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/LimitFiltersGetResult.cs
+++ b/src/polaris-api-csharp/Models/LimitFiltersGetResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/MARCTypeOfMaterialsGetResult.cs
+++ b/src/polaris-api-csharp/Models/MARCTypeOfMaterialsGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class MARCTypeOfMaterialsGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/MARCTypeOfMaterialsGetResult.cs
+++ b/src/polaris-api-csharp/Models/MARCTypeOfMaterialsGetResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/MaterialTypesGetResult.cs
+++ b/src/polaris-api-csharp/Models/MaterialTypesGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class MaterialTypesGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/MaterialTypesGetResult.cs
+++ b/src/polaris-api-csharp/Models/MaterialTypesGetResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/MultipartGetResult.cs
+++ b/src/polaris-api-csharp/Models/MultipartGetResult.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/MultipartGetResult.cs
+++ b/src/polaris-api-csharp/Models/MultipartGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class MultipartGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/NotificationUpdateParams.cs
+++ b/src/polaris-api-csharp/Models/NotificationUpdateParams.cs
@@ -1,4 +1,3 @@
-using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/NotificationUpdateParams.cs
+++ b/src/polaris-api-csharp/Models/NotificationUpdateParams.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/OrganizationsGetResult.cs
+++ b/src/polaris-api-csharp/Models/OrganizationsGetResult.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/OrganizationsGetResult.cs
+++ b/src/polaris-api-csharp/Models/OrganizationsGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/PapiRestRequest.cs
+++ b/src/polaris-api-csharp/Models/PapiRestRequest.cs
@@ -1,5 +1,4 @@
 using Clc.Rest.Models;
-using System;
 using System.Net.Http;
 
 namespace Clc.Polaris.Api.Models

--- a/src/polaris-api-csharp/Models/PatronAccountGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountGetResult.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace Clc.Polaris.Api.Models

--- a/src/polaris-api-csharp/Models/PatronAccountGetTitleListsResult.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountGetTitleListsResult.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronAccountGetTitleListsResult.cs
+++ b/src/polaris-api-csharp/Models/PatronAccountGetTitleListsResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class PatronAccountGetTitleListsResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/PatronAddress.cs
+++ b/src/polaris-api-csharp/Models/PatronAddress.cs
@@ -60,7 +60,6 @@
         /// </summary>
         public int AddressTypeID { get; set; }
 
-
         public string ZipPlusFour { get; set; }
     }
 }

--- a/src/polaris-api-csharp/Models/PatronAuthenticationToken.cs
+++ b/src/polaris-api-csharp/Models/PatronAuthenticationToken.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class PatronAuthenticationToken

--- a/src/polaris-api-csharp/Models/PatronAuthenticationToken.cs
+++ b/src/polaris-api-csharp/Models/PatronAuthenticationToken.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronBasicDataGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronBasicDataGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/PatronBasicDataGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronBasicDataGetResult.cs
@@ -1,6 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronCirculateBlocksResult.cs
+++ b/src/polaris-api-csharp/Models/PatronCirculateBlocksResult.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronCirculateBlocksResult.cs
+++ b/src/polaris-api-csharp/Models/PatronCirculateBlocksResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/PatronCodesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronCodesGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class PatronCodesGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/PatronCodesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronCodesGetResult.cs
@@ -1,5 +1,3 @@
-﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronHoldRequestsGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronHoldRequestsGetResult.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronHoldRequestsGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronHoldRequestsGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/PatronIllRequestsGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronIllRequestsGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
 

--- a/src/polaris-api-csharp/Models/PatronIllRequestsGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronIllRequestsGetResult.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronItemsOutGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronItemsOutGetResult.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronItemsOutGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronItemsOutGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/PatronLanguagesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronLanguagesGetResult.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronLanguagesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronLanguagesGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class PatronLanguagesGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/PatronMessagesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronMessagesGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
 

--- a/src/polaris-api-csharp/Models/PatronMessagesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronMessagesGetResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronNotes.cs
+++ b/src/polaris-api-csharp/Models/PatronNotes.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/PatronNotes.cs
+++ b/src/polaris-api-csharp/Models/PatronNotes.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronReadingHistoryGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronReadingHistoryGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class PatronReadingHistoryGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/PatronReadingHistoryGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronReadingHistoryGetResult.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronRegistrationCreateResult.cs
+++ b/src/polaris-api-csharp/Models/PatronRegistrationCreateResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/PatronRegistrationCreateResult.cs
+++ b/src/polaris-api-csharp/Models/PatronRegistrationCreateResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronRegistrationDataV2.cs
+++ b/src/polaris-api-csharp/Models/PatronRegistrationDataV2.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class PatronRegistrationData

--- a/src/polaris-api-csharp/Models/PatronRegistrationDataV2.cs
+++ b/src/polaris-api-csharp/Models/PatronRegistrationDataV2.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronRegistrationParams.cs
+++ b/src/polaris-api-csharp/Models/PatronRegistrationParams.cs
@@ -1,5 +1,3 @@
-using Clc.Polaris.Api.Validation;
-using System;
 
 namespace Clc.Polaris.Api.Models
 {
@@ -137,7 +135,6 @@ namespace Clc.Polaris.Api.Models
         /// Language ID
         /// </summary>
 		public int? LanguageID { get; set; }
-
 
         public int? GenderID { get; set; }
 

--- a/src/polaris-api-csharp/Models/PatronRegistrationParams.cs
+++ b/src/polaris-api-csharp/Models/PatronRegistrationParams.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/PatronRenewBlocksResult.cs
+++ b/src/polaris-api-csharp/Models/PatronRenewBlocksResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class PatronRenewBlocksResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/PatronRenewBlocksResult.cs
+++ b/src/polaris-api-csharp/Models/PatronRenewBlocksResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronSavedSearchesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronSavedSearchesGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class PatronSavedSearchesGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/PatronSavedSearchesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronSavedSearchesGetResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronSearchResult.cs
+++ b/src/polaris-api-csharp/Models/PatronSearchResult.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronSearchResult.cs
+++ b/src/polaris-api-csharp/Models/PatronSearchResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/PatronStatisticalClassesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronStatisticalClassesGetResult.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronStatisticalClassesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronStatisticalClassesGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class PatronStatisticalClassesGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/PatronTitleListGetTitlesResult.cs
+++ b/src/polaris-api-csharp/Models/PatronTitleListGetTitlesResult.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronTitleListGetTitlesResult.cs
+++ b/src/polaris-api-csharp/Models/PatronTitleListGetTitlesResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class PatronTitleListGetTitlesResult

--- a/src/polaris-api-csharp/Models/PatronUdfConfigsGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronUdfConfigsGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class PatronUdfConfigsGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/PatronUdfConfigsGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronUdfConfigsGetResult.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PatronUpdateParams.cs
+++ b/src/polaris-api-csharp/Models/PatronUpdateParams.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {
@@ -71,7 +69,6 @@ namespace Clc.Polaris.Api.Models
         /// 0 = None | 2 = Email | 8 = SMS
         /// </summary>
         public int? EReceiptOptionID { get; set; }
-
 
         public List<PatronAddress> PatronAddresses { get; set; } = new();
 

--- a/src/polaris-api-csharp/Models/PatronUpdateParams.cs
+++ b/src/polaris-api-csharp/Models/PatronUpdateParams.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/PatronValidateResult.cs
+++ b/src/polaris-api-csharp/Models/PatronValidateResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>

--- a/src/polaris-api-csharp/Models/PatronValidateResult.cs
+++ b/src/polaris-api-csharp/Models/PatronValidateResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PickupAreasGetResult.cs
+++ b/src/polaris-api-csharp/Models/PickupAreasGetResult.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PickupAreasGetResult.cs
+++ b/src/polaris-api-csharp/Models/PickupAreasGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class PickupAreasGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/PickupBranchesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PickupBranchesGetResult.cs
@@ -1,5 +1,3 @@
-﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/PickupBranchesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PickupBranchesGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class PickupBranchesRow

--- a/src/polaris-api-csharp/Models/ProtectedToken.cs
+++ b/src/polaris-api-csharp/Models/ProtectedToken.cs
@@ -1,4 +1,3 @@
-﻿
 using Newtonsoft.Json;
 using System.Xml.Serialization;
 

--- a/src/polaris-api-csharp/Models/ProtectedToken.cs
+++ b/src/polaris-api-csharp/Models/ProtectedToken.cs
@@ -1,6 +1,5 @@
 ﻿
 using Newtonsoft.Json;
-using System;
 using System.Xml.Serialization;
 
 namespace Clc.Polaris.Api.Models

--- a/src/polaris-api-csharp/Models/RecordSetRecordsGetResult.cs
+++ b/src/polaris-api-csharp/Models/RecordSetRecordsGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public partial class RecordSetRecordsGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/RecordSetRecordsGetResult.cs
+++ b/src/polaris-api-csharp/Models/RecordSetRecordsGetResult.cs
@@ -1,5 +1,3 @@
-﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/RemoteStorageItemsGetResult.cs
+++ b/src/polaris-api-csharp/Models/RemoteStorageItemsGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class RemoteStorageItemsGetResult

--- a/src/polaris-api-csharp/Models/RemoteStorageItemsGetResult.cs
+++ b/src/polaris-api-csharp/Models/RemoteStorageItemsGetResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/SAMobilePhoneCarriersGetResult.cs
+++ b/src/polaris-api-csharp/Models/SAMobilePhoneCarriersGetResult.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/SAMobilePhoneCarriersGetResult.cs
+++ b/src/polaris-api-csharp/Models/SAMobilePhoneCarriersGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class SAMobilePhoneCarriersGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/ShelfLocationsGetResult.cs
+++ b/src/polaris-api-csharp/Models/ShelfLocationsGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class ShelfLocationsGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/ShelfLocationsGetResult.cs
+++ b/src/polaris-api-csharp/Models/ShelfLocationsGetResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/SortOptionsGetResult.cs
+++ b/src/polaris-api-csharp/Models/SortOptionsGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class SortOptionsGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/SortOptionsGetResult.cs
+++ b/src/polaris-api-csharp/Models/SortOptionsGetResult.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/Sync_BibsByIdGetResult.cs
+++ b/src/polaris-api-csharp/Models/Sync_BibsByIdGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class Sync_BibsByIdGetResult

--- a/src/polaris-api-csharp/Models/Sync_BibsByIdGetResult.cs
+++ b/src/polaris-api-csharp/Models/Sync_BibsByIdGetResult.cs
@@ -1,4 +1,3 @@
-﻿using System;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/Models/SysHoldStatusesGetResult.cs
+++ b/src/polaris-api-csharp/Models/SysHoldStatusesGetResult.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api.Models
 {
     public class SysHoldStatusesGetResult : PapiResponseCommon

--- a/src/polaris-api-csharp/Models/SysHoldStatusesGetResult.cs
+++ b/src/polaris-api-csharp/Models/SysHoldStatusesGetResult.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 
 namespace Clc.Polaris.Api.Models
 {

--- a/src/polaris-api-csharp/PapiClient.cs
+++ b/src/polaris-api-csharp/PapiClient.cs
@@ -1,13 +1,6 @@
 ﻿using Clc.Polaris.Api.Configuration;
-using Clc.Polaris.Api.Models;
-using Clc.Polaris.Api.Validation;
-using Clc.Rest;
 using Clc.Rest.Models;
-using System;
-using System.Net;
 using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/PapiRequestClassifier.cs
+++ b/src/polaris-api-csharp/PapiRequestClassifier.cs
@@ -1,5 +1,3 @@
-using Clc.Polaris.Api.Models;
-using System;
 using System.Net.Http;
 
 namespace Clc.Polaris.Api

--- a/src/polaris-api-csharp/PapiRequestValidator.cs
+++ b/src/polaris-api-csharp/PapiRequestValidator.cs
@@ -1,5 +1,3 @@
-using Clc.Polaris.Api.Models;
-using System;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/PapiRequestValidator.cs
+++ b/src/polaris-api-csharp/PapiRequestValidator.cs
@@ -1,4 +1,3 @@
-
 namespace Clc.Polaris.Api
 {
     internal static class PapiRequestValidator

--- a/src/polaris-api-csharp/PapiSignature.cs
+++ b/src/polaris-api-csharp/PapiSignature.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Security.Cryptography;
 using System.Text;
 

--- a/src/polaris-api-csharp/ProtectedTokenCache.cs
+++ b/src/polaris-api-csharp/ProtectedTokenCache.cs
@@ -1,11 +1,6 @@
-using Clc.Polaris.Api.Models;
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Clc.Polaris.Api
 {

--- a/src/polaris-api-csharp/Validation/Require.cs
+++ b/src/polaris-api-csharp/Validation/Require.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 


### PR DESCRIPTION
### Motivation
- Consolidate repeated file-level `using` directives across the main library into a single set of global usings to reduce boilerplate and improve maintainability.
- Preserve runtime behavior and public APIs while performing small, safe cleanup edits to using lists and obvious excess blank lines in touched files.
- Keep specialized/usages not included in the global list (e.g., `System.Net.Http`, `Clc.Rest.Models`, `Clc.Polaris.Api.Configuration`, `Newtonsoft.Json`, XML/serialization usings, and `Microsoft.*`) as local usings where required.

### Description
- Added `src/polaris-api-csharp/GlobalUsings.cs` with the exact content provided, declaring global usings for `System`, `System.Collections.Generic`, `System.Linq`, `System.Net`, `System.Threading`, `System.Threading.Tasks`, `Clc.Polaris.Api.Models`, `Clc.Polaris.Api.Validation`, and `Clc.Rest`.
- Removed redundant file-level usings for the above namespaces from the library source files under `src/polaris-api-csharp/**/*.cs` and removed obvious excess blank lines in the files touched while preserving member ordering and implementation.
- Files changed: `src/polaris-api-csharp/GlobalUsings.cs` (new) and 163 existing library files modified (example files: `PapiClient.cs`, `IPapiClient.cs`, `ProtectedToken.cs`, `PapiRequestValidator.cs`, `ProtectedTokenCache.cs`, `PapiSignature.cs`, many `Methods/*` and `Models/*` files and multiple `Extensions/*` files). Behavior was preserved and no public API, method bodies, model shapes, XML docs, nullable annotations, or project metadata were changed.

### Testing
- Ran `dotnet build src/polaris-api-csharp/Clc.Polaris.Api.csproj` and the library build succeeded with 0 warnings and 0 errors.
- Ran `dotnet test tests/Clc.Polaris.Api.UnitTests/Clc.Polaris.Api.UnitTests.csproj` and all unit tests passed (`Passed: 443, Failed: 0`).
- Verified `src/polaris-api-csharp/GlobalUsings.cs` exists and inspected that redundant local usings for the moved namespaces were removed from the touched files and that specialized usings remain where needed; also ran a scan to ensure no triple blank lines remain in touched files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a313430c9dc8323bbdb99e49384814b)