### PR TITLE
Add safe ToString implementations for selected models

### DIFF
--- a/src/polaris-api-csharp/Internal/ModelDisplayFormatter.cs
+++ b/src/polaris-api-csharp/Internal/ModelDisplayFormatter.cs
@@ -1,0 +1,33 @@
+﻿using System.Globalization;
+
+namespace Clc.Polaris.Api.Internal
+{
+    internal static class ModelDisplayFormatter
+    {
+        public static string MaskLeadingDigits(long value, int visibleTrailingDigits = 4)
+        {
+            return MaskLeadingCharacters(value.ToString(CultureInfo.InvariantCulture), visibleTrailingDigits);
+        }
+
+        public static string MaskLeadingCharacters(string value, int visibleTrailingDigits = 4)
+        {
+            ArgumentNullException.ThrowIfNull(value);
+
+            if (visibleTrailingDigits < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(visibleTrailingDigits), visibleTrailingDigits, "Visible trailing digits cannot be negative.");
+            }
+
+            var hasSign = value.StartsWith("-", StringComparison.Ordinal);
+            var digits = hasSign ? value[1..] : value;
+
+            var visibleLength = Math.Min(visibleTrailingDigits, Math.Max(0, digits.Length - 1));
+            var maskedLength = digits.Length - visibleLength;
+
+            return string.Concat(
+                hasSign ? "-" : string.Empty,
+                new string('*', maskedLength),
+                digits[^visibleLength..]);
+        }
+    }
+}

--- a/src/polaris-api-csharp/Models/BibGetByTypeResult.cs
+++ b/src/polaris-api-csharp/Models/BibGetByTypeResult.cs
@@ -5,5 +5,7 @@ namespace Clc.Polaris.Api.Models
     public class BibGetByTypeResult : PapiResponseCommon
     {
         public List<BibGetByTypeRow> BibGetByTypeRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", BibGetByTypeRows ?? Enumerable.Empty<BibGetByTypeRow>());
     }
 }

--- a/src/polaris-api-csharp/Models/BibGetByTypeRow.cs
+++ b/src/polaris-api-csharp/Models/BibGetByTypeRow.cs
@@ -19,5 +19,7 @@ namespace Clc.Polaris.Api.Models
         public string? Label { get; set; }
         public string? Value { get; set; }
         public bool? Alternate { get; set; }
+
+        public override string ToString() => $"{ElementID} - {Label ?? string.Empty} - {Value ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/BibHoldingsGetResult.cs
+++ b/src/polaris-api-csharp/Models/BibHoldingsGetResult.cs
@@ -14,6 +14,8 @@ namespace Clc.Polaris.Api.Models
         /// </summary>
         [XmlElement(ElementName = "BibHoldingsGetRows")]
         public List<BibHoldingsGetRow> BibHoldingsGetRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", BibHoldingsGetRows ?? Enumerable.Empty<BibHoldingsGetRow>());
     }
 
     /// <summary>
@@ -159,5 +161,7 @@ namespace Clc.Polaris.Api.Models
         /// </summary>
         [XmlElement(ElementName = "IsElectronicItem")]
         public string? IsElectronicItem { get; set; }
+
+        public override string ToString() => $"{Barcode ?? string.Empty} - {LocationName ?? string.Empty} - {CollectionName ?? string.Empty} - {CallNumber ?? string.Empty} - {ShelfLocation ?? string.Empty} - {CircStatus ?? string.Empty} - {MaterialType ?? string.Empty} - {DueDate ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/BibSearchResult.cs
+++ b/src/polaris-api-csharp/Models/BibSearchResult.cs
@@ -19,6 +19,8 @@ namespace Clc.Polaris.Api.Models
         /// A row that contains bibliographic record information of the search results.
         /// </summary>
         public List<BibSearchRow> BibSearchRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", BibSearchRows ?? Enumerable.Empty<BibSearchRow>());
     }
 
     /// <summary>

--- a/src/polaris-api-csharp/Models/BibsPostResult.cs
+++ b/src/polaris-api-csharp/Models/BibsPostResult.cs
@@ -6,5 +6,7 @@ namespace Clc.Polaris.Api.Models
     public class BibsPostResult : PapiResponseCommon
     {
         public int? ImportJobID { get; set; }
+
+        public override string ToString() => ImportJobID?.ToString() ?? string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/CollectionsGetResult.cs
+++ b/src/polaris-api-csharp/Models/CollectionsGetResult.cs
@@ -3,6 +3,8 @@ namespace Clc.Polaris.Api.Models
     public class CollectionsGetResult : PapiResponseCommon
     {
         public List<CollectionsRow> CollectionsRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", CollectionsRows ?? Enumerable.Empty<CollectionsRow>());
     }
 
     public class CollectionsRow

--- a/src/polaris-api-csharp/Models/HeadingsSearchResult.cs
+++ b/src/polaris-api-csharp/Models/HeadingsSearchResult.cs
@@ -3,5 +3,7 @@ namespace Clc.Polaris.Api.Models
     public class HeadingsSearchResult : PapiResponseCommon
     {
         public List<HeadingsSearchRow> HeadingsSearchRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", HeadingsSearchRows ?? Enumerable.Empty<HeadingsSearchRow>());
     }
 }

--- a/src/polaris-api-csharp/Models/HeadingsSearchRow.cs
+++ b/src/polaris-api-csharp/Models/HeadingsSearchRow.cs
@@ -8,5 +8,7 @@ namespace Clc.Polaris.Api.Models
         public string? DisplayTerm { get; set; }
         public int? GlobalOccurrences { get; set; }
         public string? HeadingID { get; set; }
+
+        public override string ToString() => $"{Position?.ToString() ?? string.Empty} - {HeadingID ?? string.Empty} - {DisplayTerm ?? DisplayConstant ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/HoldRequestActivationResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestActivationResult.cs
@@ -9,6 +9,8 @@ namespace Clc.Polaris.Api.Models
         /// Information about activated holds.
         /// </summary>
         public List<HoldActivationRow> HoldActivationRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", HoldActivationRows ?? Enumerable.Empty<HoldActivationRow>());
     }
 
     /// <summary>
@@ -41,5 +43,7 @@ namespace Clc.Polaris.Api.Models
         /// The error message if not sucessful.
         /// </summary>
         public string? ErrorMessage { get; set; }
+
+        public override string ToString() => $"{SysHoldRequestID} - {ReturnCode} - {NewActivationDate:O} - {NewExpirationDate:O} - {ErrorMessage ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/HoldRequestCancelResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestCancelResult.cs
@@ -9,6 +9,8 @@ namespace Clc.Polaris.Api.Models
         /// Information about cancelled holds.
         /// </summary>
         public List<HoldRequestCancelRow> HoldRequestCancelRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", HoldRequestCancelRows ?? Enumerable.Empty<HoldRequestCancelRow>());
     }
 
     /// <summary>
@@ -30,5 +32,7 @@ namespace Clc.Polaris.Api.Models
         /// The error message returned by the Polaris API.
         /// </summary>
         public string? ErrorMessage { get; set; }
