### PR TITLE
Clean up XML documentation blank lines

### DIFF
--- a/src/polaris-api-csharp/Methods/BibGet.cs
+++ b/src/polaris-api-csharp/Methods/BibGet.cs
@@ -7,7 +7,6 @@ namespace Clc.Polaris.Api
         /// </summary>
         /// <param name="bibId"></param>
         /// <returns></returns>
-
         public async Task<IRestResponse<BibGetResult>> BibGetAsync(int bibId, int? branchId = null, CancellationToken cancellationToken = default)
         {
             Require.Positive(bibId);

--- a/src/polaris-api-csharp/Methods/HoldingsGet.cs
+++ b/src/polaris-api-csharp/Methods/HoldingsGet.cs
@@ -8,7 +8,6 @@ namespace Clc.Polaris.Api
         /// <param name="bibId">BibliograhpicRecordID of the record.</param>
         /// <returns>An object containing a list of holdings information for specified BibliographicRecordID.</returns>
         /// <seealso cref="BibHoldingsGetResult"/>
-
         public async Task<IRestResponse<BibHoldingsGetResult>> HoldingsGetAsync(int bibId, CancellationToken cancellationToken = default)
         {
             Require.Positive(bibId);

--- a/src/polaris-api-csharp/Methods/PatronTitleListCopyTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListCopyTitle.cs
@@ -3,7 +3,6 @@ namespace Clc.Polaris.Api
     public partial class PapiClient
     {
         /// <summary>
-        ///
         /// </summary>
         /// <param name="barcode"></param>
         /// <param name="fromRecordStoreId"></param>

--- a/src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs
@@ -3,14 +3,12 @@ namespace Clc.Polaris.Api
     public partial class PapiClient
     {
         /// <summary>
-        ///
         /// </summary>
         /// <param name="barcode"></param>
         /// <param name="listId"></param>
         /// <param name="position">starts at 1, not 0</param>
         /// <param name="password"></param>
         /// <returns></returns>
-
         public async Task<IRestResponse<PatronTitleListDeleteTitleResult>> PatronTitleListDeleteTitleAsync(string barcode, int listId, int position, string password = "", CancellationToken cancellationToken = default)
         {
             Require.Positive(listId);

--- a/src/polaris-api-csharp/Methods/PatronTitleListMoveTitle.cs
+++ b/src/polaris-api-csharp/Methods/PatronTitleListMoveTitle.cs
@@ -3,7 +3,6 @@ namespace Clc.Polaris.Api
     public partial class PapiClient
     {
         /// <summary>
-        ///
         /// </summary>
         /// <param name="barcode"></param>
         /// <param name="fromRecordStoreId"></param>
@@ -11,7 +10,6 @@ namespace Clc.Polaris.Api
         /// <param name="toRecordStoreId"></param>
         /// <param name="password"></param>
         /// <returns></returns>
-
         public async Task<IRestResponse<PatronTitleListMoveTitleResult>> PatronTitleListMoveTitleAsync(string barcode, int fromRecordStoreId, int fromPosition, int toRecordStoreId, string password = "", CancellationToken cancellationToken = default)
         {
             Require.Positive(fromRecordStoreId);

--- a/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
+++ b/src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs
@@ -8,7 +8,6 @@ namespace Clc.Polaris.Api
         /// <param name="orgId"></param>
         /// <param name="attribute"></param>
         /// <returns></returns>
-
         public async Task<IRestResponse<StringResult>> SA_GetValueByOrgAsync(string attribute, int? organizationId = null, CancellationToken cancellationToken = default)
         {
             Require.PositiveIfProvided(organizationId);

--- a/src/polaris-api-csharp/Models/PatronCirculateBlocksResult.cs
+++ b/src/polaris-api-csharp/Models/PatronCirculateBlocksResult.cs
@@ -54,7 +54,6 @@ namespace Clc.Polaris.Api.Models
         /// List of blocks on the patron's account
         /// </summary>
         ////public Blocks Blocks { get; set; }
-
         public List<Block> Blocks { get; set; } = new();
 
         /// <summary>


### PR DESCRIPTION
### Motivation
- Remove stray blank lines between XML documentation comments and the following member declarations to improve code hygiene.
- Remove empty `<summary>` body lines in a few patron title list methods to keep XML docs concise without adding new content.

### Description
- Removed unneeded blank lines between XML doc blocks and members in `BibGet.cs`, `HoldingsGet.cs`, and `SA_GetValueByOrg.cs` so the doc comments sit immediately above the methods.
- Removed empty `///` lines inside `<summary>` blocks for `PatronTitleListDeleteTitle.cs`, `PatronTitleListMoveTitle.cs`, and `PatronTitleListCopyTitle.cs` and removed the blank line separating those doc blocks from their async methods.
- Removed one extra blank line before the `Blocks` property in `Models/PatronCirculateBlocksResult.cs` to clear a repo-wide match.
- Preserved all method bodies, routes, parameters, validation, return types, public API signatures, and runtime behavior.

### Testing
- Ran the repo-wide pattern checks with `rg -n -U '(^[ \t]*///.*\n)+[ \t]*\n[ \t]*(public|private|protected|internal)\b' src tests` and `rg -n -U '^[ \t]*/// <summary>\n[ \t]*///\s*\n[ \t]*/// </summary>' src tests` and confirmed there are no remaining matches.
- Built the unit tests project with `dotnet build tests/Clc.Polaris.Api.UnitTests/Clc.Polaris.Api.UnitTests.csproj --configuration Release` which succeeded with 0 warnings and 0 errors.
- Built the live integration tests project with `dotnet build tests/Clc.Polaris.Api.LiveIntegrationTests/Clc.Polaris.Api.LiveIntegrationTests.csproj --configuration Release` which succeeded with 0 warnings and 0 errors.
- All automated checks passed and no runtime or API behavior was changed.

Files changed: `src/polaris-api-csharp/Methods/BibGet.cs`, `src/polaris-api-csharp/Methods/HoldingsGet.cs`, `src/polaris-api-csharp/Methods/SA_GetValueByOrg.cs`, `src/polaris-api-csharp/Methods/PatronTitleListDeleteTitle.cs`, `src/polaris-api-csharp/Methods/PatronTitleListMoveTitle.cs`, `src/polaris-api-csharp/Methods/PatronTitleListCopyTitle.cs`, `src/polaris-api-csharp/Models/PatronCirculateBlocksResult.cs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a31643e09048323b44e25fb26bb3dd2)