+
+        public override string ToString() => $"{SysHoldRequestID} - {ReturnCode} - {ErrorMessage ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/HoldRequestCreateParams.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestCreateParams.cs
@@ -1,3 +1,5 @@
+using Clc.Polaris.Api.Internal;
+
 namespace Clc.Polaris.Api.Models
 {
     /// <summary>
@@ -70,7 +72,7 @@ namespace Clc.Polaris.Api.Models
         /// </summary>
         public Guid? TargetGUID { get; set; }
 
-        public override string ToString() => $"PatronID={PatronID}, BibID={BibID}, PickupOrgID={PickupOrgID}, RequestingOrgID={RequestingOrgID?.ToString() ?? string.Empty}";
+        public override string ToString() => $"PatronID={ModelDisplayFormatter.MaskLeadingDigits(PatronID)}, BibID={BibID}, PickupOrgID={PickupOrgID}, RequestingOrgID={RequestingOrgID?.ToString() ?? string.Empty}";
 
         public HoldRequestCreateParams()
         {

--- a/src/polaris-api-csharp/Models/HoldRequestCreateParams.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestCreateParams.cs
@@ -70,6 +70,8 @@ namespace Clc.Polaris.Api.Models
         /// </summary>
         public Guid? TargetGUID { get; set; }
 
+        public override string ToString() => $"PatronID={PatronID}, BibID={BibID}, PickupOrgID={PickupOrgID}, RequestingOrgID={RequestingOrgID?.ToString() ?? string.Empty}";
+
         public HoldRequestCreateParams()
         {
 

--- a/src/polaris-api-csharp/Models/HoldRequestCreateResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestCreateResult.cs
@@ -44,5 +44,7 @@ namespace Clc.Polaris.Api.Models
         /// Total number of holds in the queue.
         /// </summary>
         public int QueueTotal { get; set; }
+
+        public override string ToString() => RequestGuid?.ToString() ?? string.Empty;
     }
 }

--- a/src/polaris-api-csharp/Models/HoldRequestGetListResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestGetListResult.cs
@@ -61,7 +61,7 @@ namespace Clc.Polaris.Api.Models
         public string? SortTitle { get; set; }
         public string? SortAuthor { get; set; }
 
-        public override string ToString() => $"{ItemRecordID} - {ItemBarcode} - {BrowseTitle} - {PatronFullName}";
+        public override string ToString() => $"{ItemRecordID} - {ItemBarcode ?? string.Empty} - {BrowseTitle ?? string.Empty}";
     }
 
 }

--- a/src/polaris-api-csharp/Models/HoldRequestReplyResult.cs
+++ b/src/polaris-api-csharp/Models/HoldRequestReplyResult.cs
@@ -34,5 +34,7 @@
         /// 5 - Accept local hold policy (charge)
         /// </summary>
         public int State { get; set; }
+
+        public override string ToString() => $"{TxnGroupQualifier ?? string.Empty} - {TxnQualifier ?? string.Empty} - {RequestingOrgID} - {Answer} - {State}";
     }
 }

--- a/src/polaris-api-csharp/Models/ILLRequestCancelResult.cs
+++ b/src/polaris-api-csharp/Models/ILLRequestCancelResult.cs
@@ -6,5 +6,7 @@ namespace Clc.Polaris.Api.Models
     {
         [XmlArray(IsNullable = true)]
         public List<ILLRequestCancelRow>? ILLRequestCancelRows { get; set; }
+
+        public override string ToString() => string.Join("\r\n", ILLRequestCancelRows ?? Enumerable.Empty<ILLRequestCancelRow>());
     }
 }

--- a/src/polaris-api-csharp/Models/ILLRequestCancelRow.cs
+++ b/src/polaris-api-csharp/Models/ILLRequestCancelRow.cs
@@ -5,5 +5,7 @@ namespace Clc.Polaris.Api.Models
         public int? ILLRequestID { get; set; }
         public int? ReturnCode { get; set; }
         public string? ErrorMessage { get; set; }
+
+        public override string ToString() => $"{ILLRequestID?.ToString() ?? string.Empty} - {ReturnCode?.ToString() ?? string.Empty} - {ErrorMessage ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/ILLRequestResult.cs
+++ b/src/polaris-api-csharp/Models/ILLRequestResult.cs
@@ -15,5 +15,7 @@ namespace Clc.Polaris.Api.Models
         public string? StatusType { get; set; }
         public string? StatusValue { get; set; }
         public string? Message { get; set; }
+
+        public override string ToString() => $"{RequestGUID ?? string.Empty} - {StatusType ?? string.Empty} - {StatusValue ?? string.Empty} - {Message ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/ItemCheckInResult.cs
+++ b/src/polaris-api-csharp/Models/ItemCheckInResult.cs
@@ -23,6 +23,8 @@ namespace Clc.Polaris.Api.Models
         public string? Comment { get; set; }
         public ItemCheckInHoldData? HoldData { get; set; }
         public ItemCheckInTransitResult? InTransitResult { get; set; }
+
+        public override string ToString() => $"{ItemRecordID} - {ItemBarcode ?? string.Empty} - {Title ?? string.Empty} - {ItemStatusID} - {PreviousItemStatusID} - {ShelfLocation ?? string.Empty} - {CallNumber ?? string.Empty}";
     }
 
     public class ItemCheckInHoldData
@@ -31,6 +33,8 @@ namespace Clc.Polaris.Api.Models
         public string? TrappingPatronName { get; set; }
         public string? PickupBranchName { get; set; }
         public string? PickupArea { get; set; }
+
+        public override string ToString() => $"{PickupBranchName ?? string.Empty} - {PickupArea ?? string.Empty}";
     }
 
     public class ItemCheckInTransitResult
@@ -40,5 +44,7 @@ namespace Clc.Polaris.Api.Models
         public DateTime? ItemStatusDate { get; set; }
         public DateTime? InTransitSentDate { get; set; }
         public string? Status { get; set; }
+
+        public override string ToString() => $"{InTransitSentBranchID} - {InTransitRecvdBranchID} - {ItemStatusDate:O} - {InTransitSentDate:O} - {Status ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/ItemCheckOutResult.cs
+++ b/src/polaris-api-csharp/Models/ItemCheckOutResult.cs
@@ -163,7 +163,7 @@ namespace Clc.Polaris.Api.Models
         public int DDM_MediaFormatID { get; set; }
         public string? Title { get; set; }
 
-        public override string ToString() => $"{ItemRecordID} - {Title ?? string.Empty} - {DueDate:O} - {MaterialTypeID} - {ItemBlockFlags} - {RenewalBlockFlags}";
+        public override string ToString() => $"{ItemRecordID} - {Title ?? string.Empty} - {DueDate:O} - {MaterialTypeID} - {ItemBlockFlags}";
 
         public CheckoutPatronBlockReasons PatronBlockReasons => (CheckoutPatronBlockReasons)PatronBlockFlags;
         public CheckoutItemBlockReasons ItemBlockReasons => (CheckoutItemBlockReasons)ItemBlockFlags;

--- a/src/polaris-api-csharp/Models/ItemCheckOutResult.cs
+++ b/src/polaris-api-csharp/Models/ItemCheckOutResult.cs
@@ -163,6 +163,8 @@ namespace Clc.Polaris.Api.Models
         public int DDM_MediaFormatID { get; set; }
         public string? Title { get; set; }
 
+        public override string ToString() => $"{ItemRecordID} - {Title ?? string.Empty} - {DueDate:O} - {MaterialTypeID} - {ItemBlockFlags} - {RenewalBlockFlags}";
+
         public CheckoutPatronBlockReasons PatronBlockReasons => (CheckoutPatronBlockReasons)PatronBlockFlags;
         public CheckoutItemBlockReasons ItemBlockReasons => (CheckoutItemBlockReasons)ItemBlockFlags;
         public CheckoutRenewalBlockReasons RenewalBlockReasons => (CheckoutRenewalBlockReasons)RenewalBlockFlags;

--- a/src/polaris-api-csharp/Models/ItemRenewResultWrapper.cs
+++ b/src/polaris-api-csharp/Models/ItemRenewResultWrapper.cs
@@ -3,6 +3,8 @@ namespace Clc.Polaris.Api.Models
     public class ItemRenewResultWrapper : PapiResponseCommon
     {
         public ItemRenewResultBody? ItemRenewResult { get; set; }
+
+        public override string ToString() => ItemRenewResult?.ToString() ?? base.ToString();
     }
     /// <summary>
     /// Lists of items that could and couldn't be renewed.
@@ -18,6 +20,14 @@ namespace Clc.Polaris.Api.Models
         /// A list of successfully renewed items.
         /// </summary>
         public List<ItemRenewDueDateRow> DueDateRows { get; set; } = new(); // = new List<ItemRenewDueDateRow>();
+
+        public override string ToString()
+        {
+            var rows = (BlockRows ?? Enumerable.Empty<ItemRenewBlockRow>()).Cast<object>()
+                .Concat((DueDateRows ?? Enumerable.Empty<ItemRenewDueDateRow>()).Cast<object>());
+
+            return string.Join("\r\n", rows);
+        }
     }
 
     /// <summary>
@@ -51,6 +61,8 @@ namespace Clc.Polaris.Api.Models
         /// ID of the item record.
         /// </summary>
         public int ItemRecordID { get; set; }
+
+        public override string ToString() => $"{ItemRecordID} - {PAPIErrorType} - {PolarisErrorCode} - {ErrorAllowOverride} - {ErrorDesc ?? string.Empty}";
     }
 
     /// <summary>
@@ -67,5 +79,7 @@ namespace Clc.Polaris.Api.Models
         /// Due date of the item.
         /// </summary>
         public DateTime DueDate { get; set; }
+
+        public override string ToString() => $"{ItemRecordID} - {DueDate:O}";
     }
 }

--- a/src/polaris-api-csharp/Models/ItemStatusesGetResult.cs
+++ b/src/polaris-api-csharp/Models/ItemStatusesGetResult.cs
@@ -3,6 +3,8 @@ namespace Clc.Polaris.Api.Models
     public class ItemStatusesGetResult : PapiResponseCommon
     {
         public ItemStatusRow[] ItemStatusesRows { get; set; } = Array.Empty<ItemStatusRow>();
+
+        public override string ToString() => string.Join("\r\n", ItemStatusesRows ?? Enumerable.Empty<ItemStatusRow>());
     }
 
     public class ItemStatusRow
@@ -11,5 +13,7 @@ namespace Clc.Polaris.Api.Models
         public string? Description { get; set; }
         public string? Name { get; set; }
         public string? BannerText { get; set; }
+
+        public override string ToString() => $"{ItemStatusId} - {Name ?? string.Empty} - {Description ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/ItemUpdateBarcodeData.cs
+++ b/src/polaris-api-csharp/Models/ItemUpdateBarcodeData.cs
@@ -4,5 +4,7 @@
     {
         public int TransactionBranchId { get; set; }
         public string ItemBarcode { get; set; } = string.Empty;
+
+        public override string ToString() => $"{TransactionBranchId} - {ItemBarcode}";
     }
 }

--- a/src/polaris-api-csharp/Models/ItemsOutActionResult.cs
+++ b/src/polaris-api-csharp/Models/ItemsOutActionResult.cs
@@ -9,5 +9,7 @@
         /// The result of the item renewal.
         /// </summary>
         public ItemRenewResultWrapper? ItemRenewResult { get; set; }
+
+        public override string ToString() => ItemRenewResult?.ToString() ?? base.ToString();
     }
 }

--- a/src/polaris-api-csharp/Models/LimitFiltersGetResult.cs
+++ b/src/polaris-api-csharp/Models/LimitFiltersGetResult.cs
@@ -3,6 +3,8 @@ namespace Clc.Polaris.Api.Models
     public class LimitFiltersGetResult : PapiResponseCommon
     {
         public LimitFiltersRow[] LimitFiltersRows { get; set; } = Array.Empty<LimitFiltersRow>();
+
+        public override string ToString() => string.Join("\r\n", LimitFiltersRows ?? Enumerable.Empty<LimitFiltersRow>());
     }
 
     public class LimitFiltersRow

--- a/src/polaris-api-csharp/Models/MARCTypeOfMaterialsGetResult.cs
+++ b/src/polaris-api-csharp/Models/MARCTypeOfMaterialsGetResult.cs
@@ -3,6 +3,8 @@ namespace Clc.Polaris.Api.Models
     public class MARCTypeOfMaterialsGetResult : PapiResponseCommon
     {
         public MARCTypeOfMaterialsRow[] MARCTypeOfMaterialsRows { get; set; } = Array.Empty<MARCTypeOfMaterialsRow>();
+
+        public override string ToString() => string.Join("\r\n", MARCTypeOfMaterialsRows ?? Enumerable.Empty<MARCTypeOfMaterialsRow>());
     }
 
     public class MARCTypeOfMaterialsRow

--- a/src/polaris-api-csharp/Models/MaterialTypesGetResult.cs
+++ b/src/polaris-api-csharp/Models/MaterialTypesGetResult.cs
@@ -3,11 +3,15 @@ namespace Clc.Polaris.Api.Models
     public class MaterialTypesGetResult : PapiResponseCommon
     {
         public MaterialTypesRow[] MaterialTypesRows { get; set; } = Array.Empty<MaterialTypesRow>();
+
+        public override string ToString() => string.Join("\r\n", MaterialTypesRows ?? Enumerable.Empty<MaterialTypesRow>());
     }
 
     public class MaterialTypesRow
     {
         public int MaterialTypeId { get; set; }
         public string? Description { get; set; }
+
+        public override string ToString() => $"{MaterialTypeId} - {Description ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/OrganizationsGetResult.cs
+++ b/src/polaris-api-csharp/Models/OrganizationsGetResult.cs
@@ -9,6 +9,8 @@ namespace Clc.Polaris.Api.Models
         /// List of organization data
         /// </summary>
 		public List<OrganizationsGetRow> OrganizationsGetRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", OrganizationsGetRows ?? Enumerable.Empty<OrganizationsGetRow>());
     }
 
     /// <summary>

--- a/src/polaris-api-csharp/Models/PatronAuthenicationResult.cs
+++ b/src/polaris-api-csharp/Models/PatronAuthenicationResult.cs
@@ -5,5 +5,7 @@
         public string? AccessToken { get; set; }
         public string? AccessSecret { get; set; }
         public int PatronID { get; set; }
+
+        public override string ToString() => PatronID.ToString();
     }
 }

--- a/src/polaris-api-csharp/Models/PatronLanguagesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronLanguagesGetResult.cs
@@ -3,11 +3,15 @@ namespace Clc.Polaris.Api.Models
     public class PatronLanguagesGetResult : PapiResponseCommon
     {
         public List<PatronLanguageRow> PatronLanguagesRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", PatronLanguagesRows ?? Enumerable.Empty<PatronLanguageRow>());
     }
 
     public class PatronLanguageRow
     {
         public int LanguageID { get; set; }
         public string? Description { get; set; }
+
+        public override string ToString() => $"{LanguageID} - {Description ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/PatronStatisticalClassesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronStatisticalClassesGetResult.cs
@@ -3,6 +3,8 @@ namespace Clc.Polaris.Api.Models
     public class PatronStatisticalClassesGetResult : PapiResponseCommon
     {
         public List<PatronStatisticalClassRow> PatronStatisticalClassesRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", PatronStatisticalClassesRows ?? Enumerable.Empty<PatronStatisticalClassRow>());
     }
 
     public class PatronStatisticalClassRow
@@ -10,5 +12,7 @@ namespace Clc.Polaris.Api.Models
         public int StatisticalClassID { get; set; }
         public int OrganizationID { get; set; }
         public string? Description { get; set; }
+
+        public override string ToString() => $"{StatisticalClassID} - {OrganizationID} - {Description ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/PatronTitleListAddTitleData.cs
+++ b/src/polaris-api-csharp/Models/PatronTitleListAddTitleData.cs
@@ -4,5 +4,7 @@
     {
         public int RecordStoreId { get; set; }
         public int LocalControlNumber { get; set; }
+
+        public override string ToString() => $"{RecordStoreId} - {LocalControlNumber}";
     }
 }

--- a/src/polaris-api-csharp/Models/PatronTitleListAddTitleResult.cs
+++ b/src/polaris-api-csharp/Models/PatronTitleListAddTitleResult.cs
@@ -14,5 +14,7 @@
         /// Unique Identifier for the title in the list
         /// </summary>
         public int RecordID { get; set; }
+
+        public override string ToString() => $"{Position} - {RecordID}";
     }
 }

--- a/src/polaris-api-csharp/Models/PatronTitleListCopyAllTitlesData.cs
+++ b/src/polaris-api-csharp/Models/PatronTitleListCopyAllTitlesData.cs
@@ -4,5 +4,7 @@
     {
         public int FromRecordStoreId { get; set; }
         public int ToRecordStoreId { get; set; }
+
+        public override string ToString() => $"{FromRecordStoreId} - {ToRecordStoreId}";
     }
 }

--- a/src/polaris-api-csharp/Models/PatronTitleListCopyTitleData.cs
+++ b/src/polaris-api-csharp/Models/PatronTitleListCopyTitleData.cs
@@ -5,5 +5,7 @@
         public int FromRecordStoreId { get; set; }
         public int FromPosition { get; set; }
         public int ToRecordStoreId { get; set; }
+
+        public override string ToString() => $"{FromRecordStoreId} - {FromPosition} - {ToRecordStoreId}";
     }
 }

--- a/src/polaris-api-csharp/Models/PatronTitleListMoveTitleData.cs
+++ b/src/polaris-api-csharp/Models/PatronTitleListMoveTitleData.cs
@@ -5,5 +5,7 @@
         public int FromRecordStoreId { get; set; }
         public int FromPosition { get; set; }
         public int ToRecordStoreId { get; set; }
+
+        public override string ToString() => $"{FromRecordStoreId} - {FromPosition} - {ToRecordStoreId}";
     }
 }

--- a/src/polaris-api-csharp/Models/PatronUdfConfigsGetResult.cs
+++ b/src/polaris-api-csharp/Models/PatronUdfConfigsGetResult.cs
@@ -3,6 +3,8 @@ namespace Clc.Polaris.Api.Models
     public class PatronUdfConfigsGetResult : PapiResponseCommon
     {
         public List<PatronUdfConfigRow> PatronUdfConfigsRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", PatronUdfConfigsRows ?? Enumerable.Empty<PatronUdfConfigRow>());
     }
 
     public class PatronUdfConfigRow
@@ -12,5 +14,7 @@ namespace Clc.Polaris.Api.Models
         public string? Description { get; set; }
         public string? Label { get; set; }
         public bool? Enabled { get; set; }
+
+        public override string ToString() => $"{UDFID} - {OrganizationID} - {Label ?? Description ?? string.Empty} - {Enabled?.ToString() ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/PickupAreasGetResult.cs
+++ b/src/polaris-api-csharp/Models/PickupAreasGetResult.cs
@@ -3,6 +3,8 @@ namespace Clc.Polaris.Api.Models
     public class PickupAreasGetResult : PapiResponseCommon
     {
         public List<PickupAreasRow> PickupAreasRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", PickupAreasRows ?? Enumerable.Empty<PickupAreasRow>());
     }
 
     public class PickupAreasRow
@@ -10,5 +12,7 @@ namespace Clc.Polaris.Api.Models
         public int PickupAreaID { get; set; }
         public int OrganizationID { get; set; }
         public string? Description { get; set; }
+
+        public override string ToString() => $"{PickupAreaID} - {OrganizationID} - {Description ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/PickupBranchesGetResult.cs
+++ b/src/polaris-api-csharp/Models/PickupBranchesGetResult.cs
@@ -12,5 +12,7 @@ namespace Clc.Polaris.Api.Models
         public List<PickupBranchesRow> PickupBranchesRows { get; set; } = new();
 
         public List<int> PickupBranches => PickupBranchesRows.Select(b => b.ID).ToList();
+
+        public override string ToString() => string.Join(", ", PickupBranchesRows ?? Enumerable.Empty<PickupBranchesRow>());
     }
 }

--- a/src/polaris-api-csharp/Models/RemoteStorageItemsGetResult.cs
+++ b/src/polaris-api-csharp/Models/RemoteStorageItemsGetResult.cs
@@ -7,6 +7,8 @@ namespace Clc.Polaris.Api.Models
         public int RecordCount { get; set; }
         public int RowCount { get; set; }
         public RemoteStorageItemsGetRow[] RemoteStorageItemsGetRows { get; set; } = Array.Empty<RemoteStorageItemsGetRow>();
+
+        public override string ToString() => string.Join("\r\n", RemoteStorageItemsGetRows ?? Enumerable.Empty<RemoteStorageItemsGetRow>());
     }
 
     public class RemoteStorageItemsGetRow
@@ -25,5 +27,7 @@ namespace Clc.Polaris.Api.Models
         public string? CallNumber { get; set; }
         public object? CopyNumber { get; set; }
         public object? VolumeNumber { get; set; }
+
+        public override string ToString() => $"{ItemRecordID} - {Barcode ?? string.Empty} - {BibliographicRecordID} - {BrowseTitle ?? string.Empty} - {MaterialType ?? string.Empty} - {Collection ?? string.Empty} - {ShelfLocation ?? string.Empty} - {CallNumber ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/SAMobilePhoneCarriersGetResult.cs
+++ b/src/polaris-api-csharp/Models/SAMobilePhoneCarriersGetResult.cs
@@ -3,5 +3,7 @@ namespace Clc.Polaris.Api.Models
     public class SAMobilePhoneCarriersGetResult : PapiResponseCommon
     {
         public List<SAMobilePhoneCarriersGetRow> SAMobilePhoneCarriersGetRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", SAMobilePhoneCarriersGetRows ?? Enumerable.Empty<SAMobilePhoneCarriersGetRow>());
     }
 }

--- a/src/polaris-api-csharp/Models/SAMobilePhoneCarriersGetRow.cs
+++ b/src/polaris-api-csharp/Models/SAMobilePhoneCarriersGetRow.cs
@@ -7,5 +7,7 @@ namespace Clc.Polaris.Api.Models
         public string? Email2SMSEmailAddress { get; set; }
         public int? NumberOfDigits { get; set; }
         public bool? Display { get; set; }
+
+        public override string ToString() => $"{CarrierID?.ToString() ?? string.Empty} - {CarrierName ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/ShelfLocationsGetResult.cs
+++ b/src/polaris-api-csharp/Models/ShelfLocationsGetResult.cs
@@ -3,6 +3,8 @@ namespace Clc.Polaris.Api.Models
     public class ShelfLocationsGetResult : PapiResponseCommon
     {
         public Shelflocationsrow[] ShelfLocationsRows { get; set; } = Array.Empty<Shelflocationsrow>();
+
+        public override string ToString() => string.Join("\r\n", ShelfLocationsRows ?? Enumerable.Empty<Shelflocationsrow>());
     }
 
     public class Shelflocationsrow

--- a/src/polaris-api-csharp/Models/SortOptionsGetResult.cs
+++ b/src/polaris-api-csharp/Models/SortOptionsGetResult.cs
@@ -3,5 +3,7 @@ namespace Clc.Polaris.Api.Models
     public class SortOptionsGetResult : PapiResponseCommon
     {
         public List<SortOptionsRow> SortOptionsRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", SortOptionsRows ?? Enumerable.Empty<SortOptionsRow>());
     }
 }

--- a/src/polaris-api-csharp/Models/SortOptionsRow.cs
+++ b/src/polaris-api-csharp/Models/SortOptionsRow.cs
@@ -5,5 +5,7 @@ namespace Clc.Polaris.Api.Models
         public string? Code { get; set; }
         public string? Description { get; set; }
         public string? Options { get; set; }
+
+        public override string ToString() => $"{Code ?? string.Empty} - {Description ?? string.Empty} - {Options ?? string.Empty}";
     }
 }

--- a/src/polaris-api-csharp/Models/SysHoldStatusesGetResult.cs
+++ b/src/polaris-api-csharp/Models/SysHoldStatusesGetResult.cs
@@ -3,5 +3,7 @@ namespace Clc.Polaris.Api.Models
     public class SysHoldStatusesGetResult : PapiResponseCommon
     {
         public List<SysHoldStatusesRow> SysHoldStatusesRows { get; set; } = new();
+
+        public override string ToString() => string.Join("\r\n", SysHoldStatusesRows ?? Enumerable.Empty<SysHoldStatusesRow>());
     }
 }

--- a/src/polaris-api-csharp/Models/SysHoldStatusesRow.cs
+++ b/src/polaris-api-csharp/Models/SysHoldStatusesRow.cs
@@ -5,5 +5,7 @@ namespace Clc.Polaris.Api.Models
         public int? SysHoldStatusID { get; set; }
         public string? Description { get; set; }
         public string? Name { get; set; }
+
+        public override string ToString() => $"{SysHoldStatusID?.ToString() ?? string.Empty} - {Name ?? string.Empty} - {Description ?? string.Empty}";
     }
 }

--- a/tests/Clc.Polaris.Api.UnitTests/SerializationAndModels/ModelBehavior/ModelDisplayFormatterTests.cs
+++ b/tests/Clc.Polaris.Api.UnitTests/SerializationAndModels/ModelBehavior/ModelDisplayFormatterTests.cs
@@ -1,0 +1,49 @@
+﻿using Clc.Polaris.Api.Internal;
+
+namespace Clc.Polaris.Api.UnitTests.SerializationAndModels.ModelBehavior
+{
+    [TestClass]
+    [UnitTest]
+    public sealed class ModelDisplayFormatterTests
+    {
+        [TestMethod]
+        public void MaskLeadingDigits_MasksAtLeastOneDigitAndPreservesDigitCount()
+        {
+            Assert.AreEqual("*", ModelDisplayFormatter.MaskLeadingDigits(1));
+            Assert.AreEqual("*2", ModelDisplayFormatter.MaskLeadingDigits(12));
+            Assert.AreEqual("*23", ModelDisplayFormatter.MaskLeadingDigits(123));
+            Assert.AreEqual("*234", ModelDisplayFormatter.MaskLeadingDigits(1234));
+            Assert.AreEqual("*2345", ModelDisplayFormatter.MaskLeadingDigits(12345));
+            Assert.AreEqual("***4567", ModelDisplayFormatter.MaskLeadingDigits(1234567));
+            Assert.AreEqual("*****6789", ModelDisplayFormatter.MaskLeadingDigits(123456789));
+        }
+
+        [TestMethod]
+        public void MaskLeadingDigits_HandlesZero()
+        {
+            Assert.AreEqual("*", ModelDisplayFormatter.MaskLeadingDigits(0));
+        }
+
+        [TestMethod]
+        public void MaskLeadingDigits_PreservesNegativeSignAndMasksDigits()
+        {
+            Assert.AreEqual("-*", ModelDisplayFormatter.MaskLeadingDigits(-1));
+            Assert.AreEqual("-*2345", ModelDisplayFormatter.MaskLeadingDigits(-12345));
+            Assert.AreEqual("-******3648", ModelDisplayFormatter.MaskLeadingDigits(int.MinValue));
+        }
+
+        [TestMethod]
+        public void MaskLeadingDigits_UsesRequestedVisibleTrailingDigitCount()
+        {
+            Assert.AreEqual("****56", ModelDisplayFormatter.MaskLeadingDigits(123456, visibleTrailingDigits: 2));
+            Assert.AreEqual("******", ModelDisplayFormatter.MaskLeadingDigits(123456, visibleTrailingDigits: 0));
+            Assert.AreEqual("*23456", ModelDisplayFormatter.MaskLeadingDigits(123456, visibleTrailingDigits: 10));
+        }
+
+        [TestMethod]
+        public void MaskLeadingDigits_ThrowsForNegativeVisibleTrailingDigits()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => ModelDisplayFormatter.MaskLeadingDigits(1234, visibleTrailingDigits: -1));
+        }
+    }
+}

--- a/tests/Clc.Polaris.Api.UnitTests/SerializationAndModels/ModelBehavior/ModelToStringTests.cs
+++ b/tests/Clc.Polaris.Api.UnitTests/SerializationAndModels/ModelBehavior/ModelToStringTests.cs
@@ -1,0 +1,91 @@
+namespace Clc.Polaris.Api.UnitTests.SerializationAndModels.ModelBehavior
+{
+    [TestClass]
+    [UnitTest]
+    public sealed class ModelToStringTests
+    {
+        [TestMethod]
+        public void BibsPostResult_ToString_ReturnsImportJobId()
+        {
+            var result = new BibsPostResult { ImportJobID = 1234 };
+
+            Assert.AreEqual("1234", result.ToString());
+        }
+
+        [TestMethod]
+        public void BibsPostResult_ToString_ReturnsEmptyStringForNullImportJobId()
+        {
+            var result = new BibsPostResult { ImportJobID = null };
+
+            Assert.AreEqual(string.Empty, result.ToString());
+        }
+
+        [TestMethod]
+        public void HoldRequestCreateParams_ToString_UsesStableRequestShapeFields()
+        {
+            var parameters = new HoldRequestCreateParams(patronId: 10, bibId: 20, pickupBranchId: 30, requestingOrgId: 40)
+            {
+                ItemBarcode = "item-barcode",
+                PatronNotes = "patron note"
+            };
+
+            Assert.AreEqual("PatronID=10, BibID=20, PickupOrgID=30, RequestingOrgID=40", parameters.ToString());
+        }
+
+        [TestMethod]
+        public void BibGetByTypeResult_ToString_JoinsRowsWithCarriageReturnLineFeeds()
+        {
+            var result = new BibGetByTypeResult
+            {
+                BibGetByTypeRows =
+                [
+                    new() { ElementID = 1, Label = "Title", Value = "First" },
+                    new() { ElementID = 2, Label = "Author", Value = "Second" }
+                ]
+            };
+
+            Assert.AreEqual("1 - Title - First\r\n2 - Author - Second", result.ToString());
+        }
+
+        [TestMethod]
+        public void BibGetByTypeRow_ToString_HandlesNullStrings()
+        {
+            var row = new BibGetByTypeRow { ElementID = 9 };
+
+            Assert.AreEqual("9 -  - ", row.ToString());
+        }
+
+        [TestMethod]
+        public void BibGetByTypeResult_ToString_HandlesNullRowsCollection()
+        {
+            var result = new BibGetByTypeResult { BibGetByTypeRows = null! };
+
+            Assert.AreEqual(string.Empty, result.ToString());
+        }
+
+        [TestMethod]
+        public void PapiResult_ToString_UsesInheritedCommonResponseBehavior()
+        {
+            var result = new PAPIResult { PAPIErrorCode = 7, ErrorMessage = "failed" };
+
+            Assert.AreEqual("7 - failed", result.ToString());
+        }
+
+        [TestMethod]
+        public void PatronAuthenticationResult_ToString_DoesNotExposeSecrets()
+        {
+            var result = new PatronAuthenticationResult
+            {
+                PatronID = 123,
+                AccessToken = "secret-token",
+                AccessSecret = "secret-access"
+            };
+
+            var text = result.ToString();
+
+            Assert.AreEqual("123", text);
+            Assert.DoesNotContain("secret-token", text);
+            Assert.DoesNotContain("secret-access", text);
+        }
+    }
+}

--- a/tests/Clc.Polaris.Api.UnitTests/SerializationAndModels/ModelBehavior/ModelToStringTests.cs
+++ b/tests/Clc.Polaris.Api.UnitTests/SerializationAndModels/ModelBehavior/ModelToStringTests.cs
@@ -288,7 +288,8 @@ namespace Clc.Polaris.Api.UnitTests.SerializationAndModels.ModelBehavior
 
             var text = result.ToString();
 
-            Assert.AreEqual("200 - Checkout title - 2026-06-18T12:30:00.0000000Z - 4 - 8 - 16", text);
+            Assert.AreEqual("200 - Checkout title - 2026-06-18T12:30:00.0000000Z - 4 - 8", text);
+            Assert.DoesNotContain("16", text);
             Assert.DoesNotContain("32", text);
             Assert.DoesNotContain("Patron", text);
         }
@@ -380,6 +381,47 @@ namespace Clc.Polaris.Api.UnitTests.SerializationAndModels.ModelBehavior
             Assert.DoesNotContain("alt@example.org", text);
             Assert.DoesNotContain("555-0100", text);
             Assert.DoesNotContain("sms@example.org", text);
+        }
+
+
+        [TestMethod]
+        public void PatronTitleListAddTitleResult_ToString_ReturnsPositionAndRecordId()
+        {
+            var result = new PatronTitleListAddTitleResult { Position = 3, RecordID = 456 };
+
+            Assert.AreEqual("3 - 456", result.ToString());
+        }
+
+        [TestMethod]
+        public void PatronTitleListAddTitleData_ToString_ReturnsRecordStoreAndLocalControlNumber()
+        {
+            var data = new PatronTitleListAddTitleData { RecordStoreId = 12, LocalControlNumber = 345 };
+
+            Assert.AreEqual("12 - 345", data.ToString());
+        }
+
+        [TestMethod]
+        public void PatronTitleListCopyTitleData_ToString_ReturnsSourcePositionAndDestination()
+        {
+            var data = new PatronTitleListCopyTitleData { FromRecordStoreId = 12, FromPosition = 5, ToRecordStoreId = 34 };
+
+            Assert.AreEqual("12 - 5 - 34", data.ToString());
+        }
+
+        [TestMethod]
+        public void PatronTitleListCopyAllTitlesData_ToString_ReturnsSourceAndDestination()
+        {
+            var data = new PatronTitleListCopyAllTitlesData { FromRecordStoreId = 12, ToRecordStoreId = 34 };
+
+            Assert.AreEqual("12 - 34", data.ToString());
+        }
+
+        [TestMethod]
+        public void PatronTitleListMoveTitleData_ToString_ReturnsSourcePositionAndDestination()
+        {
+            var data = new PatronTitleListMoveTitleData { FromRecordStoreId = 12, FromPosition = 5, ToRecordStoreId = 34 };
+
+            Assert.AreEqual("12 - 5 - 34", data.ToString());
         }
 
     }

--- a/tests/Clc.Polaris.Api.UnitTests/SerializationAndModels/ModelBehavior/ModelToStringTests.cs
+++ b/tests/Clc.Polaris.Api.UnitTests/SerializationAndModels/ModelBehavior/ModelToStringTests.cs
@@ -87,5 +87,138 @@ namespace Clc.Polaris.Api.UnitTests.SerializationAndModels.ModelBehavior
             Assert.DoesNotContain("secret-token", text);
             Assert.DoesNotContain("secret-access", text);
         }
+
+        [TestMethod]
+        public void CollectionsGetResult_ToString_JoinsRowsWhoseRowsAlreadyFormatSafely()
+        {
+            var result = new CollectionsGetResult
+            {
+                CollectionsRows =
+                [
+                    new() { ID = 1, Abbreviation = "FIC", Name = "Fiction" },
+                    new() { ID = 2, Abbreviation = "NF", Name = "Nonfiction" }
+                ]
+            };
+
+            Assert.AreEqual("1 - FIC - Fiction\r\n2 - NF - Nonfiction", result.ToString());
+        }
+
+        [TestMethod]
+        public void CollectionsGetResult_ToString_HandlesNullRowsCollection()
+        {
+            var result = new CollectionsGetResult { CollectionsRows = null! };
+
+            Assert.AreEqual(string.Empty, result.ToString());
+        }
+
+        [TestMethod]
+        public void MarcTypeOfMaterialsGetResult_ToString_JoinsExistingRowOutput()
+        {
+            var result = new MARCTypeOfMaterialsGetResult
+            {
+                MARCTypeOfMaterialsRows =
+                [
+                    new() { MARCTypeOfMaterialId = 7, SearchCode = "BK", Description = "Books" },
+                    new() { MARCTypeOfMaterialId = 8, SearchCode = "VM", Description = "Visual materials" }
+                ]
+            };
+
+            Assert.AreEqual("7 - BK - Books\r\n8 - VM - Visual materials", result.ToString());
+        }
+
+        [TestMethod]
+        public void ItemStatusesGetResult_ToString_JoinsRows()
+        {
+            var result = new ItemStatusesGetResult
+            {
+                ItemStatusesRows =
+                [
+                    new() { ItemStatusId = 1, Name = "In", Description = "In Library" },
+                    new() { ItemStatusId = 2, Name = "Out", Description = "Checked Out" }
+                ]
+            };
+
+            Assert.AreEqual("1 - In - In Library\r\n2 - Out - Checked Out", result.ToString());
+        }
+
+        [TestMethod]
+        public void ItemStatusRow_ToString_HandlesNullStrings()
+        {
+            var row = new ItemStatusRow { ItemStatusId = 5 };
+
+            Assert.AreEqual("5 -  - ", row.ToString());
+        }
+
+        [TestMethod]
+        public void RemoteStorageItemsGetRow_ToString_IncludesItemOnlyBarcode()
+        {
+            var row = new RemoteStorageItemsGetRow
+            {
+                ItemRecordID = 11,
+                Barcode = "item-barcode",
+                BibliographicRecordID = 22,
+                BrowseTitle = "Item title",
+                MaterialType = "Book",
+                Collection = "Stacks",
+                ShelfLocation = "Main",
+                CallNumber = "QA 1"
+            };
+
+            Assert.AreEqual("11 - item-barcode - 22 - Item title - Book - Stacks - Main - QA 1", row.ToString());
+        }
+
+        [TestMethod]
+        public void RemoteStorageItemsGetResult_ToString_JoinsRowsAndHandlesNullCollection()
+        {
+            var withRows = new RemoteStorageItemsGetResult
+            {
+                RemoteStorageItemsGetRows =
+                [
+                    new() { ItemRecordID = 11, Barcode = "item-1", BibliographicRecordID = 22, BrowseTitle = "Title 1" },
+                    new() { ItemRecordID = 12, Barcode = "item-2", BibliographicRecordID = 23, BrowseTitle = "Title 2" }
+                ]
+            };
+            var withoutRows = new RemoteStorageItemsGetResult { RemoteStorageItemsGetRows = null! };
+
+            Assert.AreEqual("11 - item-1 - 22 - Title 1 -  -  -  - \r\n12 - item-2 - 23 - Title 2 -  -  -  - ", withRows.ToString());
+            Assert.AreEqual(string.Empty, withoutRows.ToString());
+        }
+
+        [TestMethod]
+        public void SAMobilePhoneCarriersGetRow_ToString_ExcludesEmailToSmsAddress()
+        {
+            var row = new SAMobilePhoneCarriersGetRow
+            {
+                CarrierID = 3,
+                CarrierName = "Carrier",
+                Email2SMSEmailAddress = "private-sms-domain.example"
+            };
+
+            var text = row.ToString();
+
+            Assert.AreEqual("3 - Carrier", text);
+            Assert.DoesNotContain("private-sms-domain.example", text);
+        }
+
+        [TestMethod]
+        public void PatronItemsOutGetResult_ToString_UsesCommonResponseWithoutPatronScopedItemRows()
+        {
+            var result = new PatronItemsOutGetResult
+            {
+                PAPIErrorCode = 0,
+                ErrorMessage = "OK",
+                PatronItemsOutGetRows =
+                [
+                    new() { ItemID = 99, Barcode = "patron-scoped-item-barcode", Title = "Patron scoped title" }
+                ]
+            };
+
+            var text = result.ToString();
+
+            Assert.AreEqual("0 - OK", text);
+            Assert.DoesNotContain("patron-scoped-item-barcode", text);
+            Assert.DoesNotContain("Patron scoped title", text);
+        }
+
     }
 }

--- a/tests/Clc.Polaris.Api.UnitTests/SerializationAndModels/ModelBehavior/ModelToStringTests.cs
+++ b/tests/Clc.Polaris.Api.UnitTests/SerializationAndModels/ModelBehavior/ModelToStringTests.cs
@@ -220,5 +220,167 @@ namespace Clc.Polaris.Api.UnitTests.SerializationAndModels.ModelBehavior
             Assert.DoesNotContain("Patron scoped title", text);
         }
 
+
+        [TestMethod]
+        public void ItemCheckInResult_ToString_ExcludesPatronBarcodeAndTrappingPatronFields()
+        {
+            var result = new ItemCheckInResult
+            {
+                ItemRecordID = 100,
+                ItemBarcode = "item-barcode",
+                Title = "Item title",
+                ItemStatusID = 3,
+                PreviousItemStatusID = 2,
+                ShelfLocation = "Stacks",
+                CallNumber = "QA 1",
+                PatronBarcode = "patron-barcode",
+                Comment = "private comment",
+                HoldData = new ItemCheckInHoldData
+                {
+                    TrappingPatronBarcode = "trapping-barcode",
+                    TrappingPatronName = "Patron Name",
+                    PickupBranchName = "Main",
+                    PickupArea = "Desk"
+                }
+            };
+
+            var text = result.ToString();
+
+            Assert.AreEqual("100 - item-barcode - Item title - 3 - 2 - Stacks - QA 1", text);
+            Assert.DoesNotContain("patron-barcode", text);
+            Assert.DoesNotContain("private comment", text);
+            Assert.DoesNotContain("trapping-barcode", text);
+            Assert.DoesNotContain("Patron Name", text);
+        }
+
+        [TestMethod]
+        public void ItemCheckInHoldData_ToString_ExcludesTrappingPatronFields()
+        {
+            var holdData = new ItemCheckInHoldData
+            {
+                TrappingPatronBarcode = "trapping-barcode",
+                TrappingPatronName = "Patron Name",
+                PickupBranchName = "Main",
+                PickupArea = "Desk"
+            };
+
+            var text = holdData.ToString();
+
+            Assert.AreEqual("Main - Desk", text);
+            Assert.DoesNotContain("trapping-barcode", text);
+            Assert.DoesNotContain("Patron Name", text);
+        }
+
+        [TestMethod]
+        public void ItemCheckOutResult_ToString_ExcludesPatronBlockFieldsAndDescriptions()
+        {
+            var dueDate = new DateTime(2026, 6, 18, 12, 30, 0, DateTimeKind.Utc);
+            var result = new ItemCheckOutResult
+            {
+                ItemRecordID = 200,
+                Title = "Checkout title",
+                DueDate = dueDate,
+                MaterialTypeID = 4,
+                ItemBlockFlags = 8,
+                RenewalBlockFlags = 16,
+                PatronBlockFlags = 32
+            };
+
+            var text = result.ToString();
+
+            Assert.AreEqual("200 - Checkout title - 2026-06-18T12:30:00.0000000Z - 4 - 8 - 16", text);
+            Assert.DoesNotContain("32", text);
+            Assert.DoesNotContain("Patron", text);
+        }
+
+        [TestMethod]
+        public void BibHoldingsGetResult_ToString_JoinsRows()
+        {
+            var result = new BibHoldingsGetResult
+            {
+                BibHoldingsGetRows =
+                [
+                    new() { Barcode = "item-1", LocationName = "Main", CollectionName = "Stacks", CallNumber = "QA 1", ShelfLocation = "A", CircStatus = "In", MaterialType = "Book", DueDate = "2026-06-18" },
+                    new() { Barcode = "item-2", LocationName = "Branch", CollectionName = "Media", CallNumber = "DVD 2", ShelfLocation = "B", CircStatus = "Out", MaterialType = "DVD", DueDate = "2026-06-19" }
+                ]
+            };
+
+            Assert.AreEqual("item-1 - Main - Stacks - QA 1 - A - In - Book - 2026-06-18\r\nitem-2 - Branch - Media - DVD 2 - B - Out - DVD - 2026-06-19", result.ToString());
+        }
+
+        [TestMethod]
+        public void ItemRenewResultWrapper_ToString_DelegatesToBodyRows()
+        {
+            var dueDate = new DateTime(2026, 6, 18, 12, 30, 0, DateTimeKind.Utc);
+            var wrapper = new ItemRenewResultWrapper
+            {
+                PAPIErrorCode = 0,
+                ErrorMessage = "OK",
+                ItemRenewResult = new ItemRenewResultBody
+                {
+                    BlockRows =
+                    [
+                        new() { ItemRecordID = 300, PAPIErrorType = 2, PolarisErrorCode = 42, ErrorAllowOverride = true, ErrorDesc = "Renewal blocked" }
+                    ],
+                    DueDateRows =
+                    [
+                        new() { ItemRecordID = 301, DueDate = dueDate }
+                    ]
+                }
+            };
+
+            Assert.AreEqual("300 - 2 - 42 - True - Renewal blocked\r\n301 - 2026-06-18T12:30:00.0000000Z", wrapper.ToString());
+        }
+
+        [TestMethod]
+        public void ItemsOutActionResult_ToString_DelegatesToRenewResultOrCommonResponse()
+        {
+            var withRenewResult = new ItemsOutActionResult
+            {
+                ItemRenewResult = new ItemRenewResultWrapper
+                {
+                    ItemRenewResult = new ItemRenewResultBody
+                    {
+                        BlockRows =
+                        [
+                            new() { ItemRecordID = 400, PAPIErrorType = 2, PolarisErrorCode = 99, ErrorAllowOverride = false, ErrorDesc = "No renewals" }
+                        ]
+                    }
+                }
+            };
+            var withoutRenewResult = new ItemsOutActionResult { PAPIErrorCode = 5, ErrorMessage = "Failed" };
+
+            Assert.AreEqual("400 - 2 - 99 - False - No renewals", withRenewResult.ToString());
+            Assert.AreEqual("5 - Failed", withoutRenewResult.ToString());
+        }
+
+        [TestMethod]
+        public void Requestpicklistrow_ToString_ExcludesPatronFieldsAndKeepsItemFields()
+        {
+            var row = new Requestpicklistrow
+            {
+                ItemRecordID = 500,
+                ItemBarcode = "item-barcode",
+                BrowseTitle = "Hold title",
+                PatronFullName = "Patron Name",
+                PatronBarcode = "patron-barcode",
+                PatronID = 123,
+                EmailAddress = "patron@example.org",
+                AltEmailAddress = "alt@example.org",
+                PhoneVoice1 = "555-0100",
+                SMSAddress = "sms@example.org"
+            };
+
+            var text = row.ToString();
+
+            Assert.AreEqual("500 - item-barcode - Hold title", text);
+            Assert.DoesNotContain("Patron Name", text);
+            Assert.DoesNotContain("patron-barcode", text);
+            Assert.DoesNotContain("patron@example.org", text);
+            Assert.DoesNotContain("alt@example.org", text);
+            Assert.DoesNotContain("555-0100", text);
+            Assert.DoesNotContain("sms@example.org", text);
+        }
+
     }
 }

--- a/tests/Clc.Polaris.Api.UnitTests/SerializationAndModels/ModelBehavior/ModelToStringTests.cs
+++ b/tests/Clc.Polaris.Api.UnitTests/SerializationAndModels/ModelBehavior/ModelToStringTests.cs
@@ -21,15 +21,30 @@ namespace Clc.Polaris.Api.UnitTests.SerializationAndModels.ModelBehavior
         }
 
         [TestMethod]
-        public void HoldRequestCreateParams_ToString_UsesStableRequestShapeFields()
+        public void HoldRequestCreateParams_ToString_MasksPatronIdAndUsesStableRequestShapeFields()
         {
-            var parameters = new HoldRequestCreateParams(patronId: 10, bibId: 20, pickupBranchId: 30, requestingOrgId: 40)
+            var parameters = new HoldRequestCreateParams(patronId: 1234567, bibId: 20, pickupBranchId: 30, requestingOrgId: 40)
             {
                 ItemBarcode = "item-barcode",
                 PatronNotes = "patron note"
             };
 
-            Assert.AreEqual("PatronID=10, BibID=20, PickupOrgID=30, RequestingOrgID=40", parameters.ToString());
+            Assert.AreEqual("PatronID=***4567, BibID=20, PickupOrgID=30, RequestingOrgID=40", parameters.ToString());
+        }
+
+        [TestMethod]
+        public void HoldRequestCreateParams_ToString_DoesNotExposeBarcodeOrPatronNotes()
+        {
+            var parameters = new HoldRequestCreateParams(patronId: 1234567, bibId: 20, pickupBranchId: 30, requestingOrgId: 40)
+            {
+                ItemBarcode = "item-barcode",
+                PatronNotes = "patron note"
+            };
+
+            var text = parameters.ToString();
+
+            Assert.DoesNotContain("item-barcode", text);
+            Assert.DoesNotContain("patron note", text);
         }
 
         [TestMethod]


### PR DESCRIPTION
### Motivation
- Audit public request/result model classes and add compact, null-safe `ToString` overrides where a stable, non-sensitive representation is useful for debugging and diagnostics.
- Preserve runtime/request/serialization behavior and public API signatures.
- Avoid exposing credentials, tokens, patron PII, patron barcodes, patron contact details, MARC/XML payloads, and mixed patron/item identifying details.
- Allow item/bib identifiers in item/bib-only diagnostic output where no patron details are emitted.

### Description
- Added class-local `ToString` overrides for selected model files where a concise, stable display shape is useful.
- Added `ModelDisplayFormatter` helpers for masking identifier values when only partial display is appropriate.
- Preserved existing `ToString` implementations where present when they already met the diagnostic-output policy.
- Left models unchanged where a safe concise representation was not obvious, where the model contains credentials/tokens, or where output would risk exposing sensitive patron or mixed patron/item identifying data.
- In mixed patron/bib or patron/item contexts, the output emits only the safe side or masks the patron-side identifier. For example, `HoldRequestCreateParams` masks `PatronID` while leaving `BibID` visible.
- Added deterministic unit tests at `tests/Clc.Polaris.Api.UnitTests/SerializationAndModels/ModelBehavior/ModelToStringTests.cs` and `tests/Clc.Polaris.Api.UnitTests/SerializationAndModels/ModelBehavior/ModelDisplayFormatterTests.cs` covering scalar results, request params, row joins, nested-row formatting, null handling, inherited common behavior, masking behavior, and representative no-secret/no-PII assertions.

### Testing
- Ran `dotnet build tests/Clc.Polaris.Api.UnitTests/Clc.Polaris.Api.UnitTests.csproj` and the build succeeded with zero warnings or errors.
- Ran `dotnet test tests/Clc.Polaris.Api.UnitTests/Clc.Polaris.Api.UnitTests.csproj` and the unit suite passed.
- Attempted `dotnet pack src/polaris-api-csharp/Clc.Polaris.Api.csproj -c Release`, which completed build but pack failed due to package policy metadata: NU5104 triggered by a prerelease dependency (`Clc.Rest.Client [3.0.0-beta.3, )`) and a missing package readme, which is unrelated to the `ToString` changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a341f2bfb348323a597763a170f911a)